### PR TITLE
fix(desktop): avoid duplicate paste on Windows

### DIFF
--- a/desktop/host.go
+++ b/desktop/host.go
@@ -1068,7 +1068,9 @@ func buildApplicationMenu(h *desktopHost, devMode bool) *application.Menu {
 	editMenu.AddSeparator()
 	editMenu.AddRole(application.Cut)
 	editMenu.AddRole(application.Copy)
-	editMenu.AddRole(application.Paste)
+	if runtime.GOOS != "windows" {
+		editMenu.AddRole(application.Paste)
+	}
 	if runtime.GOOS == "darwin" {
 		editMenu.AddRole(application.PasteAndMatchStyle)
 		editMenu.AddRole(application.Delete)

--- a/desktop/host_test.go
+++ b/desktop/host_test.go
@@ -190,6 +190,9 @@ func TestBuildApplicationMenuIncludesEditMenu(t *testing.T) {
 	if menu.FindByRole(application.Copy) == nil {
 		t.Fatal("expected application menu to include standard clipboard shortcuts")
 	}
+	if runtime.GOOS == "windows" && menu.FindByRole(application.Paste) != nil {
+		t.Fatal("expected Windows menu to leave Paste shortcut to WebView2")
+	}
 }
 
 func TestDesktopHostSetNavigationMenuState(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes duplicate text insertion when pasting into desktop text fields with `Ctrl+V` on Windows.

The desktop host registers the Wails `application.Paste` menu role as part of the Edit menu. On Windows/WebView2, editable fields already handle `Ctrl+V` natively, so the menu role can trigger a second paste for the same shortcut. Right-click paste only goes through WebView2 and therefore inserts once.

## Changes

- Skip registering `application.Paste` on Windows.
- Keep the existing Paste role on non-Windows platforms.
- Add a Windows-specific menu test to prevent reintroducing the duplicate Paste role.

## Verification

- `gofmt -w desktop/host.go desktop/host_test.go`
- `go test ./desktop -run "TestBuildApplicationMenuIncludesEditMenu|TestDesktopHostSetNavigationMenuState"`

## Manual Check

Started the desktop app from source with `go run .` and verified it runs as `version=dev` against the embedded desktop backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Paste menu action availability across platforms. The Paste option in the Edit menu is now platform-specific and only available on non-Windows platforms. This aligns menu behavior with platform conventions while maintaining other clipboard functionality on all supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->