### PR TITLE
fix(desktop): macOS 下支持 Cmd+Q 退出应用

### DIFF
--- a/desktop/host.go
+++ b/desktop/host.go
@@ -1012,7 +1012,7 @@ func buildApplicationMenu(h *desktopHost, devMode bool) *application.Menu {
 		h.navigate("/settings")
 	})
 	appMenu.AddSeparator()
-	appMenu.Add("Quit").OnClick(func(ctx *application.Context) {
+	appMenu.Add("Quit").SetAccelerator("CmdOrCtrl+q").OnClick(func(ctx *application.Context) {
 		if h == nil {
 			return
 		}


### PR DESCRIPTION
## Summary

给应用菜单的 Quit 项绑定 `CmdOrCtrl+q`，让 macOS 上 ⌘Q（Windows/Linux 上 Ctrl+Q）能真正退出应用。

## Why

Quit 菜单项原本没挂 accelerator，⌘Q 在 macOS 上没反应。由于关窗会被收进托盘，键盘层面没有真正退出的路径，只能走托盘菜单或 Dock 右键。

`.SetAccelerator("CmdOrCtrl+q")` 复用现有的 `h.quit()` 清理流程（关闭 AI sidecar、持久化窗口状态、调 `app.Quit()`），关窗到托盘的行为不受影响。

没直接用 `application.Quit` role 是因为它会跳过 `h.quit()` 的清理。

## Related issue

N/A

## Validation

macOS 上 `make dev` 实测：⌘Q 正常退出；红叉关窗仍收进托盘；托盘 Quit 行为不变；菜单栏 Quit 右侧正确显示 ⌘Q。

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).