### PR TITLE
feat(node-image-table): 添加节点镜像表组件，支持镜像信息展示和过滤功能

### DIFF
--- a/ui/src/components/node-image-table.tsx
+++ b/ui/src/components/node-image-table.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react'
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  FilterFn,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  PaginationState,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import { ContainerImage } from 'kubernetes-types/core/v1'
+import { useTranslation } from 'react-i18next'
+
+import { formatBytes } from '@/lib/utils'
+
+import { ResourceTableView } from './resource-table-view'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+
+type NodeImageRow = {
+  id: string
+  primaryName: string
+  sizeBytes: number
+}
+
+const arrIncludesSome: FilterFn<NodeImageRow> = (row, columnId, filterValue) => {
+  if (!Array.isArray(filterValue) || filterValue.length === 0) return true
+  const value = String(row.getValue(columnId) ?? '')
+  return filterValue.includes(value)
+}
+
+function stripImageDigest(name: string) {
+  const digestIndex = name.indexOf('@')
+  return digestIndex >= 0 ? name.slice(0, digestIndex) : name
+}
+
+function hasImageTag(name: string) {
+  const withoutDigest = stripImageDigest(name)
+  const lastSlashIndex = withoutDigest.lastIndexOf('/')
+  const tagSeparatorIndex = withoutDigest.lastIndexOf(':')
+  return tagSeparatorIndex > lastSlashIndex
+}
+
+function getPreferredImageName(names: string[], fallback: string) {
+  const displayNames = names.map(stripImageDigest)
+  const taggedDisplayName = displayNames.find(hasImageTag)
+  if (taggedDisplayName) {
+    return taggedDisplayName
+  }
+
+  return displayNames[0] || fallback
+}
+
+export function NodeImageTable({ images }: { images?: ContainerImage[] }) {
+  const { t } = useTranslation()
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'sizeBytes', desc: true },
+  ])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+
+  const rows = useMemo<NodeImageRow[]>(
+    () =>
+      (images || []).map((image) => {
+        const names = image.names || []
+        const primaryName = getPreferredImageName(names, t('common.unknown'))
+
+        return {
+          id: `${primaryName}-${image.sizeBytes || 0}-${names.join('|')}`,
+          primaryName,
+          sizeBytes: image.sizeBytes || 0,
+        }
+      }),
+    [images, t]
+  )
+
+  const columns = useMemo<ColumnDef<NodeImageRow>[]>(
+    () => [
+      {
+        accessorKey: 'primaryName',
+        id: 'primaryName',
+        header: t('common.name'),
+        cell: ({ row }) => (
+          <div className="min-w-0 truncate font-medium" title={row.original.primaryName}>
+            {row.original.primaryName}
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'sizeBytes',
+        id: 'sizeBytes',
+        header: t('nodes.imageSize'),
+        cell: ({ getValue }) => (
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {formatBytes(Number(getValue()) || 0)}
+          </span>
+        ),
+      },
+    ],
+    [t]
+  )
+
+  const columnsWithFilterFn = useMemo(
+    () =>
+      columns.map((column) => ({
+        ...column,
+        filterFn: column.filterFn ?? arrIncludesSome,
+      })),
+    [columns]
+  )
+
+  const table = useReactTable<NodeImageRow>({
+    data: rows,
+    columns: columnsWithFilterFn,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    getRowId: (row) => row.id,
+    state: {
+      sorting,
+      columnFilters,
+      pagination,
+    },
+    autoResetPageIndex: false,
+  })
+
+  const filteredRowCount = table.getFilteredRowModel().rows.length
+  const totalRowCount = rows.length
+  const hasActiveFilters = columnFilters.length > 0
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('nodes.images')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResourceTableView
+          table={table}
+          columnCount={columns.length}
+          isLoading={false}
+          data={rows}
+          emptyState={null}
+          hasActiveFilters={hasActiveFilters}
+          filteredRowCount={filteredRowCount}
+          totalRowCount={totalRowCount}
+          searchQuery=""
+          pagination={pagination}
+          setPagination={setPagination}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/components/pod-table.tsx
+++ b/ui/src/components/pod-table.tsx
@@ -1,6 +1,20 @@
 import { useMemo, useState, type ReactNode } from 'react'
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  FilterFn,
+  PaginationState,
+  SortingState,
+  createColumnHelper,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
 import { IconLoader, IconTrash } from '@tabler/icons-react'
-import { Pod } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
@@ -14,7 +28,7 @@ import { DeleteConfirmationDialog } from './delete-confirmation-dialog'
 import { DescribeDialog } from './describe-dialog'
 import { MetricCell } from './metrics-cell'
 import { PodStatusIcon } from './pod-status-icon'
-import { Column, SimpleTable } from './simple-table'
+import { ResourceTableView } from './resource-table-view'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
@@ -37,28 +51,55 @@ function toCompactImageName(image: string) {
   return lastSlashIndex >= 0 ? image.slice(lastSlashIndex + 1) : image
 }
 
+const arrIncludesSome: FilterFn<PodWithMetrics> = (row, columnId, filterValue) => {
+  if (!Array.isArray(filterValue) || filterValue.length === 0) return true
+  const value = String(row.getValue(columnId) ?? '')
+  return filterValue.includes(value)
+}
+
 export function PodTable(props: {
   pods?: PodWithMetrics[]
   labelSelector?: string
   isLoading?: boolean
   hiddenNode?: boolean
+  showNamespace?: boolean
   title?: ReactNode
 }) {
   const { t } = useTranslation()
   const { pods, isLoading, title } = props
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
   const [podPendingDelete, setPodPendingDelete] = useState<{
     name: string
     namespace?: string
   } | null>(null)
+  const columnHelper = createColumnHelper<PodWithMetrics>()
 
-  // Pod table columns
   const podColumns = useMemo(
-    (): Column<PodWithMetrics>[] => [
-      {
+    (): ColumnDef<PodWithMetrics>[] => [
+      ...(props.showNamespace
+        ? [
+            columnHelper.accessor(
+              (pod) => pod.metadata?.namespace || '-',
+              {
+                id: 'namespace',
+                header: t('resourceTable.namespace'),
+                cell: ({ getValue }) => (
+                  <Badge variant="outline">{getValue()}</Badge>
+                ),
+              }
+            ),
+          ]
+        : []),
+      columnHelper.accessor((pod) => pod.metadata?.name || '-', {
+        id: 'name',
         header: t('common.name'),
-        accessor: (pod: Pod) => pod.metadata,
-        cell: (value: unknown) => {
-          const meta = value as Pod['metadata']
+        cell: ({ row }) => {
+          const meta = row.original.metadata
           return (
             <div className="font-medium app-link">
               <Link to={`/pods/${meta!.namespace}/${meta!.name}`}>
@@ -67,149 +108,163 @@ export function PodTable(props: {
             </div>
           )
         },
-        align: 'left' as const,
-      },
-      {
+      }),
+      columnHelper.accessor((pod) => {
+        const status = getPodStatus(pod)
+        return status.readyContainers / Math.max(status.totalContainers, 1)
+      }, {
+        id: 'readyRatio',
         header: t('pods.ready'),
-        accessor: (pod: Pod) => {
-          const status = getPodStatus(pod)
+        cell: ({ row }) => {
+          const status = getPodStatus(row.original)
           return `${status.readyContainers} / ${status.totalContainers}`
         },
-        cell: (value: unknown) => value as string,
-      },
-      {
+      }),
+      columnHelper.accessor((pod) => {
+        const status = getPodStatus(pod)
+        const numericRestarts = Number.parseInt(status.restartString, 10)
+        return Number.isNaN(numericRestarts) ? 0 : numericRestarts
+      }, {
+        id: 'restarts',
         header: t('pods.restarts'),
-        accessor: (pod: Pod) => {
-          const status = getPodStatus(pod)
-          return status.restartString || '0'
-        },
-        cell: (value: unknown) => {
+        cell: ({ getValue }) => {
           return (
             <span className="text-muted-foreground text-sm">
-              {value as number}
+              {String(getValue())}
             </span>
           )
         },
-      },
-      {
+      }),
+      columnHelper.accessor((pod) => getPodStatus(pod).reason, {
+        id: 'status',
         header: t('common.status'),
-        accessor: (pod: Pod) => pod,
-        cell: (value: unknown) => {
-          const status = getPodStatus(value as Pod)
+        cell: ({ getValue }) => {
+          const status = getValue()
           return (
             <Badge variant="outline" className="text-muted-foreground px-1.5">
-              <PodStatusIcon status={status.reason} />
-              {translatePodStatus(status.reason, t)}
+              <PodStatusIcon status={status} />
+              {translatePodStatus(status, t)}
             </Badge>
           )
         },
-      },
-      {
-        header: t('containerEditor.tabs.image'),
-        accessor: (pod: Pod) =>
-          pod.spec?.containers?.map((container) => ({
-            name: container.name,
-            image: container.image || '-',
-          })) || [],
-        cell: (value: unknown) => {
-          const images = value as PodImageEntry[]
+      }),
+      columnHelper.accessor(
+        (pod) =>
+          pod.spec?.containers
+            ?.map((container) =>
+              `${container.name}: ${toCompactImageName(container.image || '-')}`
+            )
+            .join(' | ') || '-',
+        {
+          id: 'imageSummary',
+          header: t('containerEditor.tabs.image'),
+          cell: ({ row }) => {
+            const images: PodImageEntry[] =
+              row.original.spec?.containers?.map((container) => ({
+                name: container.name,
+                image: container.image || '-',
+              })) || []
 
-          if (images.length === 0) {
-            return <span className="text-sm text-muted-foreground">-</span>
-          }
+            if (images.length === 0) {
+              return <span className="text-sm text-muted-foreground">-</span>
+            }
 
-          const summary = images
-            .map((entry) => `${entry.name}: ${toCompactImageName(entry.image)}`)
-            .join(' | ')
+            const summary = images
+              .map(
+                (entry) => `${entry.name}: ${toCompactImageName(entry.image)}`
+              )
+              .join(' | ')
 
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className="max-w-[320px] truncate text-xs text-muted-foreground"
+                    title={summary}
+                  >
+                    <span className="font-mono">{summary}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-md">
+                  <div className="space-y-2">
+                    {images.map((entry) => (
+                      <div
+                        key={`${entry.name}-${entry.image}`}
+                        className="min-w-0"
+                      >
+                        <div className="text-xs text-muted-foreground">
+                          {entry.name}
+                        </div>
+                        <div className="font-mono text-xs break-all">
+                          {entry.image}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            )
+          },
+        }
+      ),
+      columnHelper.accessor((pod) => pod.metrics, {
+        id: 'cpu',
+        header: t('monitoring.cpuUsage'),
+        cell: ({ getValue }) => {
+          return <MetricCell type="cpu" metrics={getValue() as MetricsData} />
+        },
+        enableSorting: false,
+        enableColumnFilter: false,
+      }),
+      columnHelper.accessor((pod) => pod.metrics, {
+        id: 'memory',
+        header: t('monitoring.memoryUsage'),
+        cell: ({ getValue }) => {
           return (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  className="max-w-[320px] truncate text-xs text-muted-foreground"
-                  title={summary}
-                >
-                  <span className="font-mono">{summary}</span>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="max-w-md">
-                <div className="space-y-2">
-                  {images.map((entry) => (
-                    <div
-                      key={`${entry.name}-${entry.image}`}
-                      className="min-w-0"
-                    >
-                      <div className="text-xs text-muted-foreground">
-                        {entry.name}
-                      </div>
-                      <div className="font-mono text-xs break-all">
-                        {entry.image}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </TooltipContent>
-            </Tooltip>
+            <MetricCell type="memory" metrics={getValue() as MetricsData} />
           )
         },
-        align: 'left' as const,
-      },
-      {
-        header: t('monitoring.cpuUsage'),
-        accessor: (pod: PodWithMetrics) => {
-          return pod.metrics
-        },
-        cell: (value: unknown) => {
-          return <MetricCell type="cpu" metrics={value as MetricsData} />
-        },
-      },
-      {
-        header: t('monitoring.memoryUsage'),
-        accessor: (pod: PodWithMetrics) => {
-          return pod.metrics
-        },
-        cell: (value: unknown) => {
-          return <MetricCell type="memory" metrics={value as MetricsData} />
-        },
-      },
-      {
+        enableSorting: false,
+        enableColumnFilter: false,
+      }),
+      columnHelper.accessor((pod) => pod.status?.podIP || '-', {
+        id: 'podIP',
         header: t('detail.fields.podIP'),
-        accessor: (pod: Pod) => pod.status?.podIP || '-',
-        cell: (value: unknown) => (
+        cell: ({ getValue }) => (
           <span className="text-sm text-muted-foreground font-mono">
-            {value as string}
+            {getValue()}
           </span>
         ),
-      },
+      }),
       ...(props.hiddenNode
         ? []
         : [
-            {
+            columnHelper.accessor((pod) => pod.spec?.nodeName || '-', {
+              id: 'node',
               header: t('pods.node'),
-              accessor: (pod: Pod) => pod.spec?.nodeName || '-',
-              cell: (value: unknown) => (
-                <Link to={`/nodes/${value}`} className="app-link">
-                  {value as string}
+              cell: ({ getValue }) => (
+                <Link to={`/nodes/${getValue()}`} className="app-link">
+                  {getValue()}
                 </Link>
               ),
-            },
+            }),
           ]),
-      {
+      columnHelper.accessor((pod) => pod.metadata?.creationTimestamp || '', {
+        id: 'created',
         header: t('common.created'),
-        accessor: (pod: Pod) => pod.metadata?.creationTimestamp || '',
-        cell: (value: unknown) => {
+        cell: ({ getValue }) => {
           return (
             <span className="text-muted-foreground text-sm">
-              {formatDate(value as string, true)}
+              {formatDate(getValue(), true)}
             </span>
           )
         },
-      },
-      {
+      }),
+      columnHelper.display({
+        id: 'actions',
         header: t('common.actions'),
-        accessor: (pod: Pod) => pod,
-        cell: (value: unknown) => {
-          const pod = value as Pod
+        cell: ({ row }) => {
+          const pod = row.original
           const podName = pod.metadata?.name || ''
           const namespace = pod.metadata?.namespace
 
@@ -237,10 +292,55 @@ export function PodTable(props: {
             </div>
           )
         },
-      },
+        enableSorting: false,
+        enableColumnFilter: false,
+      }),
     ],
-    [props.hiddenNode, t]
+    [columnHelper, props.hiddenNode, props.showNamespace, t]
   )
+
+  const memoizedPods = useMemo(() => pods || [], [pods])
+
+  const columnsWithFilterFn = useMemo(
+    () =>
+      podColumns.map((column) => {
+        if (column.id === 'actions') {
+          return column
+        }
+
+        return {
+          ...column,
+          filterFn: column.filterFn ?? arrIncludesSome,
+        }
+      }),
+    [podColumns]
+  )
+
+  const table = useReactTable({
+    data: memoizedPods,
+    columns: columnsWithFilterFn,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    getRowId: (row) =>
+      row.metadata?.uid ||
+      `${row.metadata?.namespace || '_all'}/${row.metadata?.name || 'pod'}`,
+    state: {
+      sorting,
+      columnFilters,
+      pagination,
+    },
+    autoResetPageIndex: false,
+  })
+
+  const filteredRowCount = table.getFilteredRowModel().rows.length
+  const totalRowCount = memoizedPods.length
 
   const handleDelete = async (force?: boolean, wait?: boolean) => {
     const targetPod = podPendingDelete
@@ -276,17 +376,18 @@ export function PodTable(props: {
         <CardTitle>{title ?? t('pods.title')}</CardTitle>
       </CardHeader>
       <CardContent>
-        <SimpleTable
-          data={pods || []}
-          columns={podColumns}
-          emptyMessage={t('podTable.empty')}
-          stickyFirstColumn
-          stickyLastColumn
-          pagination={{
-            enabled: true,
-            pageSize: 20,
-            showPageInfo: true,
-          }}
+        <ResourceTableView
+          table={table}
+          columnCount={podColumns.length}
+          isLoading={Boolean(isLoading)}
+          data={memoizedPods}
+          emptyState={null}
+          hasActiveFilters={columnFilters.length > 0}
+          filteredRowCount={filteredRowCount}
+          totalRowCount={totalRowCount}
+          searchQuery=""
+          pagination={pagination}
+          setPagination={setPagination}
         />
       </CardContent>
       <DeleteConfirmationDialog

--- a/ui/src/components/resource-table-view.tsx
+++ b/ui/src/components/resource-table-view.tsx
@@ -69,6 +69,18 @@ export function ResourceTableView<T>({
   getRowContextMenuItems,
 }: ResourceTableViewProps<T>) {
   const { t } = useTranslation()
+  const getStickyColumnClassName = (
+    index: number,
+    columnId: string,
+    isHeader = false
+  ) =>
+    cn(
+      index <= 1 ? 'text-left' : 'text-center',
+      columnId === 'actions' &&
+        'sticky right-0 z-20 bg-background shadow-[-10px_0_12px_-12px_color-mix(in_oklab,var(--color-foreground)_16%,transparent)]',
+      isHeader && columnId === 'actions' && 'z-30'
+    )
+
   const renderRows = () => {
     const rows = table.getRowModel().rows
 
@@ -90,7 +102,10 @@ export function ResourceTableView<T>({
           {row.getVisibleCells().map((cell, index) => (
             <TableCell
               key={cell.id}
-              className={`align-middle ${index <= 1 ? 'text-left' : 'text-center'}`}
+              className={cn(
+                'align-middle',
+                getStickyColumnClassName(index, cell.column.id)
+              )}
             >
               {cell.column.columnDef.cell
                 ? flexRender(cell.column.columnDef.cell, cell.getContext())
@@ -202,8 +217,12 @@ export function ResourceTableView<T>({
                         <TableHead
                           key={header.id}
                           className={cn(
-                            index <= 1 ? 'text-left' : 'text-center',
-                            'group/header'
+                            'group/header',
+                            getStickyColumnClassName(
+                              index,
+                              header.column.id,
+                              true
+                            )
                           )}
                         >
                           {header.isPlaceholder ? null : (

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -301,7 +301,15 @@
     "externalIP": "External IP",
     "os": "OS",
     "kernelVersion": "Kernel Version",
-    "containerRuntime": "Container Runtime"
+    "containerRuntime": "Container Runtime",
+    "images": "Images",
+    "imageSize": "Size",
+    "imageReferences": "All references",
+    "imageReferenceCount": "Refs",
+    "imageReferencesCount_one": "{{count}} reference",
+    "imageReferencesCount_other": "{{count}} references",
+    "imageSearchPlaceholder": "Search image names or references...",
+    "noImagesFound": "This node did not report any images"
   },
   "events": {
     "title": "Events",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -327,7 +327,15 @@
     "externalIP": "外部IP",
     "os": "操作系统",
     "kernelVersion": "内核版本",
-    "containerRuntime": "容器运行时"
+    "containerRuntime": "容器运行时",
+    "images": "镜像",
+    "imageSize": "大小",
+    "imageReferences": "全部引用",
+    "imageReferenceCount": "引用数",
+    "imageReferencesCount_one": "{{count}} 个引用",
+    "imageReferencesCount_other": "{{count}} 个引用",
+    "imageSearchPlaceholder": "搜索镜像名称或引用...",
+    "noImagesFound": "该节点未上报镜像信息"
   },
   "events": {
     "title": "事件",

--- a/ui/src/pages/node-detail.tsx
+++ b/ui/src/pages/node-detail.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react'
 import {
   IconBan,
   IconCircleCheckFilled,
-  IconDroplet,
   IconExclamationCircle,
   IconLoader,
   IconLock,
   IconReload,
 } from '@tabler/icons-react'
+import { Droplets } from 'lucide-react'
 import * as yaml from 'js-yaml'
 import { Node } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
@@ -53,6 +53,7 @@ import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
+import { NodeImageTable } from '@/components/node-image-table'
 import { NodeMonitoring } from '@/components/node-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
@@ -305,8 +306,12 @@ export function NodeDetail(props: { name: string }) {
             onOpenChange={setIsDrainPopoverOpen}
           >
             <PopoverTrigger asChild>
-              <Button variant="outline" size="sm">
-                <IconDroplet className="w-4 h-4" />
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/20"
+              >
+                <Droplets className="w-4 h-4" />
                 {t('detail.buttons.drain')}
               </Button>
             </PopoverTrigger>
@@ -977,11 +982,24 @@ export function NodeDetail(props: { name: string }) {
                       pods={relatedPods}
                       isLoading={isLoadingRelated}
                       hiddenNode
+                      showNamespace
                     />
                   ),
                 },
               ]
             : []),
+          {
+            value: 'images',
+            label: (
+              <>
+                {t('nodes.images')}{' '}
+                <Badge variant="secondary">
+                  {data.status?.images?.length || 0}
+                </Badge>
+              </>
+            ),
+            content: <NodeImageTable images={data.status?.images} />,
+          },
           {
             value: 'monitor',
             label: t('detail.tabs.monitor'),

--- a/ui/src/pages/node-list-page.tsx
+++ b/ui/src/pages/node-list-page.tsx
@@ -37,6 +37,39 @@ import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
 import { Terminal } from '@/components/terminal'
 
+function NodePodsUsageCell({ node }: { node: NodeWithMetrics }) {
+  const podsUsed = node.metrics?.pods || 0
+  const podsLimit = node.metrics?.podsLimit || 0
+  const percentage =
+    podsLimit > 0 ? Math.min((podsUsed / podsLimit) * 100, 100) : 0
+  const progressClassName =
+    percentage >= 85
+      ? 'bg-gradient-to-r from-orange-500 via-red-500 to-rose-500'
+      : percentage >= 60
+        ? 'bg-gradient-to-r from-amber-400 via-orange-400 to-orange-500'
+        : 'bg-gradient-to-r from-sky-500 via-cyan-500 to-emerald-500'
+
+  return (
+    <Link
+      to={`/nodes/${node.metadata!.name}?tab=pods`}
+      className="group mx-auto flex min-w-[180px] max-w-[220px] items-center gap-2 text-sm text-foreground transition-colors hover:text-primary"
+    >
+      <span className="w-[58px] shrink-0 text-right font-medium tabular-nums">
+        {podsUsed}/{podsLimit}
+      </span>
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted/80 ring-1 ring-border/50">
+        <div
+          className={`h-full rounded-full transition-all duration-300 group-hover:brightness-110 ${progressClassName}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <span className="w-[38px] shrink-0 text-left font-medium tabular-nums">
+        {Math.round(percentage)}%
+      </span>
+    </Link>
+  )
+}
+
 function getNodeStatus(node: NodeWithMetrics): string {
   const conditions = node.status?.conditions || []
   const isUnschedulable = node.spec?.unschedulable || false
@@ -244,15 +277,7 @@ export function NodeListPage() {
       columnHelper.accessor((row) => row.metrics, {
         id: 'pods',
         header: 'Pods',
-        cell: ({ row }) => (
-          <Link
-            to={`/nodes/${row.original.metadata!.name}?tab=pods`}
-            className="text-muted-foreground hover:text-primary/80 hover:underline transition-colors cursor-pointer"
-          >
-            {row.original.metrics?.pods || 0} /{' '}
-            {row.original.metrics?.podsLimit || 0}
-          </Link>
-        ),
+        cell: ({ row }) => <NodePodsUsageCell node={row.original} />,
       }),
       columnHelper.accessor((row) => row.metrics?.cpuUsage || 0, {
         id: 'cpu',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Images" tab on node detail pages displaying container images in a sortable, filterable table with pagination.
  * Enhanced pod table with improved sorting and filtering capabilities.
  * Improved pod usage visualization on node list pages with progress indicators and percentage display.

* **UI Improvements**
  * Refined table column layouts with improved sticky action column handling.
  * Added internationalization support in English and Chinese for node images and container information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->