### PR TITLE
feat(theme-provider): 添加跨窗口同步主题变化的功能

### DIFF
--- a/ui/src/components/color-theme-provider.test.tsx
+++ b/ui/src/components/color-theme-provider.test.tsx
@@ -70,4 +70,31 @@ describe('ColorThemeProvider', () => {
     expect(document.documentElement).toHaveClass('color-claude')
     expect(document.documentElement).not.toHaveClass('color-eye-care')
   })
+
+  it('syncs color theme changes from another window via storage events', async () => {
+    localStorage.clear()
+    document.documentElement.className = 'color-default'
+
+    render(
+      <ColorThemeProvider
+        defaultColorTheme="default"
+        storageKey="color-theme-key"
+      >
+        <ColorThemeConsumer />
+      </ColorThemeProvider>
+    )
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'color-theme-key',
+        newValue: 'claude',
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state')).toHaveTextContent('claude')
+    })
+    expect(document.documentElement).toHaveClass('color-claude')
+    expect(document.documentElement).not.toHaveClass('color-default')
+  })
 })

--- a/ui/src/components/color-theme-provider.tsx
+++ b/ui/src/components/color-theme-provider.tsx
@@ -53,6 +53,21 @@ export function ColorThemeProvider({
     root.classList.add(`color-${colorTheme}`)
   }, [colorTheme])
 
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey || event.newValue === null) {
+        return
+      }
+
+      if (event.newValue in colorThemes) {
+        setColorTheme(event.newValue as ColorTheme)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [storageKey])
+
   const value = {
     colorTheme,
     setColorTheme: (colorTheme: ColorTheme) => {

--- a/ui/src/components/font-provider.test.tsx
+++ b/ui/src/components/font-provider.test.tsx
@@ -81,4 +81,28 @@ describe('FontProvider', () => {
     ).toBe("'JetBrains Mono', var(--font-sans)")
     expect(localStorage.getItem('font-theme-key')).toBe('jetbrains')
   })
+
+  it('syncs font changes from another window via storage events', async () => {
+    localStorage.clear()
+
+    render(
+      <FontProvider defaultFont="maple" storageKey="font-theme-key">
+        <FontConsumer />
+      </FontProvider>
+    )
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'font-theme-key',
+        newValue: 'system',
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state')).toHaveTextContent('system')
+    })
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-sans')
+    ).toBe('var(--font-sans)')
+  })
 })

--- a/ui/src/components/font-provider.tsx
+++ b/ui/src/components/font-provider.tsx
@@ -44,6 +44,25 @@ export function FontProvider({
     localStorage.setItem(storageKey, font)
   }, [font, storageKey])
 
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey || event.newValue === null) {
+        return
+      }
+
+      if (
+        event.newValue === 'system' ||
+        event.newValue === 'maple' ||
+        event.newValue === 'jetbrains'
+      ) {
+        setFont(event.newValue)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [storageKey])
+
   const value = useMemo(
     () => ({
       font,

--- a/ui/src/components/theme-provider.test.tsx
+++ b/ui/src/components/theme-provider.test.tsx
@@ -129,4 +129,27 @@ describe('ThemeProvider', () => {
       expect(document.documentElement).not.toHaveClass('light')
     })
   })
+
+  it('syncs theme changes from another window via storage events', async () => {
+    createMatchMedia(false)
+
+    render(
+      <ThemeProvider defaultTheme="light" storageKey="theme-key">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'theme-key',
+        newValue: 'dark',
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state')).toHaveTextContent('dark/dark')
+      expect(document.documentElement).toHaveClass('dark')
+      expect(document.documentElement).not.toHaveClass('light')
+    })
+  })
 })

--- a/ui/src/components/theme-provider.tsx
+++ b/ui/src/components/theme-provider.tsx
@@ -63,6 +63,25 @@ export function ThemeProvider({
     root.classList.add(theme)
   }, [theme])
 
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey || event.newValue === null) {
+        return
+      }
+
+      if (
+        event.newValue === 'light' ||
+        event.newValue === 'dark' ||
+        event.newValue === 'system'
+      ) {
+        setTheme(event.newValue)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [storageKey])
+
   const value = {
     theme,
     setTheme: (theme: Theme) => {


### PR DESCRIPTION
feat(font-provider): 添加跨窗口同步字体变化的功能 feat(color-theme-provider): 添加跨窗口同步颜色主题变化的功能

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme settings including color theme, font selection, and theme preference now automatically synchronize across multiple browser tabs when changed.

* **Tests**
  * Added tests to verify cross-tab synchronization of color theme, font, and theme provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->