### PR TITLE
feat(ui): 支持在命名空间列表页创建命名空间

### DIFF
--- a/ui/src/components/editors/namespace-create-dialog.tsx
+++ b/ui/src/components/editors/namespace-create-dialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import type { Namespace } from 'kubernetes-types/core/v1'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { createResource } from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface NamespaceCreateDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: (namespace: Namespace) => void
+}
+
+export function NamespaceCreateDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: NamespaceCreateDialogProps) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setIsCreating(false)
+    }
+  }, [open])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      return
+    }
+
+    setIsCreating(true)
+
+    try {
+      const createdNamespace = await createResource('namespaces', undefined, {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name: trimmedName,
+        },
+      })
+
+      toast.success(
+        t('namespaceCreateDialog.success', {
+          name: createdNamespace.metadata?.name || trimmedName,
+        })
+      )
+      onOpenChange(false)
+      onSuccess(createdNamespace)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('namespaceCreateDialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('namespaceCreateDialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="namespace-name">{t('common.name')}</Label>
+            <Input
+              id="namespace-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={t('namespaceCreateDialog.namePlaceholder')}
+              autoComplete="off"
+              autoFocus
+            />
+            <p className="text-muted-foreground text-sm">
+              {t('namespaceCreateDialog.nameHint')}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isCreating}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isCreating || !name.trim()}>
+              {isCreating ? t('common.creating') : t('common.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "create": "Create",
+    "creating": "Creating...",
     "search": "Search",
     "filter": "Filter",
     "name": "Name",
@@ -1509,5 +1510,12 @@
     "period": "period",
     "imageId": "Image ID",
     "containerId": "Container ID"
+  },
+  "namespaceCreateDialog": {
+    "title": "Create Namespace",
+    "description": "Quickly create a namespace by entering its name.",
+    "namePlaceholder": "For example: dev, staging, production",
+    "nameHint": "Namespace names must follow Kubernetes naming rules.",
+    "success": "Namespace {{name}} created successfully"
   }
 }

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1800,5 +1800,12 @@
     "period": "周期",
     "imageId": "镜像 ID",
     "containerId": "容器 ID"
+  },
+  "namespaceCreateDialog": {
+    "title": "创建命名空间",
+    "description": "输入命名空间名称后即可快速创建。",
+    "namePlaceholder": "例如：dev、staging、production",
+    "nameHint": "命名空间名称需要符合 Kubernetes 命名规则。",
+    "success": "命名空间 {{name}} 创建成功"
   }
 }

--- a/ui/src/pages/namespace-list-page.test.tsx
+++ b/ui/src/pages/namespace-list-page.test.tsx
@@ -1,0 +1,86 @@
+import { type ReactNode } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { NamespaceListPage } from './namespace-list-page'
+
+const mockNavigate = vi.fn()
+const mockResourceTable = vi.fn(
+  ({
+    onCreateClick,
+    showCreateButton,
+  }: {
+    onCreateClick?: () => void
+    showCreateButton?: boolean
+  }) => (
+    <div>
+      <span>{showCreateButton ? 'create-enabled' : 'create-disabled'}</span>
+      <button onClick={onCreateClick}>open-create</button>
+    </div>
+  )
+)
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: ReactNode; to: string }) => (
+      <a href={to}>{children}</a>
+    ),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/components/resource-table', () => ({
+  ResourceTable: (props: {
+    onCreateClick?: () => void
+    showCreateButton?: boolean
+  }) => mockResourceTable(props),
+}))
+
+vi.mock('@/components/editors/namespace-create-dialog', () => ({
+  NamespaceCreateDialog: ({
+    open,
+    onSuccess,
+  }: {
+    open: boolean
+    onSuccess: (namespace: { metadata?: { name?: string } }) => void
+  }) =>
+    open ? (
+      <div>
+        <span>namespace-create-dialog</span>
+        <button
+          onClick={() => onSuccess({ metadata: { name: 'new-namespace' } })}
+        >
+          finish-create
+        </button>
+      </div>
+    ) : null,
+}))
+
+describe('NamespaceListPage', () => {
+  it('shows create action and navigates after namespace creation', () => {
+    render(<NamespaceListPage />)
+
+    expect(screen.getByText('create-enabled')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('open-create'))
+    expect(screen.getByText('namespace-create-dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('finish-create'))
+    expect(mockNavigate).toHaveBeenCalledWith('/namespaces/new-namespace')
+  })
+})

--- a/ui/src/pages/namespace-list-page.tsx
+++ b/ui/src/pages/namespace-list-page.tsx
@@ -1,14 +1,17 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
-import { Namespace } from 'kubernetes-types/core/v1'
+import type { Namespace } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { getAge } from '@/lib/utils'
+import { NamespaceCreateDialog } from '@/components/editors/namespace-create-dialog'
 import { ResourceTable } from '@/components/resource-table'
 
 export function NamespaceListPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   // Definecolumn helper outside of any hooks
   const columnHelper = createColumnHelper<Namespace>()
 
@@ -42,12 +45,30 @@ export function NamespaceListPage() {
     return ns.metadata!.name!.toLowerCase().includes(query)
   }, [])
 
+  const handleCreateSuccess = (namespace: Namespace) => {
+    const namespaceName = namespace.metadata?.name
+    if (!namespaceName) {
+      return
+    }
+    navigate(`/namespaces/${namespaceName}`)
+  }
+
   return (
-    <ResourceTable
-      resourceName="Namespaces"
-      columns={columns}
-      clusterScope={true}
-      searchQueryFilter={filter}
-    />
+    <>
+      <ResourceTable
+        resourceName="Namespaces"
+        columns={columns}
+        clusterScope={true}
+        searchQueryFilter={filter}
+        showCreateButton={true}
+        onCreateClick={() => setIsCreateDialogOpen(true)}
+      />
+
+      <NamespaceCreateDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        onSuccess={handleCreateSuccess}
+      />
+    </>
   )
 }


### PR DESCRIPTION
新增 `NamespaceCreateDialog`，在列表页提供创建入口，创建成功后自动跳转到新命名空间详情页；补充中英文文案并新增对应页面测试。