### PR TITLE
Improve pod table scrolling and delete flow

### DIFF
--- a/ui/src/components/delete-confirmation-dialog.tsx
+++ b/ui/src/components/delete-confirmation-dialog.tsx
@@ -25,6 +25,7 @@ interface DeleteConfirmationDialogProps {
   namespace?: string
   additionalNote?: string
   showAdditionalOptions?: boolean
+  requireNameConfirmation?: boolean
 }
 
 export function DeleteConfirmationDialog({
@@ -37,6 +38,7 @@ export function DeleteConfirmationDialog({
   namespace,
   additionalNote,
   showAdditionalOptions = false,
+  requireNameConfirmation = true,
 }: DeleteConfirmationDialogProps) {
   const { t } = useTranslation()
   const [confirmationInput, setConfirmationInput] = useState('')
@@ -47,17 +49,21 @@ export function DeleteConfirmationDialog({
     if (!open) {
       setConfirmationInput('')
       setForceDelete(false)
+      setWait(true)
     }
     onOpenChange(open)
   }
 
   const handleConfirm = () => {
-    if (confirmationInput === resourceName) {
-      onConfirm(forceDelete, wait)
+    if (requireNameConfirmation && confirmationInput !== resourceName) {
+      return
     }
+
+    onConfirm(forceDelete, wait)
   }
 
-  const isConfirmDisabled = confirmationInput !== resourceName || isDeleting
+  const isConfirmDisabled =
+    isDeleting || (requireNameConfirmation && confirmationInput !== resourceName)
 
   return (
     <Dialog open={open} onOpenChange={handleDialogChange}>
@@ -110,20 +116,22 @@ export function DeleteConfirmationDialog({
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="confirmation">
-              {t('deleteConfirmation.typeToConfirm')}{' '}
-              <span className=" font-semibold">{resourceName}</span>{' '}
-              {t('deleteConfirmation.toConfirm')}
-            </Label>
-            <Input
-              id="confirmation"
-              value={confirmationInput}
-              onChange={(e) => setConfirmationInput(e.target.value)}
-              placeholder={resourceName}
-              autoComplete="off"
-            />
-          </div>
+          {requireNameConfirmation && (
+            <div className="space-y-2">
+              <Label htmlFor="confirmation">
+                {t('deleteConfirmation.typeToConfirm')}{' '}
+                <span className=" font-semibold">{resourceName}</span>{' '}
+                {t('deleteConfirmation.toConfirm')}
+              </Label>
+              <Input
+                id="confirmation"
+                value={confirmationInput}
+                onChange={(e) => setConfirmationInput(e.target.value)}
+                placeholder={resourceName}
+                autoComplete="off"
+              />
+            </div>
+          )}
           {showAdditionalOptions && (
             <>
               <div className="flex items-center space-x-2">

--- a/ui/src/components/pod-table.tsx
+++ b/ui/src/components/pod-table.tsx
@@ -1,27 +1,55 @@
-import { useMemo } from 'react'
-import { IconLoader } from '@tabler/icons-react'
+import { type ReactNode, useMemo, useState } from 'react'
+import { IconLoader, IconTrash } from '@tabler/icons-react'
 import { Pod } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import { toast } from 'sonner'
 
 import { MetricsData, PodWithMetrics } from '@/types/api'
+import { deleteResource } from '@/lib/api'
 import { getPodStatus } from '@/lib/k8s'
-import { formatDate, translatePodStatus } from '@/lib/utils'
+import { formatDate, translateError, translatePodStatus } from '@/lib/utils'
 
+import { DeleteConfirmationDialog } from './delete-confirmation-dialog'
+import { DescribeDialog } from './describe-dialog'
 import { MetricCell } from './metrics-cell'
 import { PodStatusIcon } from './pod-status-icon'
 import { Column, SimpleTable } from './simple-table'
 import { Badge } from './ui/badge'
+import { Button } from './ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+
+type PodImageEntry = {
+  name: string
+  image: string
+}
+
+function toCompactImageName(image: string) {
+  if (!image || image === '-') return '-'
+
+  const digestIndex = image.lastIndexOf('@')
+  if (digestIndex >= 0) {
+    return image.slice(image.lastIndexOf('/') + 1)
+  }
+
+  const lastSlashIndex = image.lastIndexOf('/')
+  return lastSlashIndex >= 0 ? image.slice(lastSlashIndex + 1) : image
+}
 
 export function PodTable(props: {
   pods?: PodWithMetrics[]
   labelSelector?: string
   isLoading?: boolean
   hiddenNode?: boolean
+  title?: ReactNode
 }) {
   const { t } = useTranslation()
-  const { pods, isLoading } = props
+  const { pods, isLoading, title } = props
+  const [podPendingDelete, setPodPendingDelete] = useState<{
+    name: string
+    namespace?: string
+  } | null>(null)
 
   // Pod table columns
   const podColumns = useMemo(
@@ -77,6 +105,53 @@ export function PodTable(props: {
         },
       },
       {
+        header: t('containerEditor.tabs.image'),
+        accessor: (pod: Pod) =>
+          pod.spec?.containers?.map((container) => ({
+            name: container.name,
+            image: container.image || '-',
+          })) || [],
+        cell: (value: unknown) => {
+          const images = value as PodImageEntry[]
+
+          if (images.length === 0) {
+            return <span className="text-sm text-muted-foreground">-</span>
+          }
+
+          const summary = images
+            .map((entry) => `${entry.name}: ${toCompactImageName(entry.image)}`)
+            .join(' | ')
+
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  className="max-w-[320px] truncate text-xs text-muted-foreground"
+                  title={summary}
+                >
+                  <span className="font-mono">{summary}</span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-md">
+                <div className="space-y-2">
+                  {images.map((entry) => (
+                    <div key={`${entry.name}-${entry.image}`} className="min-w-0">
+                      <div className="text-xs text-muted-foreground">
+                        {entry.name}
+                      </div>
+                      <div className="font-mono text-xs break-all">
+                        {entry.image}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )
+        },
+        align: 'left' as const,
+      },
+      {
         header: t('monitoring.cpuUsage'),
         accessor: (pod: PodWithMetrics) => {
           return pod.metrics
@@ -127,9 +202,62 @@ export function PodTable(props: {
           )
         },
       },
+      {
+        header: t('common.actions'),
+        accessor: (pod: Pod) => pod,
+        cell: (value: unknown) => {
+          const pod = value as Pod
+          const podName = pod.metadata?.name || ''
+          const namespace = pod.metadata?.namespace
+
+          return (
+            <div className="flex items-center justify-center gap-2">
+              <DescribeDialog
+                resourceType="pods"
+                namespace={namespace}
+                name={podName}
+              />
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() =>
+                  setPodPendingDelete({
+                    name: podName,
+                    namespace,
+                  })
+                }
+                disabled={!podName}
+              >
+                <IconTrash className="h-4 w-4" />
+                {t('detail.buttons.delete')}
+              </Button>
+            </div>
+          )
+        },
+      },
     ],
     [props.hiddenNode, t]
   )
+
+  const handleDelete = async (force?: boolean, wait?: boolean) => {
+    const targetPod = podPendingDelete
+    if (!targetPod) return
+
+    setPodPendingDelete(null)
+    try {
+      await deleteResource('pods', targetPod.name, targetPod.namespace, {
+        force,
+        wait,
+      })
+      toast.success(
+        t('detail.status.deleted', {
+          resource: targetPod.name,
+        })
+      )
+    } catch (error) {
+      toast.error(translateError(error, t))
+    }
+  }
 
   if (isLoading) {
     return (
@@ -142,13 +270,15 @@ export function PodTable(props: {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t('pods.title')}</CardTitle>
+        <CardTitle>{title ?? t('pods.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         <SimpleTable
           data={pods || []}
           columns={podColumns}
           emptyMessage={t('podTable.empty')}
+          stickyFirstColumn
+          stickyLastColumn
           pagination={{
             enabled: true,
             pageSize: 20,
@@ -156,6 +286,20 @@ export function PodTable(props: {
           }}
         />
       </CardContent>
+      <DeleteConfirmationDialog
+        open={podPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPodPendingDelete(null)
+          }
+        }}
+        resourceName={podPendingDelete?.name || ''}
+        resourceType="pod"
+        namespace={podPendingDelete?.namespace}
+        onConfirm={handleDelete}
+        showAdditionalOptions={true}
+        requireNameConfirmation={false}
+      />
     </Card>
   )
 }

--- a/ui/src/components/resource-delete-confirmation-dialog.tsx
+++ b/ui/src/components/resource-delete-confirmation-dialog.tsx
@@ -16,6 +16,7 @@ interface ResourceDeleteConfirmationDialogProps {
   resourceType: ResourceType
   namespace?: string
   additionalNote?: string
+  requireNameConfirmation?: boolean
 }
 
 export function ResourceDeleteConfirmationDialog({
@@ -25,6 +26,7 @@ export function ResourceDeleteConfirmationDialog({
   resourceType,
   namespace,
   additionalNote,
+  requireNameConfirmation = true,
 }: ResourceDeleteConfirmationDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false)
   const navigate = useNavigate()
@@ -62,6 +64,7 @@ export function ResourceDeleteConfirmationDialog({
       namespace={namespace}
       additionalNote={additionalNote}
       showAdditionalOptions={true}
+      requireNameConfirmation={requireNameConfirmation}
     />
   )
 }

--- a/ui/src/components/simple-table.tsx
+++ b/ui/src/components/simple-table.tsx
@@ -1,4 +1,7 @@
 import React, { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/lib/utils'
 
 import { Button } from './ui/button'
 import {
@@ -28,6 +31,8 @@ interface SimpleTableProps<T> {
     currentPage?: number
     onPageChange?: (page: number) => void
   }
+  stickyFirstColumn?: boolean
+  stickyLastColumn?: boolean
 }
 
 export function SimpleTable<T>({
@@ -35,7 +40,10 @@ export function SimpleTable<T>({
   columns,
   emptyMessage = 'No data available',
   pagination,
+  stickyFirstColumn = false,
+  stickyLastColumn = false,
 }: SimpleTableProps<T>) {
+  const { t } = useTranslation()
   const isControlled =
     pagination &&
     typeof pagination.currentPage === 'number' &&
@@ -79,6 +87,9 @@ export function SimpleTable<T>({
     }
   }, [data, currentPage, paginationConfig])
 
+  const shouldShowPagination =
+    paginationConfig.enabled && totalPages > 1 && data.length > 0
+
   const handlePreviousPage = () => {
     if (isControlled) {
       setCurrentPage(Math.max(currentPage - 1, 1))
@@ -98,22 +109,34 @@ export function SimpleTable<T>({
   const handlePageChange = (page: number) => {
     setCurrentPage(page)
   }
+
+  const getColumnClassName = (
+    index: number,
+    align: Column<T>['align'],
+    isHeader = false
+  ) =>
+    cn(
+      align === 'left'
+        ? 'text-left'
+        : align === 'right'
+          ? 'text-right'
+          : 'text-center',
+      stickyFirstColumn &&
+        index === 0 &&
+        'sticky left-0 z-20 bg-background shadow-[10px_0_12px_-12px_color-mix(in_oklab,var(--color-foreground)_16%,transparent)]',
+      stickyLastColumn &&
+        index === columns.length - 1 &&
+        'sticky right-0 z-20 bg-background shadow-[-10px_0_12px_-12px_color-mix(in_oklab,var(--color-foreground)_16%,transparent)]',
+      isHeader && 'z-30'
+    )
+
   return (
     <div className="space-y-4">
-      <Table>
+      <Table containerClassName="table-scroll-thin">
         <TableHeader>
           <TableRow>
             {columns.map((column, index) => (
-              <TableHead
-                key={index}
-                className={
-                  column.align === 'left'
-                    ? 'text-left'
-                    : column.align === 'right'
-                      ? 'text-right'
-                      : 'text-center'
-                }
-              >
+              <TableHead key={index} className={getColumnClassName(index, column.align, true)}>
                 {column.header}
               </TableHead>
             ))}
@@ -135,13 +158,7 @@ export function SimpleTable<T>({
                 {columns.map((column, colIndex) => (
                   <TableCell
                     key={colIndex}
-                    className={
-                      column.align === 'left'
-                        ? 'text-left'
-                        : column.align === 'right'
-                          ? 'text-right'
-                          : 'text-center'
-                    }
+                    className={getColumnClassName(colIndex, column.align)}
                   >
                     {column.cell(column.accessor(item))}
                   </TableCell>
@@ -152,11 +169,15 @@ export function SimpleTable<T>({
         </TableBody>
       </Table>
 
-      {paginationConfig.enabled && data.length > 0 && (
+      {shouldShowPagination && (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           {paginationConfig.showPageInfo && (
             <div className="text-sm text-muted-foreground">
-              Showing {startIndex} - {endIndex} of {data.length} entries
+              {t('simpleTable.showingEntries', {
+                start: startIndex,
+                end: endIndex,
+                total: data.length,
+              })}
             </div>
           )}
 
@@ -167,7 +188,7 @@ export function SimpleTable<T>({
               onClick={handlePreviousPage}
               disabled={currentPage === 1}
             >
-              Previous
+              {t('simpleTable.previous')}
             </Button>
 
             <div className="flex flex-wrap items-center gap-1">
@@ -208,7 +229,7 @@ export function SimpleTable<T>({
               onClick={handleNextPage}
               disabled={currentPage === totalPages}
             >
-              Next
+              {t('simpleTable.next')}
             </Button>
           </div>
         </div>

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -4,11 +4,15 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+type TableProps = React.ComponentProps<"table"> & {
+  containerClassName?: string
+}
+
+function Table({ className, containerClassName, ...props }: TableProps) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn("relative w-full overflow-x-auto", containerClassName)}
     >
       <table
         data-slot="table"

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -159,6 +159,11 @@
     "emptyFilteredDescription": "Try adjusting the keyword, resource type, or namespace filters",
     "clearFilters": "Clear filters"
   },
+  "simpleTable": {
+    "showingEntries": "Showing {{start}} - {{end}} of {{total}} entries",
+    "previous": "Previous",
+    "next": "Next"
+  },
   "pods": {
     "title": "Pods",
     "ready": "Ready",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -186,6 +186,11 @@
     "emptyFilteredDescription": "试试调整搜索词、资源类型或命名空间筛选条件",
     "clearFilters": "清空筛选"
   },
+  "simpleTable": {
+    "showingEntries": "显示第 {{start}} - {{end}} 条，共 {{total}} 条",
+    "previous": "上一页",
+    "next": "下一页"
+  },
   "pods": {
     "title": "Pods",
     "ready": "就绪",

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -505,6 +505,20 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
                   </CardContent>
                 </Card>
 
+                {relatedPods ? (
+                  <PodTable
+                    pods={relatedPods}
+                    isLoading={isLoadingPods}
+                    labelSelector={labelSelector}
+                    title={
+                      <>
+                        Pods{' '}
+                        <Badge variant="secondary">{relatedPods.length}</Badge>
+                      </>
+                    }
+                  />
+                ) : null}
+
                 {/* Conditions */}
                 {status?.conditions && (
                   <Card>
@@ -560,24 +574,6 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
           },
           ...(relatedPods
             ? [
-                {
-                  value: 'pods',
-                  label: (
-                    <>
-                      Pods{' '}
-                      {relatedPods && (
-                        <Badge variant="secondary">{relatedPods.length}</Badge>
-                      )}
-                    </>
-                  ),
-                  content: (
-                    <PodTable
-                      pods={relatedPods}
-                      isLoading={isLoadingPods}
-                      labelSelector={labelSelector}
-                    />
-                  ),
-                },
                 {
                   value: 'logs',
                   label: t('detail.tabs.logs'),

--- a/ui/src/pages/pod-detail.tsx
+++ b/ui/src/pages/pod-detail.tsx
@@ -656,6 +656,7 @@ export function PodDetail(props: { namespace: string; name: string }) {
         resourceName={name}
         resourceType="pods"
         namespace={namespace}
+        requireNameConfirmation={false}
       />
       <Dialog open={isResizeDialogOpen} onOpenChange={setIsResizeDialogOpen}>
         <DialogContent className="!max-w-3xl max-h-[90vh] overflow-y-auto sm:!max-w-3xl">

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -150,6 +150,31 @@ body[data-scroll-locked] .width-before-scroll-bar {
   }
 }
 
+@layer utilities {
+  .table-scroll-thin {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--color-foreground) 22%, transparent)
+      transparent;
+  }
+
+  .table-scroll-thin::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .table-scroll-thin::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .table-scroll-thin::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background: color-mix(in oklab, var(--color-foreground) 22%, transparent);
+  }
+
+  .table-scroll-thin::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklab, var(--color-foreground) 32%, transparent);
+  }
+}
+
 /* Breathing animation for log viewer connection indicator */
 @keyframes breathing {
   0%,


### PR DESCRIPTION
## Summary
- Keep pod name and actions columns sticky in the pod table while scrolling horizontally
- Slim the table scrollbar for a lighter visual treatment
- Allow pod delete dialogs to skip name confirmation without affecting other resource deletes
- Preserve immediate pod-table deletion flow without blocking follow-up deletes

## Testing
- Not run (not requested)