### PR TITLE
支持同名集群导入与切换，按 API Server 去重并在 UI 展示完整集群信息

### DIFF
--- a/desktop/bridge.go
+++ b/desktop/bridge.go
@@ -42,6 +42,11 @@ type desktopActionResponse struct {
 	OK bool `json:"ok"`
 }
 
+type desktopImportKubeconfigResponse struct {
+	OK            bool `json:"ok"`
+	ImportedCount int  `json:"importedCount"`
+}
+
 type desktopAppPaths struct {
 	ConfigDir string `json:"configDir"`
 	LogsDir   string `json:"logsDir"`
@@ -772,18 +777,24 @@ func (d *desktopBridge) handleImportKubeconfig(c *gin.Context) {
 		return
 	}
 
-	var err error
+	var (
+		err           error
+		importedCount int
+	)
 	if strings.TrimSpace(req.Content) != "" {
-		err = d.host.importKubeconfigContent(req.Content)
+		importedCount, err = d.host.importKubeconfigContent(req.Content)
 	} else {
-		err = d.host.importKubeconfigFromDialog()
+		importedCount, err = d.host.importKubeconfigFromDialog()
 	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, desktopActionResponse{OK: true})
+	c.JSON(http.StatusOK, desktopImportKubeconfigResponse{
+		OK:            true,
+		ImportedCount: importedCount,
+	})
 }
 
 func (d *desktopBridge) resolveURL(rawURL string) (*url.URL, bool, error) {

--- a/desktop/host.go
+++ b/desktop/host.go
@@ -900,7 +900,7 @@ func (h *desktopHost) clearIgnoredUpdateVersion() error {
 	return h.updateStore.clearIgnoredVersion()
 }
 
-func (h *desktopHost) importKubeconfigFromDialog() error {
+func (h *desktopHost) importKubeconfigFromDialog() (int, error) {
 	dialog := h.app.Dialog.OpenFile().
 		CanChooseFiles(true).
 		CanChooseDirectories(false)
@@ -917,43 +917,40 @@ func (h *desktopHost) importKubeconfigFromDialog() error {
 
 	path, err := dialog.PromptForSingleSelection()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if path == "" {
-		return nil
+		return 0, nil
 	}
 
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	if err := h.importKubeconfigContent(string(content)); err != nil {
-		return err
-	}
-	return nil
+	return h.importKubeconfigContent(string(content))
 }
 
-func (h *desktopHost) importKubeconfigContent(content string) error {
+func (h *desktopHost) importKubeconfigContent(content string) (int, error) {
 	payload, err := json.Marshal(common.ImportClustersRequest{
 		Config:    content,
 		InCluster: false,
 	})
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	endpoint := h.baseURL + apiPath("/api/v1/admin/clusters/import")
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return err
+		return 0, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -962,18 +959,26 @@ func (h *desktopHost) importKubeconfigContent(content string) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		if len(body) == 0 {
-			return fmt.Errorf("import kubeconfig failed with status %d", resp.StatusCode)
+			return 0, fmt.Errorf("import kubeconfig failed with status %d", resp.StatusCode)
 		}
 		var errResp struct {
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &errResp) == nil && strings.TrimSpace(errResp.Error) != "" {
-			return fmt.Errorf("%s", errResp.Error)
+			return 0, fmt.Errorf("%s", errResp.Error)
 		}
-		return fmt.Errorf("%s", strings.TrimSpace(string(body)))
+		return 0, fmt.Errorf("%s", strings.TrimSpace(string(body)))
 	}
 
-	return nil
+	var okResp struct {
+		Message       string `json:"message"`
+		ImportedCount int    `json:"importedCount"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&okResp); err != nil && err != io.EOF {
+		return 0, err
+	}
+
+	return okResp.ImportedCount, nil
 }
 
 func (h *desktopHost) showInfoDialog(title, message string) {
@@ -1024,11 +1029,16 @@ func buildApplicationMenu(h *desktopHost, devMode bool) *application.Menu {
 		if h == nil {
 			return
 		}
-		if err := h.importKubeconfigFromDialog(); err != nil {
+		importedCount, err := h.importKubeconfigFromDialog()
+		if err != nil {
 			h.showErrorDialog("Import kubeconfig failed", err.Error())
 			return
 		}
-		h.reloadMainWindow()
+		if importedCount == 0 {
+			h.navigate(fmt.Sprintf("/settings?tab=clusters&desktopImport=skipped&desktopImportTs=%d", time.Now().UnixNano()))
+			return
+		}
+		h.navigate(fmt.Sprintf("/settings?tab=clusters&desktopImport=success&desktopImportTs=%d", time.Now().UnixNano()))
 	})
 	fileMenu.Add("Open Config Directory").OnClick(func(ctx *application.Context) {
 		if h == nil {
@@ -1168,11 +1178,16 @@ func (h *desktopHost) setupSystemTray() {
 		h.focusMainWindow()
 	})
 	menu.Add("Import kubeconfig").OnClick(func(ctx *application.Context) {
-		if err := h.importKubeconfigFromDialog(); err != nil {
+		importedCount, err := h.importKubeconfigFromDialog()
+		if err != nil {
 			h.showErrorDialog("Import kubeconfig failed", err.Error())
 			return
 		}
-		h.reloadMainWindow()
+		if importedCount == 0 {
+			h.navigate(fmt.Sprintf("/settings?tab=clusters&desktopImport=skipped&desktopImportTs=%d", time.Now().UnixNano()))
+			return
+		}
+		h.navigate(fmt.Sprintf("/settings?tab=clusters&desktopImport=success&desktopImportTs=%d", time.Now().UnixNano()))
 	})
 	menu.Add("Open Config Directory").OnClick(func(ctx *application.Context) {
 		if err := h.openConfigDir(); err != nil {

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -56,25 +56,38 @@ func (e *clusterConnectionError) Error() string {
 }
 
 func (cm *ClusterManager) GetClusters(c *gin.Context) {
-	result := make([]common.ClusterInfo, 0, len(cm.clusters))
-	for name, cluster := range cm.clusters {
-		result = append(result, common.ClusterInfo{
-			Name:      name,
-			Version:   cluster.Version,
-			IsDefault: name == cm.defaultContext,
-		})
+	clusters, err := model.ListClusters()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
-	for name, errMsg := range cm.errors {
+
+	result := make([]common.ClusterInfo, 0, len(clusters))
+	for _, cluster := range clusters {
+		apiServer, _ := getNormalizedAPIServerAddress(string(cluster.Config))
+		version := ""
+		if clientSet, exists := cm.clusters[cluster.ID]; exists {
+			version = clientSet.Version
+		}
 		result = append(result, common.ClusterInfo{
-			Name:      name,
-			Version:   "",
-			IsDefault: false,
-			Error:     errMsg,
+			ID:        cluster.ID,
+			Name:      cluster.Name,
+			APIServer: apiServer,
+			Version:   version,
+			IsDefault: cluster.IsDefault,
 		})
 	}
 	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name == result[j].Name {
+			return result[i].APIServer < result[j].APIServer
+		}
 		return result[i].Name < result[j].Name
 	})
+	for i := range result {
+		if errMsg, exists := cm.errors[result[i].ID]; exists {
+			result[i].Error = errMsg
+		}
+	}
 	c.JSON(200, result)
 }
 
@@ -94,14 +107,18 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 			"enabled":       cluster.Enable,
 			"inCluster":     cluster.InCluster,
 			"isDefault":     cluster.IsDefault,
+			"apiServer":     "",
 			"prometheusURL": cluster.PrometheusURL,
 			"config":        "",
 		}
+		if apiServer, err := getNormalizedAPIServerAddress(string(cluster.Config)); err == nil {
+			clusterInfo["apiServer"] = apiServer
+		}
 
-		if clientSet, exists := cm.clusters[cluster.Name]; exists {
+		if clientSet, exists := cm.clusters[cluster.ID]; exists {
 			clusterInfo["version"] = clientSet.Version
 		}
-		if errMsg, exists := cm.errors[cluster.Name]; exists {
+		if errMsg, exists := cm.errors[cluster.ID]; exists {
 			clusterInfo["error"] = errMsg
 		}
 
@@ -121,14 +138,6 @@ func (cm *ClusterManager) CreateCluster(c *gin.Context) {
 	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
-		return
-	}
-
-	if _, err := model.GetClusterByName(req.Name); err == nil {
-		c.JSON(http.StatusConflict, gin.H{"error": "cluster already exists"})
-		return
-	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -430,16 +439,6 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 		return
 	}
 
-	cc, err := model.CountClusters()
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if cc > 0 {
-		c.JSON(http.StatusForbidden, gin.H{"error": "import not allowed when clusters exist"})
-		return
-	}
-
 	if clusterReq.InCluster {
 		// In-cluster config
 		cluster := &model.Cluster{
@@ -454,7 +453,10 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 			return
 		}
 		_ = requestClusterSync(true)
-		c.JSON(http.StatusCreated, gin.H{"message": fmt.Sprintf("imported %d clusters successfully", 1)})
+		c.JSON(http.StatusCreated, gin.H{
+			"message":       fmt.Sprintf("imported %d clusters successfully", 1),
+			"importedCount": 1,
+		})
 		return
 	}
 
@@ -466,5 +468,8 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 
 	importedCount := ImportClustersFromKubeconfig(kubeconfig)
 	_ = requestClusterSync(true)
-	c.JSON(http.StatusCreated, gin.H{"message": fmt.Sprintf("imported %d clusters successfully", importedCount)})
+	c.JSON(http.StatusCreated, gin.H{
+		"message":       fmt.Sprintf("imported %d clusters successfully", importedCount),
+		"importedCount": importedCount,
+	})
 }

--- a/pkg/cluster/cluster_handler_test.go
+++ b/pkg/cluster/cluster_handler_test.go
@@ -4,14 +4,40 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/eryajf/kite-desktop/pkg/common"
 	"github.com/eryajf/kite-desktop/pkg/model"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
+
+func TestMain(m *testing.M) {
+	tempDir, err := os.MkdirTemp("", "kite-cluster-tests-*")
+	if err != nil {
+		panic(err)
+	}
+
+	common.DBType = "sqlite"
+	common.DBDSN = filepath.Join(tempDir, "cluster-test.db")
+	model.InitDB()
+
+	exitCode := m.Run()
+	if err := os.RemoveAll(tempDir); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup temp dir %q failed: %v\n", tempDir, err)
+		if exitCode == 0 {
+			exitCode = 1
+		}
+	}
+
+	os.Exit(exitCode)
+}
 
 func TestFormatClusterConnectionError(t *testing.T) {
 	t.Parallel()
@@ -170,3 +196,252 @@ func TestTestClusterConnectionReturnsReadableError(t *testing.T) {
 		t.Fatalf("expected errorDetail, got empty response: %+v", response)
 	}
 }
+
+func TestImportClustersFromKubeconfigSkipsClustersWithSameAPIServer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupClusterHandlerTestDB(t)
+
+	if err := model.AddCluster(&model.Cluster{
+		Name:      "existing",
+		Config:    model.SecretString(existingClusterKubeconfig),
+		IsDefault: true,
+		Enable:    true,
+	}); err != nil {
+		t.Fatalf("AddCluster() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/admin/clusters/import",
+		strings.NewReader(`{"config":"`+jsonEscape(t, sameServerDifferentNameKubeconfig)+`","inCluster":false}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	(&ClusterManager{}).ImportClustersFromKubeconfig(ctx)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+
+	count, err := model.CountClusters()
+	if err != nil {
+		t.Fatalf("CountClusters() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("CountClusters() = %d, want 1", count)
+	}
+
+	if _, err := model.GetClusterByName("same-server-new-name"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("GetClusterByName(same-server-new-name) err = %v, want record not found", err)
+	}
+
+	existing, err := model.GetClusterByName("existing")
+	if err != nil {
+		t.Fatalf("GetClusterByName(existing) error = %v", err)
+	}
+	if !existing.IsDefault {
+		t.Fatal("existing default cluster lost default flag")
+	}
+}
+
+func TestImportClustersFromKubeconfigAppendsClustersWithDifferentAPIServer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupClusterHandlerTestDB(t)
+
+	if err := model.AddCluster(&model.Cluster{
+		Name:      "existing",
+		Config:    model.SecretString(existingClusterKubeconfig),
+		IsDefault: true,
+		Enable:    true,
+	}); err != nil {
+		t.Fatalf("AddCluster() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/admin/clusters/import",
+		strings.NewReader(`{"config":"`+jsonEscape(t, additionalClusterKubeconfig)+`","inCluster":false}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	(&ClusterManager{}).ImportClustersFromKubeconfig(ctx)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+
+	count, err := model.CountClusters()
+	if err != nil {
+		t.Fatalf("CountClusters() error = %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("CountClusters() = %d, want 2", count)
+	}
+
+	imported, err := model.GetClusterByName("new-dev")
+	if err != nil {
+		t.Fatalf("GetClusterByName(new-dev) error = %v", err)
+	}
+	if imported.IsDefault {
+		t.Fatal("imported cluster unexpectedly became default")
+	}
+
+	existing, err := model.GetClusterByName("existing")
+	if err != nil {
+		t.Fatalf("GetClusterByName(existing) error = %v", err)
+	}
+	if !existing.IsDefault {
+		t.Fatal("existing default cluster lost default flag")
+	}
+}
+
+func TestImportClustersFromKubeconfigAppendsSameNameClusterWithDifferentAPIServer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupClusterHandlerTestDB(t)
+
+	if err := model.AddCluster(&model.Cluster{
+		Name:      "existing",
+		Config:    model.SecretString(existingClusterKubeconfig),
+		IsDefault: true,
+		Enable:    true,
+	}); err != nil {
+		t.Fatalf("AddCluster() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/admin/clusters/import",
+		strings.NewReader(`{"config":"`+jsonEscape(t, sameNameDifferentServerKubeconfig)+`","inCluster":false}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	(&ClusterManager{}).ImportClustersFromKubeconfig(ctx)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+
+	count, err := model.CountClusters()
+	if err != nil {
+		t.Fatalf("CountClusters() error = %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("CountClusters() = %d, want 2", count)
+	}
+
+	if _, err := model.GetClusterByName("existing"); err != nil {
+		t.Fatalf("GetClusterByName(existing) error = %v", err)
+	}
+	var importedClusters []model.Cluster
+	if err := model.DB.Where("name = ?", "existing").Find(&importedClusters).Error; err != nil {
+		t.Fatalf("Find(imported clusters) error = %v", err)
+	}
+	if len(importedClusters) != 2 {
+		t.Fatalf("len(importedClusters) = %d, want 2", len(importedClusters))
+	}
+	defaultCount := 0
+	for _, cluster := range importedClusters {
+		if cluster.IsDefault {
+			defaultCount++
+		}
+	}
+	if defaultCount != 1 {
+		t.Fatalf("defaultCount = %d, want 1", defaultCount)
+	}
+}
+
+func setupClusterHandlerTestDB(t *testing.T) {
+	t.Helper()
+
+	if err := model.DB.Exec("DELETE FROM clusters").Error; err != nil {
+		t.Fatalf("cleanup clusters failed: %v", err)
+	}
+}
+
+func jsonEscape(t *testing.T, input string) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return strings.Trim(string(encoded), `"`)
+}
+
+const additionalClusterKubeconfig = `apiVersion: v1
+kind: Config
+current-context: new-dev
+clusters:
+- name: new-dev
+  cluster:
+    server: https://example.invalid
+users:
+- name: new-dev
+  user:
+    token: test-token
+contexts:
+- name: new-dev
+  context:
+    cluster: new-dev
+    user: new-dev
+`
+
+const existingClusterKubeconfig = `apiVersion: v1
+kind: Config
+current-context: existing
+clusters:
+- name: existing
+  cluster:
+    server: https://demo.example.com
+users:
+- name: existing
+  user:
+    token: existing-token
+contexts:
+- name: existing
+  context:
+    cluster: existing
+    user: existing
+`
+
+const sameServerDifferentNameKubeconfig = `apiVersion: v1
+kind: Config
+current-context: same-server-new-name
+clusters:
+- name: same-server-new-name
+  cluster:
+    server: https://demo.example.com:443/
+users:
+- name: same-server-new-name
+  user:
+    token: same-server-token
+contexts:
+- name: same-server-new-name
+  context:
+    cluster: same-server-new-name
+    user: same-server-new-name
+`
+
+const sameNameDifferentServerKubeconfig = `apiVersion: v1
+kind: Config
+current-context: existing
+clusters:
+- name: existing
+  cluster:
+    server: https://another.example.com
+users:
+- name: existing
+  user:
+    token: another-token
+contexts:
+- name: existing
+  context:
+    cluster: existing
+    user: existing
+`

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -1,10 +1,10 @@
 package cluster
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -12,7 +12,6 @@ import (
 	"github.com/eryajf/kite-desktop/pkg/kube"
 	"github.com/eryajf/kite-desktop/pkg/model"
 	"github.com/eryajf/kite-desktop/pkg/prometheus"
-	"gorm.io/gorm"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -20,7 +19,9 @@ import (
 )
 
 type ClientSet struct {
+	ID         uint
 	Name       string
+	APIServer  string
 	Version    string // Kubernetes version
 	K8sClient  *kube.K8sClient
 	PromClient *prometheus.Client
@@ -31,9 +32,9 @@ type ClientSet struct {
 }
 
 type ClusterManager struct {
-	clusters       map[string]*ClientSet
-	errors         map[string]string
-	defaultContext string
+	clusters         map[uint]*ClientSet
+	errors           map[uint]string
+	defaultClusterID uint
 }
 
 func createClientSetInCluster(name, prometheusURL string) (*ClientSet, error) {
@@ -173,18 +174,45 @@ func (cm *ClusterManager) GetClientSet(clusterName string) (*ClientSet, error) {
 		return nil, fmt.Errorf("no clusters available")
 	}
 	if clusterName == "" {
-		if cm.defaultContext == "" {
+		if cm.defaultClusterID == 0 {
 			// If no default context is set, return the first available cluster
 			for _, cs := range cm.clusters {
 				return cs, nil
 			}
 		}
-		return cm.GetClientSet(cm.defaultContext)
+		return cm.GetClientSetByID(cm.defaultClusterID)
 	}
-	if cluster, ok := cm.clusters[clusterName]; ok {
+
+	if clusterID, err := strconv.ParseUint(clusterName, 10, 32); err == nil {
+		return cm.GetClientSetByID(uint(clusterID))
+	}
+
+	for _, cluster := range cm.clusters {
+		if cluster.Name == clusterName {
+			return cluster, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cluster not found: %s", clusterName)
+}
+
+func (cm *ClusterManager) GetClientSetByID(clusterID uint) (*ClientSet, error) {
+	if len(cm.clusters) == 0 {
+		return nil, fmt.Errorf("no clusters available")
+	}
+	if clusterID == 0 {
+		if cm.defaultClusterID == 0 {
+			for _, cs := range cm.clusters {
+				return cs, nil
+			}
+			return nil, fmt.Errorf("no clusters available")
+		}
+		clusterID = cm.defaultClusterID
+	}
+	if cluster, ok := cm.clusters[clusterID]; ok {
 		return cluster, nil
 	}
-	return nil, fmt.Errorf("cluster not found: %s", clusterName)
+	return nil, fmt.Errorf("cluster not found: %d", clusterID)
 }
 
 func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
@@ -192,8 +220,43 @@ func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
 		return 0
 	}
 
+	hasDefaultCluster, err := model.HasDefaultCluster()
+	if err != nil {
+		klog.Warningf("failed to check existing default cluster: %v", err)
+		hasDefaultCluster = false
+	}
+
+	existingAPIServers := make(map[string]struct{})
+	clusters, err := model.ListClusters()
+	if err != nil {
+		klog.Warningf("failed to list clusters for api server dedupe: %v", err)
+	} else {
+		for _, existing := range clusters {
+			apiServer, err := getNormalizedAPIServerAddress(string(existing.Config))
+			if err != nil || apiServer == "" {
+				continue
+			}
+			existingAPIServers[apiServer] = struct{}{}
+		}
+	}
+
 	importedCount := 0
 	for contextName, context := range kubeconfig.Contexts {
+		clusterConfig, ok := kubeconfig.Clusters[context.Cluster]
+		if !ok || clusterConfig == nil {
+			continue
+		}
+
+		apiServer, err := normalizeAPIServerAddress(clusterConfig.Server)
+		if err != nil {
+			klog.Warningf("failed to normalise api server for cluster %s: %v", contextName, err)
+			continue
+		}
+		if _, exists := existingAPIServers[apiServer]; exists {
+			klog.Infof("Skipped importing cluster %s because api server %s already exists", contextName, apiServer)
+			continue
+		}
+
 		config := clientcmdapi.NewConfig()
 		config.Contexts = map[string]*clientcmdapi.Context{
 			contextName: context,
@@ -212,20 +275,80 @@ func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
 		cluster := model.Cluster{
 			Name:      contextName,
 			Config:    model.SecretString(configStr),
-			IsDefault: contextName == kubeconfig.CurrentContext,
+			IsDefault: !hasDefaultCluster && contextName == kubeconfig.CurrentContext,
 		}
-		if _, err := model.GetClusterByName(contextName); err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				if err := model.AddCluster(&cluster); err != nil {
-					continue
-				}
-				importedCount++
-				klog.Infof("Imported cluster success: %s", contextName)
-			}
+		if err := model.AddCluster(&cluster); err != nil {
 			continue
 		}
+		if cluster.IsDefault {
+			hasDefaultCluster = true
+		}
+		existingAPIServers[apiServer] = struct{}{}
+		importedCount++
+		klog.Infof("Imported cluster success: %s", cluster.Name)
 	}
 	return int64(importedCount)
+}
+
+func getNormalizedAPIServerAddress(config string) (string, error) {
+	if strings.TrimSpace(config) == "" {
+		return "", nil
+	}
+
+	kubeconfig, err := clientcmd.Load([]byte(config))
+	if err != nil {
+		return "", err
+	}
+	if kubeconfig.CurrentContext == "" {
+		return "", nil
+	}
+
+	ctx, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]
+	if !ok || ctx == nil {
+		return "", nil
+	}
+	clusterConfig, ok := kubeconfig.Clusters[ctx.Cluster]
+	if !ok || clusterConfig == nil {
+		return "", nil
+	}
+
+	return normalizeAPIServerAddress(clusterConfig.Server)
+}
+
+func normalizeAPIServerAddress(rawURL string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid api server url: %s", rawURL)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	switch {
+	case port != "":
+	case scheme == "https":
+		port = "443"
+	case scheme == "http":
+		port = "80"
+	}
+
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "/" {
+		path = ""
+	}
+
+	if port != "" {
+		return fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path), nil
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, host, path), nil
 }
 
 var (
@@ -253,7 +376,8 @@ func syncClusters(cm *ClusterManager) error {
 		time.Sleep(5 * time.Second)
 		return err
 	}
-	dbClusterMap := make(map[string]interface{})
+	dbClusterMap := make(map[uint]struct{})
+	cm.defaultClusterID = 0
 	type buildResult struct {
 		cluster   *model.Cluster
 		clientSet *ClientSet
@@ -261,20 +385,20 @@ func syncClusters(cm *ClusterManager) error {
 	}
 	buildQueue := make([]*model.Cluster, 0)
 	for _, cluster := range clusters {
-		dbClusterMap[cluster.Name] = cluster
+		dbClusterMap[cluster.ID] = struct{}{}
 		if cluster.IsDefault {
-			cm.defaultContext = cluster.Name
+			cm.defaultClusterID = cluster.ID
 		}
-		current, currentExist := cm.clusters[cluster.Name]
+		current, currentExist := cm.clusters[cluster.ID]
 		if shouldUpdateCluster(current, cluster) {
 			if currentExist {
-				delete(cm.clusters, cluster.Name)
+				delete(cm.clusters, cluster.ID)
 				current.K8sClient.Stop(cluster.Name)
 			}
 			if cluster.Enable {
 				buildQueue = append(buildQueue, cluster)
 			} else {
-				delete(cm.errors, cluster.Name)
+				delete(cm.errors, cluster.ID)
 			}
 		}
 	}
@@ -297,21 +421,21 @@ func syncClusters(cm *ClusterManager) error {
 	for result := range results {
 		if result.err != nil {
 			klog.Errorf("Failed to build k8s client for cluster %s, in cluster: %t, err: %v", result.cluster.Name, result.cluster.InCluster, result.err)
-			cm.errors[result.cluster.Name] = result.err.Error()
+			cm.errors[result.cluster.ID] = result.err.Error()
 			continue
 		}
-		delete(cm.errors, result.cluster.Name)
-		cm.clusters[result.cluster.Name] = result.clientSet
+		delete(cm.errors, result.cluster.ID)
+		cm.clusters[result.cluster.ID] = result.clientSet
 	}
-	for name, clientSet := range cm.clusters {
-		if _, ok := dbClusterMap[name]; !ok {
-			delete(cm.clusters, name)
-			clientSet.K8sClient.Stop(name)
+	for id, clientSet := range cm.clusters {
+		if _, ok := dbClusterMap[id]; !ok {
+			delete(cm.clusters, id)
+			clientSet.K8sClient.Stop(clientSet.Name)
 		}
 	}
-	for name := range cm.errors {
-		if _, ok := dbClusterMap[name]; !ok {
-			delete(cm.errors, name)
+	for id := range cm.errors {
+		if _, ok := dbClusterMap[id]; !ok {
+			delete(cm.errors, id)
 		}
 	}
 
@@ -362,15 +486,28 @@ func shouldUpdateCluster(cs *ClientSet, cluster *model.Cluster) bool {
 
 func buildClientSet(cluster *model.Cluster) (*ClientSet, error) {
 	if cluster.InCluster {
-		return createClientSetInCluster(cluster.Name, cluster.PrometheusURL)
+		clientSet, err := createClientSetInCluster(cluster.Name, cluster.PrometheusURL)
+		if err != nil {
+			return nil, err
+		}
+		clientSet.ID = cluster.ID
+		return clientSet, nil
 	}
-	return createClientSetFromConfig(cluster.Name, string(cluster.Config), cluster.PrometheusURL)
+	clientSet, err := createClientSetFromConfig(cluster.Name, string(cluster.Config), cluster.PrometheusURL)
+	if err != nil {
+		return nil, err
+	}
+	clientSet.ID = cluster.ID
+	if apiServer, apiErr := getNormalizedAPIServerAddress(string(cluster.Config)); apiErr == nil {
+		clientSet.APIServer = apiServer
+	}
+	return clientSet, nil
 }
 
 func NewClusterManager() (*ClusterManager, error) {
 	cm := new(ClusterManager)
-	cm.clusters = make(map[string]*ClientSet)
-	cm.errors = make(map[string]string)
+	cm.clusters = make(map[uint]*ClientSet)
+	cm.errors = make(map[uint]string)
 	go func() {
 		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()

--- a/pkg/cluster/cluster_manager_additional_test.go
+++ b/pkg/cluster/cluster_manager_additional_test.go
@@ -174,8 +174,8 @@ func TestDiscoveryPrometheusURL(t *testing.T) {
 func TestGetClientSet(t *testing.T) {
 	t.Run("returns error when no clusters exist", func(t *testing.T) {
 		cm := &ClusterManager{
-			clusters: map[string]*ClientSet{},
-			errors:   map[string]string{},
+			clusters: map[uint]*ClientSet{},
+			errors:   map[uint]string{},
 		}
 
 		_, err := cm.GetClientSet("")
@@ -185,14 +185,14 @@ func TestGetClientSet(t *testing.T) {
 	})
 
 	t.Run("returns default cluster when set", func(t *testing.T) {
-		expected := &ClientSet{Name: "default"}
+		expected := &ClientSet{ID: 1, Name: "default"}
 		cm := &ClusterManager{
-			clusters: map[string]*ClientSet{
-				"default": expected,
-				"other":   {Name: "other"},
+			clusters: map[uint]*ClientSet{
+				1: expected,
+				2: {ID: 2, Name: "other"},
 			},
-			errors:         map[string]string{},
-			defaultContext: "default",
+			errors:           map[uint]string{},
+			defaultClusterID: 1,
 		}
 
 		got, err := cm.GetClientSet("")
@@ -205,12 +205,12 @@ func TestGetClientSet(t *testing.T) {
 	})
 
 	t.Run("falls back to first cluster when default context is empty", func(t *testing.T) {
-		expected := &ClientSet{Name: "first"}
+		expected := &ClientSet{ID: 1, Name: "first"}
 		cm := &ClusterManager{
-			clusters: map[string]*ClientSet{
-				"first": expected,
+			clusters: map[uint]*ClientSet{
+				1: expected,
 			},
-			errors: map[string]string{},
+			errors: map[uint]string{},
 		}
 
 		got, err := cm.GetClientSet("")
@@ -223,12 +223,12 @@ func TestGetClientSet(t *testing.T) {
 	})
 
 	t.Run("returns named cluster", func(t *testing.T) {
-		expected := &ClientSet{Name: "target"}
+		expected := &ClientSet{ID: 7, Name: "target"}
 		cm := &ClusterManager{
-			clusters: map[string]*ClientSet{
-				"target": expected,
+			clusters: map[uint]*ClientSet{
+				7: expected,
 			},
-			errors: map[string]string{},
+			errors: map[uint]string{},
 		}
 
 		got, err := cm.GetClientSet("target")
@@ -242,10 +242,10 @@ func TestGetClientSet(t *testing.T) {
 
 	t.Run("returns error for missing cluster", func(t *testing.T) {
 		cm := &ClusterManager{
-			clusters: map[string]*ClientSet{
-				"target": {Name: "target"},
+			clusters: map[uint]*ClientSet{
+				7: {ID: 7, Name: "target"},
 			},
-			errors: map[string]string{},
+			errors: map[uint]string{},
 		}
 
 		_, err := cm.GetClientSet("missing")

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -42,7 +42,9 @@ type ImportClustersRequest struct {
 }
 
 type ClusterInfo struct {
+	ID        uint   `json:"id"`
 	Name      string `json:"name"`
+	APIServer string `json:"apiServer,omitempty"`
 	Version   string `json:"version"`
 	IsDefault bool   `json:"isDefault"`
 	Error     string `json:"error,omitempty"`

--- a/pkg/middleware/cluster.go
+++ b/pkg/middleware/cluster.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/eryajf/kite-desktop/pkg/cluster"
@@ -9,7 +10,9 @@ import (
 )
 
 const (
+	ClusterIDHeader   = "x-cluster-id"
 	ClusterNameHeader = "x-cluster-name"
+	ClusterIDKey      = "cluster-id"
 	ClusterNameKey    = "cluster-name"
 	K8sClientKey      = "k8s-client"
 	PromClientKey     = "prom-client"
@@ -18,10 +21,25 @@ const (
 // ClusterMiddleware extracts cluster name from header and injects clients into context
 func ClusterMiddleware(cm *cluster.ClusterManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		clusterName := c.GetHeader(ClusterNameHeader)
+		clusterID := readClusterIDRequestValue(c)
+		if clusterID != 0 {
+			cluster, err := cm.GetClientSetByID(clusterID)
+			if err != nil {
+				c.JSON(404, gin.H{"error": err.Error()})
+				c.Abort()
+				return
+			}
+			c.Set("cluster", cluster)
+			c.Set(ClusterIDKey, cluster.ID)
+			c.Set(ClusterNameKey, cluster.Name)
+			c.Next()
+			return
+		}
+
+		clusterName := strings.TrimSpace(c.GetHeader(ClusterNameHeader))
 		if clusterName == "" {
 			if v, ok := c.GetQuery(ClusterNameHeader); ok {
-				clusterName = v
+				clusterName = strings.TrimSpace(v)
 			}
 			if clusterName == "" {
 				clusterName = ReadClusterNameCookie(c)
@@ -34,9 +52,44 @@ func ClusterMiddleware(cm *cluster.ClusterManager) gin.HandlerFunc {
 			return
 		}
 		c.Set("cluster", cluster)
+		c.Set(ClusterIDKey, cluster.ID)
 		c.Set(ClusterNameKey, cluster.Name)
 		c.Next()
 	}
+}
+
+func readClusterIDRequestValue(c *gin.Context) uint {
+	if raw := strings.TrimSpace(c.GetHeader(ClusterIDHeader)); raw != "" {
+		if value, err := strconv.ParseUint(raw, 10, 32); err == nil {
+			return uint(value)
+		}
+	}
+	if raw, ok := c.GetQuery(ClusterIDHeader); ok {
+		if value, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 32); err == nil {
+			return uint(value)
+		}
+	}
+	return ReadClusterIDCookie(c)
+}
+
+func ReadClusterIDCookie(c *gin.Context) uint {
+	rawValue, err := c.Cookie(ClusterIDHeader)
+	if err != nil {
+		return 0
+	}
+	trimmed := strings.TrimSpace(rawValue)
+	if trimmed == "" {
+		return 0
+	}
+	decoded, err := url.QueryUnescape(trimmed)
+	if err != nil {
+		decoded = trimmed
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(decoded), 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint(value)
 }
 
 func ReadClusterNameCookie(c *gin.Context) string {

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -2,7 +2,7 @@ package model
 
 type Cluster struct {
 	Model
-	Name          string       `json:"name" gorm:"type:varchar(100);uniqueIndex;not null"`
+	Name          string       `json:"name" gorm:"type:varchar(100);not null"`
 	Description   string       `json:"description" gorm:"type:text"`
 	Config        SecretString `json:"config" gorm:"type:text"`
 	PrometheusURL string       `json:"prometheus_url,omitempty" gorm:"type:varchar(255)"`
@@ -61,4 +61,12 @@ func ListClusters() ([]*Cluster, error) {
 
 func CountClusters() (count int64, err error) {
 	return count, DB.Model(&Cluster{}).Count(&count).Error
+}
+
+func HasDefaultCluster() (bool, error) {
+	var count int64
+	if err := DB.Model(&Cluster{}).Where("is_default = ?", true).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,13 +33,13 @@ const FloatingTerminal = lazy(async () => {
 
 function ClusterGate({ children }: { children: ReactNode }) {
   const { t } = useTranslation()
-  const { currentCluster, isLoading, error } = useCluster()
+  const { currentClusterId, isLoading, error } = useCluster()
 
   useEffect(() => {
     apiClient.setClusterProvider(() => {
-      return currentCluster || localStorage.getItem('current-cluster')
+      return currentClusterId || localStorage.getItem('current-cluster-id')
     })
-  }, [currentCluster])
+  }, [currentClusterId])
 
   if (isLoading) {
     return (

--- a/ui/src/components/cluster-selector.tsx
+++ b/ui/src/components/cluster-selector.tsx
@@ -30,7 +30,8 @@ export function ClusterSelector() {
   const { t } = useTranslation()
   const {
     clusters,
-    currentCluster,
+    currentClusterId,
+    currentClusterData,
     setCurrentCluster,
     isSwitching,
     isLoading,
@@ -48,8 +49,6 @@ export function ClusterSelector() {
       </div>
     )
   }
-
-  const currentClusterData = clusters.find((c) => c.name === currentCluster)
 
   return (
     <DropdownMenu>
@@ -105,8 +104,8 @@ export function ClusterSelector() {
         ) : null}
         {clusters.map((cluster) => (
           <DropdownMenuItem
-            key={cluster.name}
-            onClick={() => setCurrentCluster(cluster.name)}
+            key={cluster.id}
+            onClick={() => setCurrentCluster(String(cluster.id))}
             disabled={!!cluster.error}
             className="flex items-center justify-between"
           >
@@ -129,12 +128,15 @@ export function ClusterSelector() {
                   'text-xs truncate',
                   cluster.error ? 'text-red-500' : 'text-muted-foreground'
                 )}
-                title={cluster.error}
+                title={cluster.error || cluster.apiServer}
               >
-                {cluster.error || cluster.version}
+                {cluster.error ||
+                  cluster.apiServer ||
+                  cluster.version ||
+                  t('globalSearch.clusterReady')}
               </span>
             </div>
-            {currentCluster === cluster.name && (
+            {currentClusterId === String(cluster.id) && (
               <IconCheck className="h-4 w-4" />
             )}
           </DropdownMenuItem>

--- a/ui/src/components/column-filter-popover.tsx
+++ b/ui/src/components/column-filter-popover.tsx
@@ -96,12 +96,12 @@ function FacetedFilterContent<TData>({
   const listRef = useRef<HTMLDivElement>(null)
   const [highlightIndex, setHighlightIndex] = useState(-1)
 
+  const filterValue = column.getFilterValue()
   const selectedValues = useMemo(() => {
-    const val = column.getFilterValue()
-    return Array.isArray(val)
-      ? new Set<string>(val as string[])
+    return Array.isArray(filterValue)
+      ? new Set<string>(filterValue as string[])
       : new Set<string>()
-  }, [column.getFilterValue()])
+  }, [filterValue])
 
   const sortedEntries = useMemo(() => {
     return Array.from(facetedValues.entries())

--- a/ui/src/components/global-search.tsx
+++ b/ui/src/components/global-search.tsx
@@ -155,7 +155,7 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
   const { openSearch } = useGlobalSearch()
   const {
     clusters,
-    currentCluster,
+    currentClusterId,
     setCurrentCluster,
     isSwitching,
     isLoading: isClusterLoading,
@@ -354,19 +354,20 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
     }
 
     const recentClusterOrder = new Map(
-      recentClusters.map((clusterName, index) => [clusterName, index])
+      recentClusters.map((clusterId, index) => [clusterId, index])
     )
 
     const sortedClusters = [...clusters].sort((left, right) => {
-      if (left.name === currentCluster) {
+      if (String(left.id) === currentClusterId) {
         return -1
       }
-      if (right.name === currentCluster) {
+      if (String(right.id) === currentClusterId) {
         return 1
       }
 
-      const leftRecentIndex = recentClusterOrder.get(left.name) ?? Infinity
-      const rightRecentIndex = recentClusterOrder.get(right.name) ?? Infinity
+      const leftRecentIndex = recentClusterOrder.get(String(left.id)) ?? Infinity
+      const rightRecentIndex =
+        recentClusterOrder.get(String(right.id)) ?? Infinity
       if (leftRecentIndex !== rightRecentIndex) {
         return leftRecentIndex - rightRecentIndex
       }
@@ -380,16 +381,17 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
 
     const normalizedQuery = query.trim().toLowerCase()
     const items = sortedClusters.map((cluster) => ({
-      id: `cluster-${cluster.name}`,
+      id: `cluster-${cluster.id}`,
       cluster,
       clusterNameText: cluster.name.toLowerCase(),
       searchText: [
         cluster.name,
+        cluster.apiServer,
         cluster.description,
         cluster.version,
         cluster.error,
         cluster.isDefault ? 'default 默认' : '',
-        cluster.name === currentCluster ? 'current 当前' : '',
+        String(cluster.id) === currentClusterId ? 'current 当前' : '',
         'cluster clusters switch 集群 切换',
       ]
         .filter(Boolean)
@@ -397,6 +399,7 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
         .toLowerCase(),
       subtitle:
         cluster.error ||
+        cluster.apiServer ||
         cluster.description ||
         cluster.version ||
         t('globalSearch.clusterReady'),
@@ -404,8 +407,8 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
         !!cluster.error ||
         isSwitching ||
         isClusterLoading ||
-        cluster.name === currentCluster,
-      isCurrent: cluster.name === currentCluster,
+        String(cluster.id) === currentClusterId,
+      isCurrent: String(cluster.id) === currentClusterId,
     }))
 
     if (mode === 'cluster') {
@@ -436,7 +439,7 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
       : []
   }, [
     clusters,
-    currentCluster,
+    currentClusterId,
     isClusterLoading,
     isSwitching,
     mode,
@@ -568,24 +571,20 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
       : t('globalSearch.description')
 
   const handleClusterSelect = useCallback(
-    (clusterName: string) => {
-      if (
-        isSwitching ||
-        isClusterLoading ||
-        clusterName === currentCluster
-      ) {
+    (clusterId: string) => {
+      if (isSwitching || isClusterLoading || clusterId === currentClusterId) {
         return
       }
       trackDesktopEvent('global_search_select', {
         mode,
         item_type: 'cluster',
       })
-      setCurrentCluster(clusterName)
+      setCurrentCluster(clusterId)
       onOpenChange(false)
       setQuery('')
     },
     [
-      currentCluster,
+      currentClusterId,
       isClusterLoading,
       isSwitching,
       mode,
@@ -713,7 +712,9 @@ export function GlobalSearch({ open, mode, onOpenChange }: GlobalSearchProps) {
                     key={item.id}
                     value={item.clusterNameText}
                     disabled={item.disabled}
-                    onSelect={() => handleClusterSelect(item.cluster.name)}
+                    onSelect={() =>
+                      handleClusterSelect(String(item.cluster.id))
+                    }
                     className="flex items-center gap-3 py-3"
                   >
                     <IconServer className="h-4 w-4 text-sidebar-primary" />

--- a/ui/src/components/settings/cluster-management.test.tsx
+++ b/ui/src/components/settings/cluster-management.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
 
 const {
   useClusterList,
@@ -91,7 +96,7 @@ vi.mock('../action-table', () => ({
     columns,
   }: {
     data: Array<Record<string, unknown>>
-    columns: any[]
+    columns: ColumnDef<Record<string, unknown>>[]
   }) => {
     const table = useReactTable({
       data,

--- a/ui/src/components/settings/cluster-management.test.tsx
+++ b/ui/src/components/settings/cluster-management.test.tsx
@@ -1,0 +1,292 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+
+const {
+  useClusterList,
+  createCluster,
+  updateCluster,
+  deleteCluster,
+  testClusterConnection,
+} = vi.hoisted(() => ({
+  useClusterList: vi.fn(),
+  createCluster: vi.fn(),
+  updateCluster: vi.fn(),
+  deleteCluster: vi.fn(),
+  testClusterConnection: vi.fn(),
+}))
+
+const { successToast, errorToast } = vi.hoisted(() => ({
+  successToast: vi.fn(),
+  errorToast: vi.fn(),
+}))
+
+const { invalidateClusterQueries } = vi.hoisted(() => ({
+  invalidateClusterQueries: vi.fn(() => Promise.resolve()),
+}))
+
+const { importKubeconfig } = vi.hoisted(() => ({
+  importKubeconfig: vi.fn(),
+}))
+
+const { useRuntime } = vi.hoisted(() => ({
+  useRuntime: vi.fn(),
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (
+        _key: string,
+        fallbackOrOptions?: string | { defaultValue?: string }
+      ) => {
+        if (typeof fallbackOrOptions === 'string') {
+          return fallbackOrOptions
+        }
+        return fallbackOrOptions?.defaultValue ?? _key
+      },
+    }),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: successToast,
+    error: errorToast,
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  useClusterList,
+  createCluster,
+  updateCluster,
+  deleteCluster,
+  testClusterConnection,
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  trackDesktopEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/cluster-query', () => ({
+  invalidateClusterQueries,
+}))
+
+vi.mock('@/lib/desktop', () => ({
+  importKubeconfig,
+}))
+
+vi.mock('@/contexts/runtime-context', () => ({
+  useRuntime,
+}))
+
+vi.mock('../action-table', () => ({
+  ActionTable: ({
+    data,
+    columns,
+  }: {
+    data: Array<Record<string, unknown>>
+    columns: any[]
+  }) => {
+    const table = useReactTable({
+      data,
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+    })
+
+    return (
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  },
+}))
+
+vi.mock('./cluster-dialog', () => ({
+  ClusterDialog: () => null,
+}))
+
+vi.mock('@/components/delete-confirmation-dialog', () => ({
+  DeleteConfirmationDialog: () => null,
+}))
+
+import { ClusterManagement } from './cluster-management'
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location-search">{location.search}</div>
+}
+
+function renderComponent(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/settings"
+            element={
+              <>
+                <ClusterManagement />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('ClusterManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useRuntime.mockReturnValue({
+      isDesktop: true,
+      isReady: true,
+    })
+    importKubeconfig.mockResolvedValue({
+      importedCount: 1,
+      ok: true,
+    })
+    useClusterList.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('shows an import success toast once and clears the desktop import marker', async () => {
+    renderComponent('/settings?tab=clusters&desktopImport=success')
+
+    await waitFor(() => {
+      expect(successToast).toHaveBeenCalledWith(
+        'Kubeconfig imported successfully'
+      )
+    })
+    await waitFor(() => {
+      expect(invalidateClusterQueries).toHaveBeenCalled()
+    })
+    expect(errorToast).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search')).toHaveTextContent(
+        '?tab=clusters'
+      )
+    })
+  })
+
+  it('shows a skipped import toast when no new clusters were added', async () => {
+    renderComponent('/settings?tab=clusters&desktopImport=skipped')
+
+    await waitFor(() => {
+      expect(successToast).toHaveBeenCalledWith(
+        'No new clusters were imported because matching clusters already exist'
+      )
+    })
+    await waitFor(() => {
+      expect(invalidateClusterQueries).toHaveBeenCalled()
+    })
+  })
+
+  it('shows the api server column and value in the cluster table', () => {
+    useClusterList.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: 'demo',
+          apiServer: 'https://demo.example.com:443',
+          enabled: true,
+          inCluster: false,
+          isDefault: true,
+          createdAt: '',
+          updatedAt: '',
+          prometheusURL: '',
+        },
+      ],
+      isLoading: false,
+      error: null,
+    })
+
+    renderComponent('/settings?tab=clusters')
+
+    expect(screen.getByRole('columnheader', { name: 'API Server' })).toBeInTheDocument()
+    expect(screen.getByText('https://demo.example.com:443')).toBeInTheDocument()
+  })
+
+  it('shows an import cluster button in desktop mode', () => {
+    renderComponent('/settings?tab=clusters')
+
+    expect(
+      screen.getByRole('button', { name: 'Import Cluster' })
+    ).toBeInTheDocument()
+  })
+
+  it('hides the import cluster button outside desktop mode', () => {
+    useRuntime.mockReturnValue({
+      isDesktop: false,
+      isReady: true,
+    })
+
+    renderComponent('/settings?tab=clusters')
+
+    expect(
+      screen.queryByRole('button', { name: 'Import Cluster' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('imports clusters from the page button and refreshes the list', async () => {
+    const user = userEvent.setup()
+
+    renderComponent('/settings?tab=clusters')
+
+    await user.click(screen.getByRole('button', { name: 'Import Cluster' }))
+
+    await waitFor(() => {
+      expect(importKubeconfig).toHaveBeenCalledWith()
+    })
+    await waitFor(() => {
+      expect(invalidateClusterQueries).toHaveBeenCalled()
+    })
+    expect(successToast).toHaveBeenCalledWith(
+      'Kubeconfig imported successfully'
+    )
+  })
+})

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -1,8 +1,15 @@
-import { useCallback, useMemo, useState } from 'react'
-import { IconEdit, IconPlus, IconServer, IconTrash } from '@tabler/icons-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  IconEdit,
+  IconFileImport,
+  IconPlus,
+  IconServer,
+  IconTrash,
+} from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { Cluster } from '@/types/api'
@@ -18,6 +25,8 @@ import {
 } from '@/lib/api'
 import { trackDesktopEvent } from '@/lib/analytics'
 import { invalidateClusterQueries } from '@/lib/cluster-query'
+import { importKubeconfig } from '@/lib/desktop'
+import { useRuntime } from '@/contexts/runtime-context'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -45,12 +54,45 @@ function getClusterAnalyticsPayload(
 export function ClusterManagement() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { isDesktop } = useRuntime()
 
   const { data: clusters = [], isLoading, error } = useClusterList()
 
   const [showClusterDialog, setShowClusterDialog] = useState(false)
   const [editingCluster, setEditingCluster] = useState<Cluster | null>(null)
   const [deletingCluster, setDeletingCluster] = useState<Cluster | null>(null)
+
+  useEffect(() => {
+    const importResult = searchParams.get('desktopImport')
+    if (importResult !== 'success' && importResult !== 'skipped') {
+      return
+    }
+
+    void invalidateClusterQueries(queryClient)
+
+    toast.success(
+      importResult === 'success'
+        ? t(
+            'clusterManagement.messages.imported',
+            'Kubeconfig imported successfully'
+          )
+        : t(
+            'clusterManagement.messages.importSkipped',
+            'No new clusters were imported because matching clusters already exist'
+          )
+    )
+
+    setSearchParams(
+      (prev) => {
+        const nextParams = new URLSearchParams(prev)
+        nextParams.delete('desktopImport')
+        nextParams.delete('desktopImportTs')
+        return nextParams
+      },
+      { replace: true }
+    )
+  }, [queryClient, searchParams, setSearchParams, t])
 
   const getClusterTypeBadge = useCallback(
     (cluster: Cluster) => {
@@ -137,6 +179,15 @@ export function ClusterManagement() {
           }
           return <Badge variant="secondary">{cluster.version || '-'}</Badge>
         },
+      },
+      {
+        id: 'apiServer',
+        header: t('clusterManagement.table.apiServer', 'API Server'),
+        cell: ({ row: { original: cluster } }) => (
+          <div className="max-w-[20rem] break-all text-sm text-muted-foreground">
+            {cluster.apiServer || '-'}
+          </div>
+        ),
       },
       {
         id: 'type',
@@ -324,6 +375,39 @@ export function ClusterManagement() {
     deleteMutation.mutate(deletingCluster.id)
   }
 
+  const handleImportCluster = async () => {
+    try {
+      const result = await importKubeconfig()
+
+      await invalidateClusterQueries(queryClient)
+
+      if (result.importedCount > 0) {
+        toast.success(
+          t(
+            'clusterManagement.messages.imported',
+            'Kubeconfig imported successfully'
+          )
+        )
+      } else {
+        toast.success(
+          t(
+            'clusterManagement.messages.importSkipped',
+            'No new clusters were imported because matching clusters already exist'
+          )
+        )
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t(
+              'clusterManagement.messages.importError',
+              'Failed to import kubeconfig'
+            )
+      )
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -355,16 +439,28 @@ export function ClusterManagement() {
                 {t('clusterManagement.title', 'Cluster Management')}
               </CardTitle>
             </div>
-            <Button
-              onClick={() => {
-                setEditingCluster(null)
-                setShowClusterDialog(true)
-              }}
-              className="gap-2"
-            >
-              <IconPlus className="h-4 w-4" />
-              {t('clusterManagement.actions.add', 'Add Cluster')}
-            </Button>
+            <div className="flex items-center gap-2">
+              {isDesktop && (
+                <Button
+                  variant="outline"
+                  onClick={() => void handleImportCluster()}
+                  className="gap-2"
+                >
+                  <IconFileImport className="h-4 w-4" />
+                  {t('clusterManagement.actions.import', 'Import Cluster')}
+                </Button>
+              )}
+              <Button
+                onClick={() => {
+                  setEditingCluster(null)
+                  setShowClusterDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconPlus className="h-4 w-4" />
+                {t('clusterManagement.actions.add', 'Add Cluster')}
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/ui/src/components/settings/general-management-runtime.ts
+++ b/ui/src/components/settings/general-management-runtime.ts
@@ -1,0 +1,15 @@
+export function shouldReloadForAnalyticsChange(
+  previousEnableAnalytics: boolean | undefined,
+  nextEnableAnalytics: boolean
+) {
+  return (
+    typeof previousEnableAnalytics === 'boolean' &&
+    previousEnableAnalytics !== nextEnableAnalytics
+  )
+}
+
+export const browserRuntime = {
+  reloadWindow() {
+    window.location.reload()
+  },
+}

--- a/ui/src/components/settings/general-management.test.tsx
+++ b/ui/src/components/settings/general-management.test.tsx
@@ -55,7 +55,8 @@ vi.mock('sonner', () => ({
   },
 }))
 
-import * as GeneralManagementModule from './general-management'
+import { GeneralManagement } from './general-management'
+import * as GeneralManagementRuntime from './general-management-runtime'
 
 function renderComponent() {
   const queryClient = new QueryClient({
@@ -67,7 +68,7 @@ function renderComponent() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <GeneralManagementModule.GeneralManagement />
+      <GeneralManagement />
     </QueryClientProvider>
   )
 }
@@ -100,7 +101,7 @@ describe('GeneralManagement', () => {
   it('reloads the app after analytics is disabled so the injected script is removed', async () => {
     const user = userEvent.setup()
     const reloadSpy = vi
-      .spyOn(GeneralManagementModule.browserRuntime, 'reloadWindow')
+      .spyOn(GeneralManagementRuntime.browserRuntime, 'reloadWindow')
       .mockImplementation(() => undefined)
 
     updateGeneralSetting.mockResolvedValue({
@@ -138,7 +139,7 @@ describe('GeneralManagement', () => {
   it('does not reload when analytics setting is unchanged', async () => {
     const user = userEvent.setup()
     const reloadSpy = vi
-      .spyOn(GeneralManagementModule.browserRuntime, 'reloadWindow')
+      .spyOn(GeneralManagementRuntime.browserRuntime, 'reloadWindow')
       .mockImplementation(() => undefined)
 
     updateGeneralSetting.mockResolvedValue({
@@ -175,16 +176,16 @@ describe('GeneralManagement', () => {
 describe('shouldReloadForAnalyticsChange', () => {
   it('only reloads when the analytics toggle actually changes', () => {
     expect(
-      GeneralManagementModule.shouldReloadForAnalyticsChange(true, false)
+      GeneralManagementRuntime.shouldReloadForAnalyticsChange(true, false)
     ).toBe(true)
     expect(
-      GeneralManagementModule.shouldReloadForAnalyticsChange(false, true)
+      GeneralManagementRuntime.shouldReloadForAnalyticsChange(false, true)
     ).toBe(true)
     expect(
-      GeneralManagementModule.shouldReloadForAnalyticsChange(true, true)
+      GeneralManagementRuntime.shouldReloadForAnalyticsChange(true, true)
     ).toBe(false)
     expect(
-      GeneralManagementModule.shouldReloadForAnalyticsChange(undefined, false)
+      GeneralManagementRuntime.shouldReloadForAnalyticsChange(undefined, false)
     ).toBe(false)
   })
 })

--- a/ui/src/components/settings/general-management.tsx
+++ b/ui/src/components/settings/general-management.tsx
@@ -10,6 +10,10 @@ import {
   updateGeneralSetting,
   useGeneralSetting,
 } from '@/lib/api'
+import {
+  browserRuntime,
+  shouldReloadForAnalyticsChange,
+} from './general-management-runtime'
 import { translateError } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -44,22 +48,6 @@ interface GeneralSettingsFormData {
   nodeTerminalImage: string
   enableAnalytics: boolean
   enableVersionCheck: boolean
-}
-
-export function shouldReloadForAnalyticsChange(
-  previousEnableAnalytics: boolean | undefined,
-  nextEnableAnalytics: boolean
-) {
-  return (
-    typeof previousEnableAnalytics === 'boolean' &&
-    previousEnableAnalytics !== nextEnableAnalytics
-  )
-}
-
-export const browserRuntime = {
-  reloadWindow() {
-    window.location.reload()
-  },
 }
 
 export function GeneralManagement() {

--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -298,7 +298,7 @@ export function Terminal({
 
     // WebSocket connection
     setIsConnected(false)
-    const currentCluster = localStorage.getItem('current-cluster')
+    const currentCluster = localStorage.getItem('current-cluster-id')
     const wsPath =
       type === 'pod'
         ? appendClusterNameParam(

--- a/ui/src/contexts/cluster-context.test.tsx
+++ b/ui/src/contexts/cluster-context.test.tsx
@@ -31,7 +31,7 @@ function ClusterSwitchProbe() {
       {(value) => (
         <button
           type="button"
-          onClick={() => value?.setCurrentCluster('cluster-b')}
+          onClick={() => value?.setCurrentCluster('2')}
         >
           switch
         </button>
@@ -73,6 +73,7 @@ describe('ClusterProvider', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     localStorage.setItem('current-cluster', 'stale-cluster')
+    localStorage.setItem('current-cluster-id', '99')
     const removeItemSpy = vi.spyOn(localStorage, 'removeItem')
     const setItemSpy = vi.spyOn(localStorage, 'setItem')
 
@@ -82,6 +83,7 @@ describe('ClusterProvider', () => {
       expect(screen.getByTestId('cluster-state')).toHaveTextContent('none|false')
     )
 
+    expect(removeItemSpy).toHaveBeenCalledWith('current-cluster-id')
     expect(removeItemSpy).toHaveBeenCalledWith('current-cluster')
     expect(setItemSpy).not.toHaveBeenCalledWith(
       'current-cluster',
@@ -95,8 +97,8 @@ describe('ClusterProvider', () => {
       ok: true,
       status: 200,
       json: async () => [
-        { name: 'cluster-a', isDefault: true },
-        { name: 'cluster-b', isDefault: false },
+        { id: 1, name: 'cluster-a', isDefault: true },
+        { id: 2, name: 'cluster-b', isDefault: false },
       ],
     })
     vi.stubGlobal('fetch', fetchMock)

--- a/ui/src/contexts/cluster-context.tsx
+++ b/ui/src/contexts/cluster-context.tsx
@@ -15,7 +15,9 @@ const recentClustersStorageKey = 'recent-clusters'
 interface ClusterContextType {
   clusters: Cluster[]
   currentCluster: string | null
-  setCurrentCluster: (clusterName: string) => void
+  currentClusterId: string | null
+  currentClusterData: Cluster | null
+  setCurrentCluster: (clusterId: string) => void
   isLoading: boolean
   isSwitching?: boolean
   error: Error | null
@@ -28,19 +30,19 @@ export const ClusterContext = createContext<ClusterContextType | undefined>(
 export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [currentCluster, setCurrentClusterState] = useState<string | null>(
-    localStorage.getItem('current-cluster')
+  const [currentClusterId, setCurrentClusterIdState] = useState<string | null>(
+    localStorage.getItem('current-cluster-id')
   )
   const queryClient = useQueryClient()
   const [isSwitching, setIsSwitching] = useState(false)
 
-  const saveRecentCluster = (clusterName: string) => {
+  const saveRecentCluster = (clusterId: string) => {
     const recentClusters = JSON.parse(
       localStorage.getItem(recentClustersStorageKey) || '[]'
     ) as string[]
     const nextRecentClusters = [
-      clusterName,
-      ...recentClusters.filter((name) => name !== clusterName),
+      clusterId,
+      ...recentClusters.filter((id) => id !== clusterId),
     ].slice(0, 8)
     localStorage.setItem(
       recentClustersStorageKey,
@@ -49,12 +51,12 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   useEffect(() => {
-    if (currentCluster) {
-      setClusterCookie(currentCluster)
+    if (currentClusterId) {
+      setClusterCookie(currentClusterId)
       return
     }
     clearClusterCookie()
-  }, [currentCluster])
+  }, [currentClusterId])
 
   // Fetch clusters from API (this request shouldn't need cluster header)
   const {
@@ -90,46 +92,64 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
 
+  const currentClusterData =
+    clusters.find((cluster) => String(cluster.id) === currentClusterId) ?? null
+  const currentCluster = currentClusterData?.name ?? null
+
   // Set default cluster if none is selected
   useEffect(() => {
-    if (clusters.length > 0 && !currentCluster) {
+    if (clusters.length > 0 && !currentClusterId) {
       const defaultCluster = clusters.find((c) => c.isDefault)
       if (defaultCluster) {
-        setCurrentClusterState(defaultCluster.name)
-        setClusterCookie(defaultCluster.name)
+        const defaultClusterId = String(defaultCluster.id)
+        setCurrentClusterIdState(defaultClusterId)
+        setClusterCookie(defaultClusterId)
+        localStorage.setItem('current-cluster-id', defaultClusterId)
         localStorage.setItem('current-cluster', defaultCluster.name)
       } else {
         // If no default cluster, use the first one
-        setCurrentClusterState(clusters[0].name)
+        const firstClusterId = String(clusters[0].id)
+        setCurrentClusterIdState(firstClusterId)
+        localStorage.setItem('current-cluster-id', firstClusterId)
         localStorage.setItem('current-cluster', clusters[0].name)
-        setClusterCookie(clusters[0].name)
+        setClusterCookie(firstClusterId)
       }
     }
-    if (clusters.length === 0 && currentCluster) {
-      setCurrentClusterState(null)
+    if (clusters.length === 0 && currentClusterId) {
+      setCurrentClusterIdState(null)
+      localStorage.removeItem('current-cluster-id')
       localStorage.removeItem('current-cluster')
       clearClusterCookie()
     }
     if (
-      currentCluster &&
+      currentClusterId &&
       clusters.length > 0 &&
-      !clusters.some((c) => c.name === currentCluster)
+      !clusters.some((c) => String(c.id) === currentClusterId)
     ) {
       // If current cluster is not in the list, reset it
-      setCurrentClusterState(null)
+      setCurrentClusterIdState(null)
+      localStorage.removeItem('current-cluster-id')
       localStorage.removeItem('current-cluster')
       clearClusterCookie()
     }
-  }, [clusters, currentCluster])
+  }, [clusters, currentClusterId])
 
-  const setCurrentCluster = (clusterName: string) => {
-    if (clusterName !== currentCluster && !isSwitching) {
+  const setCurrentCluster = (clusterId: string) => {
+    const nextCluster = clusters.find(
+      (cluster) => String(cluster.id) === clusterId
+    )
+    if (!nextCluster) {
+      return
+    }
+
+    if (clusterId !== currentClusterId && !isSwitching) {
       try {
         setIsSwitching(true)
-        setCurrentClusterState(clusterName)
-        localStorage.setItem('current-cluster', clusterName)
-        saveRecentCluster(clusterName)
-        setClusterCookie(clusterName)
+        setCurrentClusterIdState(clusterId)
+        localStorage.setItem('current-cluster-id', clusterId)
+        localStorage.setItem('current-cluster', nextCluster.name)
+        saveRecentCluster(clusterId)
+        setClusterCookie(clusterId)
         trackEvent('cluster_switch', {
           runtime: 'desktop',
           page: getCurrentAnalyticsPageKey(),
@@ -142,7 +162,7 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
             },
           })
           setIsSwitching(false)
-          toast.success(`Switched to cluster: ${clusterName}`, {
+          toast.success(`Switched to cluster: ${nextCluster.name}`, {
             id: 'cluster-switch',
           })
         }, 300)
@@ -159,6 +179,8 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
   const value: ClusterContextType = {
     clusters,
     currentCluster,
+    currentClusterId,
+    currentClusterData,
     setCurrentCluster,
     isLoading,
     isSwitching,

--- a/ui/src/contexts/runtime-context.tsx
+++ b/ui/src/contexts/runtime-context.tsx
@@ -74,7 +74,7 @@ export function RuntimeProvider({ children }: { children: ReactNode }) {
     return () => {
       active = false
     }
-  }, [])
+  }, [queryClient])
 
   return (
     <RuntimeContext.Provider value={state}>{children}</RuntimeContext.Provider>

--- a/ui/src/hooks/use-ai-chat.ts
+++ b/ui/src/hooks/use-ai-chat.ts
@@ -896,7 +896,7 @@ export function useAIChat() {
       language: string,
       abortSignal?: AbortSignal
     ) => {
-      const clusterName = localStorage.getItem('current-cluster') || ''
+      const clusterName = localStorage.getItem('current-cluster-id') || ''
       const requestLanguage = (language || '').trim() || 'en'
 
       const response = await fetch(

--- a/ui/src/hooks/use-ai-chat.ts
+++ b/ui/src/hooks/use-ai-chat.ts
@@ -1034,6 +1034,7 @@ export function useAIChat() {
       saveCurrentSession,
       streamChat,
       currentCluster,
+      currentSessionId,
       getToolStatusContent,
       t,
     ]

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -668,6 +668,7 @@
     "resourceType": "cluster",
     "actions": {
       "add": "Add Cluster",
+      "import": "Import Cluster",
       "testConnection": "Test Connection",
       "testingConnection": "Testing...",
       "edit": "Edit",
@@ -675,6 +676,7 @@
     },
     "table": {
       "name": "Name",
+      "apiServer": "API Server",
       "type": "Type",
       "status": "Status",
       "prometheus": "Prometheus",
@@ -694,6 +696,9 @@
     },
     "messages": {
       "created": "Cluster created successfully",
+      "imported": "Kubeconfig imported successfully",
+      "importSkipped": "No new clusters were imported because matching API Server addresses already exist",
+      "importError": "Failed to import kubeconfig",
       "updated": "Cluster updated successfully",
       "deleted": "Cluster deleted successfully",
       "testing": "Testing cluster connection...",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -802,6 +802,7 @@
     "resourceType": "集群",
     "actions": {
       "add": "添加集群",
+      "import": "导入集群",
       "testConnection": "测试连接",
       "testingConnection": "测试中...",
       "edit": "编辑",
@@ -810,6 +811,7 @@
     },
     "table": {
       "name": "名称",
+      "apiServer": "API Server",
       "type": "类型",
       "status": "状态",
       "prometheus": "Prometheus",
@@ -829,6 +831,9 @@
     },
     "messages": {
       "created": "集群创建成功",
+      "imported": "kubeconfig 导入成功",
+      "importSkipped": "未导入新的集群，已存在相同的集群",
+      "importError": "导入 kubeconfig 失败",
       "updated": "集群更新成功",
       "deleted": "集群删除成功",
       "testing": "正在测试集群连接...",

--- a/ui/src/lib/api-client.test.ts
+++ b/ui/src/lib/api-client.test.ts
@@ -8,14 +8,14 @@ describe('apiClient cluster transport', () => {
   beforeEach(() => {
     fetchMock.mockReset()
     vi.stubGlobal('fetch', fetchMock)
-    apiClient.setClusterProvider(() => '生产集群')
+    apiClient.setClusterProvider(() => '12')
   })
 
   afterEach(() => {
     apiClient.setClusterProvider(() => null)
   })
 
-  it('moves the cluster name from headers to the query string', async () => {
+  it('moves the cluster id from headers to the query string', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -28,7 +28,7 @@ describe('apiClient cluster transport', () => {
     await apiClient.get('/nodes')
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/nodes?x-cluster-name=%E7%94%9F%E4%BA%A7%E9%9B%86%E7%BE%A4',
+      '/api/v1/nodes?x-cluster-id=12',
       expect.objectContaining({
         headers: {
           'Content-Type': 'application/json',

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -391,8 +391,8 @@ export function useResourcesWatch<T extends ResourceType>(
       params.append('labelSelector', options.labelSelector)
     if (options?.fieldSelector)
       params.append('fieldSelector', options.fieldSelector)
-    const cluster = localStorage.getItem('current-cluster')
-    if (cluster) params.append('x-cluster-name', cluster)
+    const cluster = localStorage.getItem('current-cluster-id')
+    if (cluster) params.append('x-cluster-id', cluster)
     return withSubPath(
       `${API_BASE_URL}/${resource}/${ns}/watch?${params.toString()}`
     )

--- a/ui/src/lib/api/observability.ts
+++ b/ui/src/lib/api/observability.ts
@@ -182,9 +182,9 @@ export const createLogsSSEStream = (
     params.append('sinceSeconds', options.sinceSeconds.toString())
   }
 
-  const currentCluster = localStorage.getItem('current-cluster')
+  const currentCluster = localStorage.getItem('current-cluster-id')
   if (currentCluster) {
-    params.append('x-cluster-name', currentCluster)
+    params.append('x-cluster-id', currentCluster)
   }
 
   const endpoint = `${API_BASE_URL}/logs/${namespace}/${podName}?${params.toString()}`
@@ -484,9 +484,9 @@ export const useLogsWebSocket = (
       params.append('labelSelector', options.labelSelector)
     }
 
-    const currentCluster = localStorage.getItem('current-cluster')
+    const currentCluster = localStorage.getItem('current-cluster-id')
     if (currentCluster) {
-      params.append('x-cluster-name', currentCluster)
+      params.append('x-cluster-id', currentCluster)
     }
 
     const wsPath = `/api/v1/logs/${namespace}/${podName}/ws?${params.toString()}`

--- a/ui/src/lib/cluster-cookie.test.ts
+++ b/ui/src/lib/cluster-cookie.test.ts
@@ -3,18 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { clearClusterCookie, setClusterCookie } from './cluster-cookie'
 
 describe('cluster cookie helpers', () => {
-  it('encodes non-ascii cluster names before writing cookies', () => {
-    setClusterCookie('生产集群')
+  it('writes the selected cluster id to cookies', () => {
+    setClusterCookie('12')
 
-    expect(document.cookie).toContain(
-      'x-cluster-name=%E7%94%9F%E4%BA%A7%E9%9B%86%E7%BE%A4'
-    )
+    expect(document.cookie).toContain('x-cluster-id=12')
   })
 
   it('clears the cluster cookie', () => {
-    setClusterCookie('cluster-a')
+    setClusterCookie('12')
     clearClusterCookie()
 
-    expect(document.cookie).not.toContain('x-cluster-name=')
+    expect(document.cookie).not.toContain('x-cluster-id=')
   })
 })

--- a/ui/src/lib/cluster-cookie.ts
+++ b/ui/src/lib/cluster-cookie.ts
@@ -1,10 +1,13 @@
-const CLUSTER_COOKIE_NAME = 'x-cluster-name'
+const CLUSTER_ID_COOKIE_NAME = 'x-cluster-id'
+const LEGACY_CLUSTER_NAME_COOKIE_NAME = 'x-cluster-name'
 
-export function setClusterCookie(clusterName: string) {
-  document.cookie = `${CLUSTER_COOKIE_NAME}=${encodeURIComponent(clusterName)}; path=/`
+export function setClusterCookie(clusterId: string) {
+  document.cookie = `${CLUSTER_ID_COOKIE_NAME}=${encodeURIComponent(clusterId)}; path=/`
 }
 
 export function clearClusterCookie() {
   document.cookie =
-    `${CLUSTER_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    `${CLUSTER_ID_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  document.cookie =
+    `${LEGACY_CLUSTER_NAME_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
 }

--- a/ui/src/lib/cluster-transport.test.ts
+++ b/ui/src/lib/cluster-transport.test.ts
@@ -6,16 +6,16 @@ import {
 } from './cluster-transport'
 
 describe('appendClusterNameParam', () => {
-  it('appends a UTF-8 cluster name as a query parameter', () => {
-    expect(appendClusterNameParam('/api/v1/nodes', '生产集群')).toBe(
-      '/api/v1/nodes?x-cluster-name=%E7%94%9F%E4%BA%A7%E9%9B%86%E7%BE%A4'
+  it('appends a cluster id as a query parameter', () => {
+    expect(appendClusterNameParam('/api/v1/nodes', '12')).toBe(
+      '/api/v1/nodes?x-cluster-id=12'
     )
   })
 
   it('preserves existing query parameters and hashes', () => {
-    expect(
-      appendClusterNameParam('/api/v1/nodes?limit=20#table', 'prod')
-    ).toBe('/api/v1/nodes?limit=20&x-cluster-name=prod#table')
+    expect(appendClusterNameParam('/api/v1/nodes?limit=20#table', '7')).toBe(
+      '/api/v1/nodes?limit=20&x-cluster-id=7#table'
+    )
   })
 })
 
@@ -23,10 +23,10 @@ describe('stripClusterNameHeader', () => {
   it('removes cluster headers and returns the trimmed value', () => {
     const headers = {
       'Content-Type': 'application/json',
-      'x-cluster-name': '  生产集群  ',
+      'x-cluster-id': '  12  ',
     }
 
-    expect(stripClusterNameHeader(headers)).toBe('生产集群')
+    expect(stripClusterNameHeader(headers)).toBe('12')
     expect(headers).toEqual({
       'Content-Type': 'application/json',
     })

--- a/ui/src/lib/cluster-transport.ts
+++ b/ui/src/lib/cluster-transport.ts
@@ -1,18 +1,19 @@
-const CLUSTER_NAME_PARAM = 'x-cluster-name'
+const CLUSTER_ID_PARAM = 'x-cluster-id'
+const LEGACY_CLUSTER_NAME_PARAM = 'x-cluster-name'
 
 export function appendClusterNameParam(
   url: string,
-  clusterName?: string | null
+  clusterID?: string | null
 ): string {
-  const normalizedClusterName = clusterName?.trim()
-  if (!normalizedClusterName) {
+  const normalizedClusterID = clusterID?.trim()
+  if (!normalizedClusterID) {
     return url
   }
 
   const [base, hash = ''] = url.split('#', 2)
   const separator = base.includes('?') ? '&' : '?'
   const nextUrl = `${base}${separator}${new URLSearchParams({
-    [CLUSTER_NAME_PARAM]: normalizedClusterName,
+    [CLUSTER_ID_PARAM]: normalizedClusterID,
   }).toString()}`
 
   if (!hash) {
@@ -26,10 +27,15 @@ export function stripClusterNameHeader(
   headers: Record<string, string>
 ): string | undefined {
   const clusterName =
+    headers['x-cluster-id'] ??
+    headers['X-Cluster-ID'] ??
     headers['x-cluster-name'] ??
     headers['X-Cluster-Name'] ??
-    headers[CLUSTER_NAME_PARAM]
+    headers[CLUSTER_ID_PARAM] ??
+    headers[LEGACY_CLUSTER_NAME_PARAM]
 
+  delete headers['x-cluster-id']
+  delete headers['X-Cluster-ID']
   delete headers['x-cluster-name']
   delete headers['X-Cluster-Name']
 

--- a/ui/src/lib/desktop.ts
+++ b/ui/src/lib/desktop.ts
@@ -115,6 +115,11 @@ export interface DesktopAppInfo {
   paths: DesktopAppPaths
 }
 
+export interface DesktopImportKubeconfigResult {
+  ok: boolean
+  importedCount: number
+}
+
 export interface DesktopUpdateAsset {
   name: string
   downloadUrl: string
@@ -460,15 +465,21 @@ export async function copyTextToClipboard(text: string): Promise<void> {
   }
 }
 
-export async function importKubeconfig(content?: string): Promise<boolean> {
-  const imported = await invokeDesktopAction('/api/desktop/import-kubeconfig', {
-    content,
-  })
-  if (imported) {
+export async function importKubeconfig(
+  content?: string
+): Promise<DesktopImportKubeconfigResult> {
+  const imported = await postDesktop<DesktopImportKubeconfigResult>(
+    '/api/desktop/import-kubeconfig',
+    {
+      content,
+    }
+  )
+  if (imported.ok) {
     trackEvent('kubeconfig_import', {
       runtime: 'desktop',
       mode: content?.trim() ? 'text_import' : 'file_dialog',
       page: getCurrentAnalyticsPageKey(),
+      imported_count: imported.importedCount,
     })
   }
   return imported

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -351,6 +351,7 @@ export interface RelatedResources {
 export interface Cluster {
   id: number
   name: string
+  apiServer?: string
   description?: string
   version?: string
   config?: string


### PR DESCRIPTION
**背景**
当前桌面端在集群导入、集群管理和左下角快速切换等场景中，默认使用 `cluster name` 作为集群唯一标识。这个行为会导致同名但不同 API Server 的集群被误判为重复，进而无法正确导入、展示和切换。

本次改动将重复判断规则调整为基于 `API Server`，并补齐前后端的集群标识链路，使系统能够正确支持“同名但不同集群”的场景。

**改动**
- 取消 `cluster.name` 的唯一约束，允许同名集群存在
- kubeconfig 导入时改为基于标准化后的 `API Server` 去重
- 如果导入的 kubeconfig 中集群 `API Server` 已存在，则跳过导入
- 如果 `API Server` 不同，则允许追加导入，即使集群名相同
- 集群管理页展示 `API Server` 字段
- 集群管理页增加桌面端“导入集群”按钮并接入导入逻辑
- 导入完成后增加成功 / 跳过 / 失败提示
- 跳过提示文案调整为：`未导入新的集群，已存在相同的集群`
- 左下角快速切换列表展示所有集群，不再按 `name` 去重
- 左下角快速切换项展示 `cluster name + api server`
- `/api/v1/clusters` 返回补充 `id` 和 `apiServer`
- 前端集群切换主链路改为基于 `cluster id`
- 后端中间件支持优先通过 `x-cluster-id` 识别当前集群，并兼容旧的 `x-cluster-name`

**验证**
- `pnpm --dir ui run test src/contexts/cluster-context.test.tsx src/lib/cluster-transport.test.ts src/lib/cluster-cookie.test.ts src/lib/api-client.test.ts`
- `pnpm --dir ui exec tsc --noEmit`
- `go test ./pkg/middleware -run 'TestReadCluster(Name|ID)Cookie' -v`
- `go test ./pkg/cluster -run TestGetClientSet -v`

**风险与说明**
- 本次改动涉及集群标识从 `name` 向 `id` 迁移的主链路，已经覆盖集群列表、快速切换、cookie、query 参数和中间件识别逻辑。
- 为兼容旧逻辑，后端仍保留对 `x-cluster-name` 的兼容处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster kubeconfig import capability with success/skip/error feedback
  * Cluster table now displays API Server addresses

* **Improvements**
  * Clusters now identified by stable ID rather than name for more reliable management
  * Improved cluster deduplication when importing kubeconfig files
  * Enhanced cluster selection and persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->