### PR TITLE
Add navigation routes and update application menu for settings and about sections

### DIFF
--- a/desktop/host.go
+++ b/desktop/host.go
@@ -46,6 +46,9 @@ const (
 	aiSidecarGap          = 0
 	aiSidecarSideRight    = "right"
 	aiSidecarSideLeft     = "left"
+	settingsGeneralRoute  = "/settings?tab=general"
+	settingsDesktopRoute  = "/settings?tab=desktop"
+	settingsAboutRoute    = "/settings?tab=about"
 )
 
 func desktopApplicationIcon() []byte {
@@ -238,6 +241,12 @@ func (h *desktopHost) mainWindowOptions() application.WebviewWindowOptions {
 func (h *desktopHost) registerMainWindow(window *application.WebviewWindow) {
 	h.mainWindow = window
 	h.bindWindowName(window, mainWindowName)
+	window.RegisterKeyBinding("CmdOrCtrl+W", func(_ application.Window) {
+		if h.quitting.Load() {
+			return
+		}
+		window.Close()
+	})
 
 	window.RegisterHook(events.Common.WindowClosing, func(event *application.WindowEvent) {
 		h.closeAISidecar()
@@ -806,9 +815,8 @@ func (h *desktopHost) navigate(route string) {
 	if h.mainWindow == nil {
 		return
 	}
-	target := appRoute(route)
-	h.mainWindow.ExecJS(fmt.Sprintf("window.location.assign(%s)", strconv.Quote(target)))
 	h.focusMainWindow()
+	h.mainWindow.SetURL(appURL(h.baseURL, route))
 }
 
 func (h *desktopHost) openExternalURL(rawURL string) error {
@@ -999,18 +1007,14 @@ func buildApplicationMenu(h *desktopHost, devMode bool) *application.Menu {
 		if h == nil {
 			return
 		}
-		info := h.appInfo()
-		h.showInfoDialog(
-			"About Kite",
-			fmt.Sprintf("Kite Desktop\nVersion: %s\nBuild Date: %s\nCommit: %s\nConfig Dir: %s", info.Version, info.BuildDate, info.CommitID, info.Paths.ConfigDir),
-		)
+		h.navigate(settingsAboutRoute)
 	})
 	appMenu.Add("Preferences").OnClick(func(ctx *application.Context) {
 		if h == nil {
 			return
 		}
-		h.navigate("/settings")
-	})
+		h.navigate(settingsGeneralRoute)
+	}).SetAccelerator("CmdOrCtrl+,")
 	appMenu.AddSeparator()
 	appMenu.Add("Quit").SetAccelerator("CmdOrCtrl+q").OnClick(func(ctx *application.Context) {
 		if h == nil {
@@ -1123,7 +1127,14 @@ func buildApplicationMenu(h *desktopHost, devMode bool) *application.Menu {
 	windowMenu := menu.AddSubmenu("Window")
 	windowMenu.AddRole(application.Minimise)
 	windowMenu.AddRole(application.Zoom)
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS == "darwin" {
+		windowMenu.Add("Close Window").SetAccelerator("CmdOrCtrl+W").OnClick(func(ctx *application.Context) {
+			if h == nil {
+				return
+			}
+			h.hideMainWindow()
+		})
+	} else {
 		windowMenu.AddRole(application.CloseWindow)
 	}
 
@@ -1155,6 +1166,68 @@ func (h *desktopHost) setupApplicationMenu() {
 	h.app.Menu.SetApplicationMenu(menu)
 }
 
+func buildTrayMenu(h *desktopHost) *application.Menu {
+	menu := application.NewMenu()
+	menu.Add("Show Kite").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		h.focusMainWindow()
+	})
+	menu.Add("Settings").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		h.navigate(settingsGeneralRoute)
+	})
+	menu.Add("Desktop Settings").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		h.navigate(settingsDesktopRoute)
+	})
+	menu.Add("About Kite").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		h.navigate(settingsAboutRoute)
+	})
+	menu.Add("Import kubeconfig").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		if err := h.importKubeconfigFromDialog(); err != nil {
+			h.showErrorDialog("Import kubeconfig failed", err.Error())
+			return
+		}
+		h.reloadMainWindow()
+	})
+	menu.Add("Open Config Directory").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		if err := h.openConfigDir(); err != nil {
+			h.showErrorDialog("Open config directory failed", err.Error())
+		}
+	})
+	menu.Add("Open Logs Directory").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		if err := h.openLogsDir(); err != nil {
+			h.showErrorDialog("Open logs directory failed", err.Error())
+		}
+	})
+	menu.AddSeparator()
+	menu.Add("Quit").OnClick(func(ctx *application.Context) {
+		if h == nil {
+			return
+		}
+		h.quit()
+	})
+	return menu
+}
+
 func (h *desktopHost) setupSystemTray() {
 	tray := h.app.SystemTray.New()
 	tray.SetTooltip("Kite")
@@ -1165,33 +1238,7 @@ func (h *desktopHost) setupSystemTray() {
 		tray.SetIcon(desktopTrayIcon)
 	}
 
-	menu := h.app.NewMenu()
-	menu.Add("Show Kite").OnClick(func(ctx *application.Context) {
-		h.focusMainWindow()
-	})
-	menu.Add("Import kubeconfig").OnClick(func(ctx *application.Context) {
-		if err := h.importKubeconfigFromDialog(); err != nil {
-			h.showErrorDialog("Import kubeconfig failed", err.Error())
-			return
-		}
-		h.reloadMainWindow()
-	})
-	menu.Add("Open Config Directory").OnClick(func(ctx *application.Context) {
-		if err := h.openConfigDir(); err != nil {
-			h.showErrorDialog("Open config directory failed", err.Error())
-		}
-	})
-	menu.Add("Open Logs Directory").OnClick(func(ctx *application.Context) {
-		if err := h.openLogsDir(); err != nil {
-			h.showErrorDialog("Open logs directory failed", err.Error())
-		}
-	})
-	menu.AddSeparator()
-	menu.Add("Quit").OnClick(func(ctx *application.Context) {
-		h.quit()
-	})
-
-	tray.SetMenu(menu)
+	tray.SetMenu(buildTrayMenu(h))
 	tray.OnClick(func() {
 		h.focusMainWindow()
 	})
@@ -1230,6 +1277,10 @@ func appRoute(route string) string {
 		return common.Base + "/"
 	}
 	return common.Base + route
+}
+
+func appURL(baseURL, route string) string {
+	return strings.TrimRight(baseURL, "/") + appRoute(route)
 }
 
 func apiPath(route string) string {

--- a/desktop/host_test.go
+++ b/desktop/host_test.go
@@ -164,6 +164,15 @@ func TestNormalizeAndDenormalizeWindowBounds(t *testing.T) {
 
 func TestBuildApplicationMenuIncludesEditMenu(t *testing.T) {
 	menu := buildApplicationMenu(nil, false)
+	if menu.FindByLabel("About Kite") == nil {
+		t.Fatal("expected application menu to include About Kite entry")
+	}
+	if menu.FindByLabel("Preferences") == nil {
+		t.Fatal("expected application menu to include Preferences entry")
+	}
+	if preferences := menu.FindByLabel("Preferences"); preferences.GetAccelerator() != "Cmd+," {
+		t.Fatalf("expected Preferences accelerator to be Cmd+,, got %q", preferences.GetAccelerator())
+	}
 	if menu.FindByLabel("Edit") == nil {
 		t.Fatal("expected application menu to include an Edit submenu")
 	}
@@ -190,8 +199,33 @@ func TestBuildApplicationMenuIncludesEditMenu(t *testing.T) {
 	if menu.FindByRole(application.Copy) == nil {
 		t.Fatal("expected application menu to include standard clipboard shortcuts")
 	}
+	if runtime.GOOS == "darwin" {
+		closeWindow := menu.FindByLabel("Close Window")
+		if closeWindow == nil {
+			t.Fatal("expected application menu to include Close Window entry on macOS")
+		}
+		if closeWindow.GetAccelerator() != "Cmd+W" {
+			t.Fatalf("expected Close Window accelerator to be Cmd+W, got %q", closeWindow.GetAccelerator())
+		}
+	}
 	if runtime.GOOS == "windows" && menu.FindByRole(application.Paste) != nil {
 		t.Fatal("expected Windows menu to leave Paste shortcut to WebView2")
+	}
+}
+
+func TestBuildTrayMenuIncludesDesktopNavigationEntries(t *testing.T) {
+	menu := buildTrayMenu(nil)
+	if menu.FindByLabel("Show Kite") == nil {
+		t.Fatal("expected tray menu to include Show Kite entry")
+	}
+	if menu.FindByLabel("Settings") == nil {
+		t.Fatal("expected tray menu to include Settings entry")
+	}
+	if menu.FindByLabel("Desktop Settings") == nil {
+		t.Fatal("expected tray menu to include Desktop Settings entry")
+	}
+	if menu.FindByLabel("About Kite") == nil {
+		t.Fatal("expected tray menu to include About Kite entry")
 	}
 }
 


### PR DESCRIPTION
## Summary

Add navigation routes for settings and about sections, and update the application menu to include these new entries.

## Why

These changes enhance the user experience by providing easy access to settings and about information directly from the application menu.

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

Tested the application menu to ensure all new entries are accessible and function correctly.

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).

