### PR TITLE
feat(sidebar): 重构分组并新增高级网络聚合页

### DIFF
--- a/ui/src/components/dynamic-breadcrumb.tsx
+++ b/ui/src/components/dynamic-breadcrumb.tsx
@@ -27,6 +27,14 @@ export function DynamicBreadcrumb() {
       return breadcrumbs
     }
 
+    if (
+      pathSegments.length === 2 &&
+      pathSegments[0] === 'networking' &&
+      pathSegments[1] === 'advanced'
+    ) {
+      return [{ label: t('nav.advancedNetworking') }]
+    }
+
     // Resource name mappings
     const resourceLabels: Record<string, string> = {
       pods: t('nav.pods'),
@@ -39,12 +47,21 @@ export function DynamicBreadcrumb() {
       gateways: t('nav.gateways'),
       httproutes: t('nav.httproutes'),
       jobs: t('nav.jobs'),
+      cronjobs: t('nav.cronjobs'),
       daemonsets: t('nav.daemonsets'),
       statefulsets: t('nav.statefulsets'),
       namespaces: t('nav.namespaces'),
-      pvcs: t('sidebar.short.pvcs'),
+      nodes: t('nav.nodes'),
+      events: t('nav.events'),
+      persistentvolumeclaims: t('nav.persistentvolumeclaims'),
+      persistentvolumes: t('nav.persistentvolumes'),
       crds: t('nav.crds'),
       crs: t('nav.customResources'),
+      serviceaccounts: t('nav.serviceaccounts'),
+      roles: t('nav.roles'),
+      rolebindings: t('nav.rolebindings'),
+      clusterroles: t('nav.clusterroles'),
+      clusterrolebindings: t('nav.clusterrolebindings'),
       horizontalpodautoscalers: t('nav.horizontalpodautoscalers'),
     }
 

--- a/ui/src/contexts/sidebar-config-context.test.tsx
+++ b/ui/src/contexts/sidebar-config-context.test.tsx
@@ -7,7 +7,7 @@ import {
 } from './sidebar-config-context'
 
 const workloadsGroupId = 'sidebar-groups-workloads'
-const trafficGroupId = 'sidebar-groups-traffic'
+const networkGroupId = 'sidebar-groups-network'
 const workloadsPodsItemId = 'sidebar-groups-workloads--pods'
 const customGroupId = 'custom-my-group'
 const customGroupItemId = 'custom-my-group-widgets-example-com'
@@ -37,6 +37,12 @@ function SidebarConfigConsumer() {
     (group) => group.id === workloadsGroupId
   )
   const customGroup = config.groups.find((group) => group.id === customGroupId)
+  const securityGroup = config.groups.find(
+    (group) => group.id === 'sidebar-groups-security'
+  )
+  const extensionGroup = config.groups.find(
+    (group) => group.id === 'sidebar-groups-extension'
+  )
 
   return (
     <div>
@@ -50,6 +56,12 @@ function SidebarConfigConsumer() {
       </div>
       <div data-testid="workloads-collapsed">
         {String(workloadsGroup?.collapsed)}
+      </div>
+      <div data-testid="security-collapsed">
+        {String(securityGroup?.collapsed)}
+      </div>
+      <div data-testid="extension-collapsed">
+        {String(extensionGroup?.collapsed)}
       </div>
       <div data-testid="custom-groups">
         {config.groups
@@ -88,8 +100,8 @@ function SidebarConfigConsumer() {
       <button type="button" onClick={() => moveGroup(workloadsGroupId, 'down')}>
         move workloads down
       </button>
-      <button type="button" onClick={() => moveGroup(trafficGroupId, 'up')}>
-        move traffic up
+      <button type="button" onClick={() => moveGroup(networkGroupId, 'up')}>
+        move network up
       </button>
       <button type="button" onClick={() => createCustomGroup('My Group')}>
         create custom group
@@ -225,6 +237,9 @@ describe('SidebarConfigProvider', () => {
   it('toggles group visibility and collapsed state', async () => {
     await renderProvider()
 
+    expect(screen.getByTestId('security-collapsed')).toHaveTextContent('true')
+    expect(screen.getByTestId('extension-collapsed')).toHaveTextContent('true')
+
     fireEvent.click(
       screen.getByRole('button', { name: 'toggle workloads visibility' })
     )
@@ -247,12 +262,13 @@ describe('SidebarConfigProvider', () => {
 
     expect(screen.getByTestId('group-order')).toHaveTextContent(
       [
+        'sidebar-groups-cluster',
         workloadsGroupId,
-        trafficGroupId,
-        'sidebar-groups-storage',
+        networkGroupId,
         'sidebar-groups-config',
+        'sidebar-groups-storage',
         'sidebar-groups-security',
-        'sidebar-groups-other',
+        'sidebar-groups-extension',
       ].join(',')
     )
 
@@ -261,11 +277,12 @@ describe('SidebarConfigProvider', () => {
       expect(screen.getByTestId('group-order')).toHaveTextContent(
         [
           workloadsGroupId,
-          trafficGroupId,
-          'sidebar-groups-storage',
+          'sidebar-groups-cluster',
+          networkGroupId,
           'sidebar-groups-config',
+          'sidebar-groups-storage',
           'sidebar-groups-security',
-          'sidebar-groups-other',
+          'sidebar-groups-extension',
         ].join(',')
       )
     )
@@ -274,29 +291,119 @@ describe('SidebarConfigProvider', () => {
     await waitFor(() =>
       expect(screen.getByTestId('group-order')).toHaveTextContent(
         [
-          trafficGroupId,
+          'sidebar-groups-cluster',
           workloadsGroupId,
-          'sidebar-groups-storage',
+          networkGroupId,
           'sidebar-groups-config',
+          'sidebar-groups-storage',
           'sidebar-groups-security',
-          'sidebar-groups-other',
+          'sidebar-groups-extension',
         ].join(',')
       )
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'move traffic up' }))
+    fireEvent.click(screen.getByRole('button', { name: 'move network up' }))
     await waitFor(() =>
       expect(screen.getByTestId('group-order')).toHaveTextContent(
         [
-          trafficGroupId,
+          'sidebar-groups-cluster',
+          networkGroupId,
           workloadsGroupId,
-          'sidebar-groups-storage',
           'sidebar-groups-config',
+          'sidebar-groups-storage',
           'sidebar-groups-security',
-          'sidebar-groups-other',
+          'sidebar-groups-extension',
         ].join(',')
       )
     )
+  })
+
+  it('migrates legacy sidebar configs to the new group structure', async () => {
+    storedSidebarPreference = JSON.stringify({
+      version: 1,
+      groups: [
+        {
+          id: 'sidebar-groups-workloads',
+          nameKey: 'sidebar.groups.workloads',
+          visible: true,
+          collapsed: false,
+          order: 0,
+          items: [
+            {
+              id: workloadsPodsItemId,
+              titleKey: 'nav.pods',
+              url: '/pods',
+              icon: 'IconBox',
+              visible: true,
+              pinned: false,
+              order: 0,
+            },
+          ],
+        },
+        {
+          id: 'sidebar-groups-other',
+          nameKey: 'sidebar.groups.other',
+          visible: true,
+          collapsed: false,
+          order: 1,
+          items: [
+            {
+              id: 'sidebar-groups-other--nodes',
+              titleKey: 'nav.nodes',
+              url: '/nodes',
+              icon: 'IconServer2',
+              visible: true,
+              pinned: false,
+              order: 0,
+            },
+            {
+              id: 'sidebar-groups-other--events',
+              titleKey: 'nav.events',
+              url: '/events',
+              icon: 'IconBell',
+              visible: true,
+              pinned: false,
+              order: 1,
+            },
+            {
+              id: 'sidebar-groups-other--crds',
+              titleKey: 'nav.crds',
+              url: '/crds',
+              icon: 'IconCode',
+              visible: true,
+              pinned: false,
+              order: 2,
+            },
+          ],
+        },
+      ],
+      hiddenItems: ['sidebar-groups-other--events'],
+      pinnedItems: ['sidebar-groups-other--nodes'],
+      groupOrder: ['sidebar-groups-workloads', 'sidebar-groups-other'],
+      lastUpdated: Date.now(),
+    })
+
+    await renderProvider()
+
+    expect(screen.getByTestId('group-order')).toHaveTextContent(
+      [
+        'sidebar-groups-cluster',
+        'sidebar-groups-workloads',
+        'sidebar-groups-network',
+        'sidebar-groups-config',
+        'sidebar-groups-storage',
+        'sidebar-groups-security',
+        'sidebar-groups-extension',
+      ].join(',')
+    )
+    expect(screen.getByTestId('pinned-items')).toHaveTextContent(
+      'sidebar-groups-cluster--nodes'
+    )
+    expect(screen.getByTestId('hidden-items')).toHaveTextContent(
+      'sidebar-groups-cluster--events'
+    )
+    expect(screen.getByTestId('security-collapsed')).toHaveTextContent('true')
+    expect(screen.getByTestId('extension-collapsed')).toHaveTextContent('true')
   })
 
   it('creates a custom group and manages CRD items inside it', async () => {

--- a/ui/src/contexts/sidebar-config-context.tsx
+++ b/ui/src/contexts/sidebar-config-context.tsx
@@ -122,8 +122,16 @@ interface SidebarConfigProviderProps {
 }
 
 const defaultMenus: DefaultMenus = {
+  'sidebar.groups.cluster': [
+    { titleKey: 'nav.nodes', url: '/nodes', icon: IconServer2 },
+    {
+      titleKey: 'nav.namespaces',
+      url: '/namespaces',
+      icon: IconBoxMultiple,
+    },
+    { titleKey: 'nav.events', url: '/events', icon: IconBell },
+  ],
   'sidebar.groups.workloads': [
-    { titleKey: 'nav.pods', url: '/pods', icon: IconBox },
     { titleKey: 'nav.deployments', url: '/deployments', icon: IconRocket },
     {
       titleKey: 'nav.statefulsets',
@@ -135,28 +143,36 @@ const defaultMenus: DefaultMenus = {
       url: '/daemonsets',
       icon: IconTopologyBus,
     },
+    { titleKey: 'nav.pods', url: '/pods', icon: IconBox },
     { titleKey: 'nav.jobs', url: '/jobs', icon: IconPlayerPlay },
     { titleKey: 'nav.cronjobs', url: '/cronjobs', icon: IconClockHour4 },
+    {
+      titleKey: 'nav.horizontalpodautoscalers',
+      url: '/horizontalpodautoscalers',
+      icon: IconArrowsHorizontal,
+    },
   ],
-  'sidebar.groups.traffic': [
+  'sidebar.groups.network': [
+    { titleKey: 'nav.services', url: '/services', icon: IconNetwork },
     { titleKey: 'nav.ingresses', url: '/ingresses', icon: IconRouter },
     {
-      titleKey: 'nav.networkpolicies',
-      url: '/networkpolicies',
-      icon: IconShield,
+      titleKey: 'nav.advancedNetworking',
+      url: '/networking/advanced',
+      icon: IconRoute,
     },
-    { titleKey: 'nav.services', url: '/services', icon: IconNetwork },
-    { titleKey: 'nav.gateways', url: '/gateways', icon: IconLoadBalancer },
-    { titleKey: 'nav.httproutes', url: '/httproutes', icon: IconRoute },
+  ],
+  'sidebar.groups.config': [
+    { titleKey: 'nav.configMaps', url: '/configmaps', icon: IconMap },
+    { titleKey: 'nav.secrets', url: '/secrets', icon: IconLock },
   ],
   'sidebar.groups.storage': [
     {
-      titleKey: 'sidebar.short.pvcs',
+      titleKey: 'nav.persistentvolumeclaims',
       url: '/persistentvolumeclaims',
       icon: IconFileDatabase,
     },
     {
-      titleKey: 'sidebar.short.pvs',
+      titleKey: 'nav.persistentvolumes',
       url: '/persistentvolumes',
       icon: IconDatabase,
     },
@@ -164,15 +180,6 @@ const defaultMenus: DefaultMenus = {
       titleKey: 'nav.storageclasses',
       url: '/storageclasses',
       icon: IconFileDatabase,
-    },
-  ],
-  'sidebar.groups.config': [
-    { titleKey: 'nav.configMaps', url: '/configmaps', icon: IconMap },
-    { titleKey: 'nav.secrets', url: '/secrets', icon: IconLock },
-    {
-      titleKey: 'nav.horizontalpodautoscalers',
-      url: '/horizontalpodautoscalers',
-      icon: IconArrowsHorizontal,
     },
   ],
   'sidebar.groups.security': [
@@ -194,20 +201,32 @@ const defaultMenus: DefaultMenus = {
       icon: IconKey,
     },
   ],
-  'sidebar.groups.other': [
-    {
-      titleKey: 'nav.namespaces',
-      url: '/namespaces',
-      icon: IconBoxMultiple,
-    },
-    { titleKey: 'nav.nodes', url: '/nodes', icon: IconServer2 },
-    { titleKey: 'nav.events', url: '/events', icon: IconBell },
+  'sidebar.groups.extension': [
     { titleKey: 'nav.crds', url: '/crds', icon: IconCode },
   ],
 }
 
-const CURRENT_CONFIG_VERSION = 1
+const CURRENT_CONFIG_VERSION = 3
 const SIDEBAR_CONFIG_STORAGE_KEY = 'desktop-sidebar-config'
+const DEFAULT_COLLAPSED_GROUP_IDS = new Set([
+  'sidebar-groups-security',
+  'sidebar-groups-extension',
+])
+const SIDEBAR_GROUP_MIGRATION_SOURCES: Record<string, string[]> = {
+  'sidebar-groups-cluster': ['sidebar-groups-cluster', 'sidebar-groups-other'],
+  'sidebar-groups-workloads': ['sidebar-groups-workloads'],
+  'sidebar-groups-network': ['sidebar-groups-network', 'sidebar-groups-traffic'],
+  'sidebar-groups-config': ['sidebar-groups-config'],
+  'sidebar-groups-storage': ['sidebar-groups-storage'],
+  'sidebar-groups-security': ['sidebar-groups-security'],
+  'sidebar-groups-extension': [
+    'sidebar-groups-extension',
+    'sidebar-groups-other',
+  ],
+}
+
+const isDefaultCollapsedGroup = (groupId: string) =>
+  DEFAULT_COLLAPSED_GROUP_IDS.has(groupId)
 
 const defaultConfigs = (): SidebarConfig => {
   const groups: SidebarGroup[] = []
@@ -233,7 +252,7 @@ const defaultConfigs = (): SidebarConfig => {
       nameKey: groupKey,
       items: sidebarItems,
       visible: true,
-      collapsed: false,
+      collapsed: isDefaultCollapsedGroup(groupId),
       order: groupOrder++,
     })
   })
@@ -248,6 +267,83 @@ const defaultConfigs = (): SidebarConfig => {
   }
 }
 
+const migrateSidebarConfig = (config: SidebarConfig): SidebarConfig => {
+  const nextConfig = defaultConfigs()
+  const itemIdMap = new Map<string, string>()
+  const existingItemsByUrl = new Map(
+    config.groups.flatMap((group) =>
+      group.items.map((item) => [item.url, item] as const)
+    )
+  )
+
+  const groups = nextConfig.groups.map((group) => {
+    const sourceGroup = config.groups.find((candidate) =>
+      (SIDEBAR_GROUP_MIGRATION_SOURCES[group.id] || []).includes(candidate.id)
+    )
+
+    return {
+      ...group,
+      visible: sourceGroup?.visible ?? group.visible,
+      collapsed: isDefaultCollapsedGroup(group.id)
+        ? true
+        : (sourceGroup?.collapsed ?? group.collapsed),
+      items: group.items.map((item, index) => {
+        const existingItem = existingItemsByUrl.get(item.url)
+        if (existingItem) {
+          itemIdMap.set(existingItem.id, item.id)
+        }
+
+        return {
+          ...item,
+          visible: existingItem?.visible ?? item.visible,
+          pinned: existingItem?.pinned ?? item.pinned,
+          order: index,
+        }
+      }),
+    }
+  })
+
+  const customGroups = config.groups
+    .filter((group) => group.isCustom)
+    .sort((a, b) => a.order - b.order)
+    .map((group, index) => {
+      group.items.forEach((item) => itemIdMap.set(item.id, item.id))
+      return {
+        ...group,
+        order: groups.length + index,
+        items: group.items.map((item, itemIndex) => ({
+          ...item,
+          order: itemIndex,
+        })),
+      }
+    })
+
+  const mergedGroups = [...groups, ...customGroups].map((group, index) => ({
+    ...group,
+    order: index,
+  }))
+  const validItemIds = new Set(
+    mergedGroups.flatMap((group) => group.items.map((item) => item.id))
+  )
+  const remapItemIds = (itemIds: string[]) =>
+    Array.from(
+      new Set(
+        itemIds
+          .map((itemId) => itemIdMap.get(itemId))
+          .filter((itemId): itemId is string => !!itemId && validItemIds.has(itemId))
+      )
+    )
+
+  return {
+    version: CURRENT_CONFIG_VERSION,
+    groups: mergedGroups,
+    hiddenItems: remapItemIds(config.hiddenItems),
+    pinnedItems: remapItemIds(config.pinnedItems),
+    groupOrder: mergedGroups.map((group) => group.id),
+    lastUpdated: Date.now(),
+  }
+}
+
 export const SidebarConfigProvider: React.FC<SidebarConfigProviderProps> = ({
   children,
 }) => {
@@ -255,20 +351,48 @@ export const SidebarConfigProvider: React.FC<SidebarConfigProviderProps> = ({
   const [isLoading, setIsLoading] = useState(true)
   const [hasUpdate, setHasUpdate] = useState(false)
 
+  const applyConfig = useCallback(
+    async (
+      nextConfig: SidebarConfig,
+      options: { persistRemote?: boolean } = {}
+    ) => {
+      const configToStore = {
+        ...nextConfig,
+        lastUpdated: Date.now(),
+        version: CURRENT_CONFIG_VERSION,
+      }
+      const serializedConfig = JSON.stringify(configToStore)
+
+      localStorage.setItem(SIDEBAR_CONFIG_STORAGE_KEY, serializedConfig)
+      setConfig(configToStore)
+
+      if (options.persistRemote) {
+        await saveSidebarPreference(serializedConfig)
+      }
+
+      return configToStore
+    },
+    []
+  )
+
   const loadConfig = useCallback(async () => {
     try {
+      setHasUpdate(false)
+
       const response = await getSidebarPreference()
       const remoteConfig = response.sidebar_preference.trim()
 
       if (remoteConfig) {
         const parsedConfig = JSON.parse(remoteConfig) as SidebarConfig
-        localStorage.setItem(SIDEBAR_CONFIG_STORAGE_KEY, remoteConfig)
-        setConfig(parsedConfig)
-
         const currentVersion = parsedConfig.version || 0
         if (currentVersion < CURRENT_CONFIG_VERSION) {
-          setHasUpdate(true)
+          await applyConfig(migrateSidebarConfig(parsedConfig), {
+            persistRemote: true,
+          })
+          return
         }
+
+        await applyConfig(parsedConfig)
         return
       }
 
@@ -279,39 +403,32 @@ export const SidebarConfigProvider: React.FC<SidebarConfigProviderProps> = ({
       }
 
       const parsedConfig = JSON.parse(storedConfig) as SidebarConfig
-      setConfig(parsedConfig)
-
       const currentVersion = parsedConfig.version || 0
       if (currentVersion < CURRENT_CONFIG_VERSION) {
-        setHasUpdate(true)
+        await applyConfig(migrateSidebarConfig(parsedConfig), {
+          persistRemote: true,
+        })
+        return
       }
+
+      await applyConfig(parsedConfig)
       return
     } catch (error) {
       console.error('Failed to load sidebar config from storage:', error)
     }
 
     setConfig(defaultConfigs())
-  }, [])
+  }, [applyConfig])
 
   const saveConfig = useCallback(
     async (newConfig: SidebarConfig) => {
       try {
-        const configToSave = {
-          ...newConfig,
-          lastUpdated: Date.now(),
-          version: CURRENT_CONFIG_VERSION,
-        }
-        localStorage.setItem(
-          SIDEBAR_CONFIG_STORAGE_KEY,
-          JSON.stringify(configToSave)
-        )
-        setConfig(configToSave)
-        await saveSidebarPreference(JSON.stringify(configToSave))
+        await applyConfig(newConfig, { persistRemote: true })
       } catch (error) {
         console.error('Failed to save sidebar config to storage:', error)
       }
     },
-    []
+    [applyConfig]
   )
 
   const updateConfig = useCallback(

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -67,12 +67,13 @@
   },
   "sidebar": {
     "groups": {
-      "traffic": "traffic",
-      "storage": "storage",
-      "config": "config",
-      "other": "other",
+      "cluster": "Cluster",
+      "network": "Network",
+      "storage": "Storage",
+      "config": "Config",
       "security": "Security",
-      "workloads": "Workloads"
+      "workloads": "Workloads",
+      "extension": "Extension"
     },
     "short": {
       "pvcs": "PVCs",
@@ -102,14 +103,15 @@
     "daemonsets": "DaemonSets",
     "jobs": "Jobs",
     "services": "Services",
-    "ingresses": "Ingresses",
+    "ingresses": "Ingress",
     "networkpolicies": "Network Policies",
     "gateways": "Gateways",
     "httproutes": "HTTP Routes",
-    "configMaps": "ConfigMaps",
+    "advancedNetworking": "Advanced Networking",
+    "configMaps": "Config Items",
     "secrets": "Secrets",
-    "persistentvolumeclaims": "Persistent Volume Claims",
-    "persistentvolumes": "Persistent Volumes",
+    "persistentvolumeclaims": "Storage Claims",
+    "persistentvolumes": "Storage Volumes",
     "nodes": "Nodes",
     "namespaces": "Namespaces",
     "customResources": "Custom Resources",
@@ -126,6 +128,9 @@
     "clusterroles": "Cluster Roles",
     "clusterrolebindings": "Cluster Role Bindings",
     "horizontalpodautoscalers": "HPA"
+  },
+  "advancedNetworking": {
+    "description": "Manage network policies, gateways, and HTTP routes in one place"
   },
   "overview": {
     "title": "Overview",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -95,14 +95,15 @@
     "daemonsets": "守护进程集",
     "jobs": "任务",
     "services": "服务",
-    "ingresses": "入口",
+    "ingresses": "Ingress",
     "networkpolicies": "网络策略",
     "gateways": "网关",
     "httproutes": "HTTP 路由",
-    "configMaps": "配置映射",
+    "advancedNetworking": "高级网络",
+    "configMaps": "配置项",
     "secrets": "密钥",
-    "persistentvolumeclaims": "持久卷声明",
-    "persistentvolumes": "持久卷",
+    "persistentvolumeclaims": "存储声明",
+    "persistentvolumes": "存储卷",
     "nodes": "节点",
     "namespaces": "命名空间",
     "customResources": "自定义资源",
@@ -119,15 +120,17 @@
     "rolebindings": "角色绑定",
     "clusterroles": "集群角色",
     "clusterrolebindings": "集群角色绑定",
-    "horizontalpodautoscalers": "Pod 水平自动扩缩"
+    "horizontalpodautoscalers": "HPA"
   },
   "sidebar": {
     "groups": {
-      "traffic": "流量",
+      "cluster": "集群",
+      "network": "网络",
       "storage": "存储",
       "config": "配置",
-      "other": "其他",
-      "security": "安全"
+      "security": "安全",
+      "workloads": "工作负载",
+      "extension": "扩展"
     },
     "short": {
       "pvcs": "PVCs",
@@ -152,6 +155,9 @@
     "expand": "展开",
     "collapse": "折叠",
     "newVersionAvailable": "发现新版本"
+  },
+  "advancedNetworking": {
+    "description": "在一个页面中统一查看网络策略、网关和 HTTP 路由"
   },
   "overview": {
     "title": "概览",

--- a/ui/src/pages/advanced-networking.tsx
+++ b/ui/src/pages/advanced-networking.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { usePageTitle } from '@/hooks/use-page-title'
+import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
+
+import { GatewayListPage } from './gateway-list-page'
+import { HTTPRouteListPage } from './httproute-list-page'
+import { SimpleListPage } from './simple-list-page'
+
+export function AdvancedNetworkingPage() {
+  const { t } = useTranslation()
+
+  usePageTitle(t('nav.advancedNetworking'))
+
+  const tabs: Array<{
+    value: string
+    label: string
+    content: ReactNode
+  }> = [
+    {
+      value: 'networkpolicies',
+      label: t('nav.networkpolicies'),
+      content: <SimpleListPage resourceType="networkpolicies" />,
+    },
+    {
+      value: 'gateways',
+      label: t('nav.gateways'),
+      content: <GatewayListPage />,
+    },
+    {
+      value: 'httproutes',
+      label: t('nav.httproutes'),
+      content: <HTTPRouteListPage />,
+    },
+  ]
+
+  return (
+    <div className="space-y-2">
+      <div className="mb-4">
+        <div className="flex items-center gap-3 mb-2">
+          <h1 className="text-3xl">{t('nav.advancedNetworking')}</h1>
+        </div>
+        <p className="text-muted-foreground">
+          {t(
+            'advancedNetworking.description',
+            'Manage network policies, gateways, and HTTP routes in one place'
+          )}
+        </p>
+      </div>
+
+      <ResponsiveTabs tabs={tabs} />
+    </div>
+  )
+}

--- a/ui/src/routes.test.tsx
+++ b/ui/src/routes.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react'
-import { RouterProvider } from 'react-router-dom'
+import { Outlet, RouterProvider } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('./App', () => ({
   __esModule: true,
-  default: () => <div>app shell</div>,
+  default: () => (
+    <div>
+      <div>app shell</div>
+      <Outlet />
+    </div>
+  ),
   StandaloneAIChatApp: () => <div>standalone ai chat</div>,
 }))
 
@@ -46,6 +51,23 @@ describe('router', () => {
     expect(await screen.findByText('app shell')).toBeInTheDocument()
     expect(screen.queryByTestId('init-check-route')).not.toBeInTheDocument()
     expect(screen.queryByTestId('protected-route')).not.toBeInTheDocument()
+  })
+
+  it('registers the advanced networking aggregate route before generic resources', () => {
+    const rootRoute = (
+      router as unknown as {
+        routes: Array<{ path?: string; children?: Array<{ path?: string }> }>
+      }
+    ).routes.find((route) => route.path === '/')
+
+    const childPaths = rootRoute?.children?.map((route) => route.path) || []
+    const advancedNetworkingIndex = childPaths.indexOf('networking/advanced')
+    const resourceDetailIndex = childPaths.indexOf(':resource/:name')
+    const resourceListIndex = childPaths.indexOf(':resource')
+
+    expect(advancedNetworkingIndex).toBeGreaterThan(-1)
+    expect(advancedNetworkingIndex).toBeLessThan(resourceDetailIndex)
+    expect(advancedNetworkingIndex).toBeLessThan(resourceListIndex)
   })
 
   it('does not register /login or /setup routes', () => {

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom'
 
 import App, { StandaloneAIChatApp } from './App'
 import { getSubPath } from './lib/subpath'
+import { AdvancedNetworkingPage } from './pages/advanced-networking'
 import { CRListPage } from './pages/cr-list-page'
 import { Overview } from './pages/overview'
 import { ResourceDetail } from './pages/resource-detail'
@@ -31,6 +32,10 @@ export const router = createBrowserRouter(
         {
           path: 'settings',
           element: <SettingsPage />,
+        },
+        {
+          path: 'networking/advanced',
+          element: <AdvancedNetworkingPage />,
         },
         {
           path: 'crds/:crd',


### PR DESCRIPTION
新增「集群/网络/扩展」分组与默认折叠策略，支持旧版侧边栏配置自动迁移与持久化同步；新增 `/networking/advanced` 高级网络聚合页（NetworkPolicy/Gateway/HTTPRoute）并补齐面包屑、路由与中英文文案。

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).
