### PR TITLE
feat(deployment): 添加镜像更新、暂停和恢复编排功能，优化部署列表操作

### DIFF
--- a/pkg/handlers/resources/node_handler.go
+++ b/pkg/handlers/resources/node_handler.go
@@ -39,10 +39,10 @@ func (h *NodeHandler) DrainNode(c *gin.Context) {
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	// Parse the request body for drain options
 	var drainRequest struct {
-		Force            bool `json:"force" binding:"required"`
-		GracePeriod      int  `json:"gracePeriod" binding:"min=0"`
-		DeleteLocal      bool `json:"deleteLocalData"`
-		IgnoreDaemonsets bool `json:"ignoreDaemonsets"`
+		Force            *bool `json:"force" binding:"required"`
+		GracePeriod      int   `json:"gracePeriod" binding:"min=0"`
+		DeleteLocal      bool  `json:"deleteLocalData"`
+		IgnoreDaemonsets bool  `json:"ignoreDaemonsets"`
 	}
 
 	if err := c.ShouldBindJSON(&drainRequest); err != nil {
@@ -72,7 +72,12 @@ func (h *NodeHandler) DrainNode(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": fmt.Sprintf("Node %s drain initiated", nodeName),
 		"node":    node.Name,
-		"options": drainRequest,
+		"options": gin.H{
+			"force":            *drainRequest.Force,
+			"gracePeriod":      drainRequest.GracePeriod,
+			"deleteLocalData":  drainRequest.DeleteLocal,
+			"ignoreDaemonsets": drainRequest.IgnoreDaemonsets,
+		},
 	})
 }
 

--- a/pkg/handlers/resources/node_handler_test.go
+++ b/pkg/handlers/resources/node_handler_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -163,6 +164,29 @@ func decodeNodeListResponse(t *testing.T, rec *httptest.ResponseRecorder) *commo
 }
 
 // ---------- Tests ----------
+
+func TestNodeHandlerDrain_AcceptsExplicitFalseForce(t *testing.T) {
+	node := makeNode("node-a", 4000, 8*1024*1024*1024, 110)
+	cs := newFakeClientSet(t, node)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Next()
+	})
+	handler := NewNodeHandler()
+	router.POST("/nodes/_all/:name/drain", handler.DrainNode)
+
+	body := []byte(`{"force":false,"gracePeriod":30,"deleteLocalData":false,"ignoreDaemonsets":true}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/nodes/_all/node-a/drain", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "unexpected status code; body=%s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "Node node-a drain initiated")
+}
 
 // TestNodeHandlerList_PodAssignmentByFieldIndex verifies that the List method
 // correctly uses the spec.nodeName field indexer to count pods per node and

--- a/ui/src/components/container-edit-dialog.test.tsx
+++ b/ui/src/components/container-edit-dialog.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import { Deployment } from 'kubernetes-types/apps/v1'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContainerEditDialog } from './container-edit-dialog'
+
+vi.mock('@radix-ui/react-dialog', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@radix-ui/react-dialog')>()
+
+  return {
+    ...actual,
+    DialogDescription: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode
+      className?: string
+    }) => <p className={className}>{children}</p>,
+  }
+})
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, string>) =>
+        options?.name ? `${key}:${options.name}` : key,
+    }),
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    useParams: () => ({ namespace: 'default' }),
+  }
+})
+
+vi.mock('./editors', () => ({
+  EnvironmentEditor: () => <div>environment-editor</div>,
+  ImageEditor: () => <div>image-editor</div>,
+  ProbeGroupEditor: () => <div>probe-group-editor</div>,
+  ResourceEditor: () => <div>resource-editor</div>,
+  VolumeMountEditor: () => <div>volume-mount-editor</div>,
+  VolumeSourceEditor: () => <div>volume-source-editor</div>,
+}))
+
+const deployment = {
+  metadata: {
+    name: 'web',
+    namespace: 'default',
+  },
+  spec: {
+    template: {
+      spec: {
+        containers: [
+          {
+            name: 'nginx-container',
+            image: 'nginx:1.0',
+          },
+          {
+            name: 'sidecar-container',
+            image: 'busybox:1.0',
+          },
+        ],
+      },
+    },
+  },
+} as Deployment
+
+describe('ContainerEditDialog', () => {
+  it('renders deployment containers as horizontal tabs', () => {
+    render(
+      <ContainerEditDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="deployment"
+        deployment={deployment}
+        namespace="default"
+        onSaveDeployment={vi.fn()}
+      />
+    )
+
+    const tabList = screen.getByRole('tablist', {
+      name: 'containerEditor.containerSelector',
+    })
+    expect(tabList).toHaveAttribute('data-slot', 'tabs-list')
+    expect(tabList).toHaveClass('overflow-x-auto')
+    expect(
+      screen.getByRole('tablist', { name: 'containerEditor.containerSelector' })
+    ).toBeInTheDocument()
+    const selectedContainerTab = screen.getByRole('tab', {
+      name: 'nginx-container',
+    })
+    expect(selectedContainerTab).toHaveAttribute('data-slot', 'tabs-trigger')
+    expect(selectedContainerTab).toHaveAttribute('aria-selected', 'true')
+    expect(selectedContainerTab).toHaveAttribute('data-state', 'active')
+    expect(
+      screen.getByRole('tab', { name: 'sidecar-container' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/components/container-edit-dialog.tsx
+++ b/ui/src/components/container-edit-dialog.tsx
@@ -23,13 +23,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from './ui/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from './ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
 
 interface BaseContainerEditDialogProps {
@@ -77,7 +70,10 @@ export function ContainerEditDialog({
           />
         ) : (
           <SimpleContainerEditDialogContent
-            {...(props as Omit<SimpleContainerEditDialogProps, 'open' | 'mode'>)}
+            {...(props as Omit<
+              SimpleContainerEditDialogProps,
+              'open' | 'mode'
+            >)}
           />
         )
       ) : null}
@@ -241,25 +237,30 @@ function DeploymentContainerEditDialogContent({
         </DialogDescription>
       </DialogHeader>
       {containers.length > 1 ? (
-        <div className="space-y-2">
+        <div className="space-y-2 overflow-hidden">
           <label className="text-sm font-medium">
             {t('containerEditor.containerSelector')}
           </label>
-          <Select
+          <Tabs
             value={selectedContainerName}
             onValueChange={setSelectedContainerName}
+            className="gap-0"
           >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
+            <TabsList
+              aria-label={t('containerEditor.containerSelector')}
+              className="h-auto max-w-full justify-start overflow-x-auto"
+            >
               {containers.map((container) => (
-                <SelectItem key={container.name} value={container.name}>
+                <TabsTrigger
+                  key={container.name}
+                  value={container.name}
+                  className="h-9 min-w-fit flex-none px-4 font-mono text-sm"
+                >
                   {container.name}
-                </SelectItem>
+                </TabsTrigger>
               ))}
-            </SelectContent>
-          </Select>
+            </TabsList>
+          </Tabs>
         </div>
       ) : null}
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1545,6 +1545,14 @@
     "manageAnnotations": "Manage annotations"
   },
   "deploymentList": {
+    "editImage": "Update image version",
+    "pauseOrchestration": "Pause rollout",
+    "pauseInitiated": "Deployment rollout paused",
+    "resumeOrchestration": "Resume rollout",
+    "resumeInitiated": "Deployment rollout resumed",
+    "rolloutRestart": "Rolling restart",
+    "rollback": "Rollback",
+    "imageUpdateInitiated": "Deployment image update initiated",
     "manageLabels": "Manage labels",
     "manageAnnotations": "Manage annotations"
   },

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1837,6 +1837,14 @@
     "manageAnnotations": "管理注解"
   },
   "deploymentList": {
+    "editImage": "修改镜像版本",
+    "pauseOrchestration": "暂停编排",
+    "pauseInitiated": "Deployment 编排已暂停",
+    "resumeOrchestration": "恢复编排",
+    "resumeInitiated": "Deployment 编排已恢复",
+    "rolloutRestart": "滚动重启",
+    "rollback": "回滚",
+    "imageUpdateInitiated": "Deployment 镜像更新已发起",
     "manageLabels": "管理标签",
     "manageAnnotations": "管理注解"
   },

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -11,6 +11,7 @@ import { Container } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
+import { trackResourceAction } from '@/lib/analytics'
 import {
   patchResource,
   updateResource,
@@ -18,7 +19,6 @@ import {
   useResources,
   useResourcesWatch,
 } from '@/lib/api'
-import { trackResourceAction } from '@/lib/analytics'
 import {
   buildDeploymentOverviewViewModel,
   filterPodsOwnedByDeployment,
@@ -47,12 +47,12 @@ import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
-import { RefreshButton } from '@/components/refresh-button'
 import { YamlEditor } from '@/components/yaml-editor'
 
 export function DeploymentDetail(props: { namespace: string; name: string }) {

--- a/ui/src/pages/deployment-list-page.test.tsx
+++ b/ui/src/pages/deployment-list-page.test.tsx
@@ -54,10 +54,9 @@ vi.mock('react-router-dom', async () => {
 })
 
 vi.mock('@tanstack/react-query', async () => {
-  const actual =
-    await vi.importActual<typeof import('@tanstack/react-query')>(
-      '@tanstack/react-query'
-    )
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query'
+  )
 
   return {
     ...actual,
@@ -132,6 +131,61 @@ vi.mock('@/components/editors/resource-metadata-dialog', () => ({
       <div>
         <span>{`resource-metadata-dialog-${type}`}</span>
         <span>{resource?.metadata?.name}</span>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/container-edit-dialog', () => ({
+  ContainerEditDialog: ({
+    open,
+    deployment,
+    onSaveDeployment,
+  }: {
+    open: boolean
+    deployment?: { metadata?: { name?: string } }
+    onSaveDeployment?: (deployment: Deployment) => void | Promise<void>
+  }) =>
+    open ? (
+      <div>
+        <span>container-edit-dialog</span>
+        <span>{deployment?.metadata?.name}</span>
+        <button
+          onClick={() =>
+            onSaveDeployment?.({
+              metadata: deployment?.metadata,
+              spec: {
+                template: {
+                  spec: {
+                    containers: [
+                      {
+                        name: 'api',
+                        image: 'nginx:2.0',
+                      },
+                    ],
+                  },
+                },
+              },
+            } as Deployment)
+          }
+        >
+          save-container-edit
+        </button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
+  ResourceDeleteConfirmationDialog: ({
+    open,
+    resourceName,
+  }: {
+    open: boolean
+    resourceName: string
+  }) =>
+    open ? (
+      <div>
+        <span>resource-delete-confirmation-dialog</span>
+        <span>{resourceName}</span>
       </div>
     ) : null,
 }))
@@ -305,45 +359,61 @@ describe('DeploymentListPage', () => {
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
-      'primary-actions-separator',
-      'copy-name',
-      'copy-namespace',
+      'edit-image',
+      'pause-orchestration',
+      'rollout-restart',
+      'rollback',
       'metadata-actions-separator',
       'manage-labels',
       'manage-annotations',
-      'deployment-operations-separator',
-      'scale-deployment',
-      'restart-deployment',
+      'delete-deployment',
     ])
 
     await items[0].onSelect?.()
-    expect(mockNavigate).toHaveBeenCalledWith('/deployments/default/web?tab=yaml')
-
-    await items[2].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('web')
-
-    await items[3].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('default')
-    expect(mockToastSuccess).toHaveBeenCalledWith(
-      'keyValueDataViewer.copiedToClipboard'
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/deployments/default/web?tab=yaml'
     )
 
     await act(async () => {
-      await items[5].onSelect?.()
+      await items[1].onSelect?.()
+    })
+    expect(screen.getByText('container-edit-dialog')).toBeInTheDocument()
+
+    await act(async () => {
+      await items[3].onSelect?.()
+    })
+    expect(
+      screen.getByText('detail.dialogs.restartDeployment.title')
+    ).toBeInTheDocument()
+
+    await items[4].onSelect?.()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/deployments/default/web?tab=history'
+    )
+
+    await act(async () => {
+      await items[6].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-labels')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[6].onSelect?.()
+      await items[7].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-annotations')
     ).toBeInTheDocument()
+
+    await act(async () => {
+      await items[8].onSelect?.()
+    })
+    expect(
+      screen.getByText('resource-delete-confirmation-dialog')
+    ).toBeInTheDocument()
   })
 
-  it('opens scale and restart dialogs from row context menu actions', async () => {
+  it('opens restart dialog from row context menu actions', async () => {
     vi.useRealTimers()
     mockPatchResource.mockResolvedValue(undefined)
 
@@ -369,48 +439,7 @@ describe('DeploymentListPage', () => {
     const items = resourceTableProps.getRowContextMenuItems(deployment)
 
     await act(async () => {
-      await items[8].onSelect?.()
-    })
-    expect(
-      screen.getByText('detail.dialogs.scaleDeployment.title')
-    ).toBeInTheDocument()
-
-    await act(async () => {
-      fireEvent.change(
-        screen.getByLabelText('detail.dialogs.scaleDeployment.replicas'),
-        {
-          target: { value: '5' },
-        }
-      )
-    })
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('button', {
-          name: 'detail.dialogs.scaleDeployment.scaleButton',
-        })
-      )
-    })
-
-    await waitFor(() => {
-      expect(mockPatchResource).toHaveBeenCalledWith(
-        'deployments',
-        'web',
-        'default',
-        {
-          spec: {
-            replicas: 5,
-          },
-        }
-      )
-    })
-    await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['deployments'],
-      })
-    })
-
-    await act(async () => {
-      await items[9].onSelect?.()
+      await items[3].onSelect?.()
     })
     expect(
       screen.getByText('detail.dialogs.restartDeployment.title')
@@ -440,6 +469,132 @@ describe('DeploymentListPage', () => {
             },
           },
         })
+      )
+    })
+  })
+
+  it('patches deployment pause and image edits from row context menu actions', async () => {
+    vi.useRealTimers()
+    mockPatchResource.mockResolvedValue(undefined)
+
+    render(<DeploymentListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      getRowContextMenuItems: (deployment: Deployment) => {
+        key: string
+        onSelect?: () => void | Promise<void>
+      }[]
+    }
+
+    const deployment = {
+      metadata: {
+        name: 'web',
+        namespace: 'default',
+      },
+      spec: {
+        paused: false,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'api',
+                image: 'nginx:1.0',
+              },
+            ],
+          },
+        },
+      },
+    } as Deployment
+
+    const items = resourceTableProps.getRowContextMenuItems(deployment)
+
+    await act(async () => {
+      await items[2].onSelect?.()
+    })
+    await waitFor(() => {
+      expect(mockPatchResource).toHaveBeenCalledWith(
+        'deployments',
+        'web',
+        'default',
+        {
+          spec: {
+            paused: true,
+          },
+        }
+      )
+    })
+
+    await act(async () => {
+      await items[1].onSelect?.()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByText('save-container-edit'))
+    })
+    await waitFor(() => {
+      expect(mockPatchResource).toHaveBeenCalledWith(
+        'deployments',
+        'web',
+        'default',
+        {
+          spec: {
+            template: {
+              spec: {
+                containers: [
+                  {
+                    name: 'api',
+                    image: 'nginx:2.0',
+                  },
+                ],
+              },
+            },
+          },
+        }
+      )
+    })
+  })
+
+  it('shows resume orchestration for paused deployments', async () => {
+    vi.useRealTimers()
+    mockPatchResource.mockResolvedValue(undefined)
+
+    render(<DeploymentListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      getRowContextMenuItems: (deployment: Deployment) => {
+        key: string
+        label?: string
+        onSelect?: () => void | Promise<void>
+      }[]
+    }
+
+    const deployment = {
+      metadata: {
+        name: 'web',
+        namespace: 'default',
+      },
+      spec: {
+        paused: true,
+      },
+    } as Deployment
+
+    const items = resourceTableProps.getRowContextMenuItems(deployment)
+
+    expect(items[2].key).toBe('resume-orchestration')
+    expect(items[2].label).toBe('deploymentList.resumeOrchestration')
+
+    await act(async () => {
+      await items[2].onSelect?.()
+    })
+    await waitFor(() => {
+      expect(mockPatchResource).toHaveBeenCalledWith(
+        'deployments',
+        'web',
+        'default',
+        {
+          spec: {
+            paused: false,
+          },
+        }
       )
     })
   })

--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -3,30 +3,30 @@ import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Deployment } from 'kubernetes-types/apps/v1'
 import type { Container } from 'kubernetes-types/core/v1'
-import { Copy, FileCode2, FileText, RefreshCcw, Scaling, Tags } from 'lucide-react'
+import {
+  FileCode2,
+  FileText,
+  History,
+  Image,
+  Pause,
+  Play,
+  RefreshCcw,
+  Tags,
+  Trash2,
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import {
-  aggregateContainerResources,
-  getDeploymentStatus,
-} from '@/lib/k8s'
 import { patchResource } from '@/lib/api'
-import { copyTextToClipboard } from '@/lib/desktop'
-import { formatDate, formatRelativeTimeStrict, translateError } from '@/lib/utils'
-import { ContainerImagesSummary } from '@/components/container-images-summary'
+import { aggregateContainerResources, getDeploymentStatus } from '@/lib/k8s'
+import {
+  formatDate,
+  formatRelativeTimeStrict,
+  translateError,
+} from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { DeploymentStatusIcon } from '@/components/deployment-status-icon'
-import { DeploymentCreateDialog } from '@/components/editors/deployment-create-dialog'
-import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
-import {
-  MetadataActionButton,
-  renderMetadataTooltipContent,
-} from '@/components/metadata-action-button'
-import { ResourceTable } from '@/components/resource-table'
-import { RowContextMenuItem } from '@/components/row-context-menu'
 import {
   Dialog,
   DialogContent,
@@ -35,8 +35,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { ContainerEditDialog } from '@/components/container-edit-dialog'
+import { ContainerImagesSummary } from '@/components/container-images-summary'
+import { DeploymentStatusIcon } from '@/components/deployment-status-icon'
+import { DeploymentCreateDialog } from '@/components/editors/deployment-create-dialog'
+import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
+import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
+import { ResourceTable } from '@/components/resource-table'
+import { RowContextMenuItem } from '@/components/row-context-menu'
 
 const cpuUnits: Record<string, number> = {
   n: 1e-9,
@@ -180,13 +190,14 @@ export function DeploymentListPage() {
   )
   const [annotationsDeployment, setAnnotationsDeployment] =
     useState<Deployment | null>(null)
-  const [scaleDeploymentTarget, setScaleDeploymentTarget] =
-    useState<Deployment | null>(null)
   const [restartDeploymentTarget, setRestartDeploymentTarget] =
     useState<Deployment | null>(null)
-  const [scaleReplicas, setScaleReplicas] = useState<number>(0)
-  const [isScaling, setIsScaling] = useState(false)
+  const [imageDeploymentTarget, setImageDeploymentTarget] =
+    useState<Deployment | null>(null)
+  const [deleteDeploymentTarget, setDeleteDeploymentTarget] =
+    useState<Deployment | null>(null)
   const [isRestarting, setIsRestarting] = useState(false)
+  const [isPauseToggling, setIsPauseToggling] = useState(false)
 
   // Define column helper outside of any hooks
   const columnHelper = createColumnHelper<Deployment>()
@@ -317,52 +328,9 @@ export function DeploymentListPage() {
     return `/deployments/${deployment.metadata!.namespace}/${deployment.metadata!.name}`
   }, [])
 
-  const handleCopy = useCallback(
-    async (value: string) => {
-      await copyTextToClipboard(value)
-      toast.success(t('keyValueDataViewer.copiedToClipboard'))
-    },
-    [t]
-  )
-
   const refreshDeploymentList = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ['deployments'] })
   }, [queryClient])
-
-  const openScaleDialog = useCallback((deployment: Deployment) => {
-    setScaleDeploymentTarget(deployment)
-    setScaleReplicas(deployment.spec?.replicas || 0)
-  }, [])
-
-  const handleScale = useCallback(async () => {
-    if (
-      !scaleDeploymentTarget?.metadata?.name ||
-      !scaleDeploymentTarget.metadata?.namespace
-    ) {
-      return
-    }
-
-    setIsScaling(true)
-    try {
-      await patchResource(
-        'deployments',
-        scaleDeploymentTarget.metadata.name,
-        scaleDeploymentTarget.metadata.namespace,
-        {
-          spec: {
-            replicas: scaleReplicas,
-          },
-        }
-      )
-      toast.success(`Deployment scaled to ${scaleReplicas} replicas`)
-      setScaleDeploymentTarget(null)
-      await refreshDeploymentList()
-    } catch (error) {
-      toast.error(translateError(error, t))
-    } finally {
-      setIsScaling(false)
-    }
-  }, [refreshDeploymentList, scaleDeploymentTarget, scaleReplicas, t])
 
   const handleRestart = useCallback(async () => {
     if (
@@ -400,9 +368,70 @@ export function DeploymentListPage() {
     }
   }, [refreshDeploymentList, restartDeploymentTarget, t])
 
+  const handlePauseToggle = useCallback(
+    async (deployment: Deployment) => {
+      if (!deployment.metadata?.name || !deployment.metadata?.namespace) {
+        return
+      }
+
+      const nextPaused = deployment.spec?.paused !== true
+
+      setIsPauseToggling(true)
+      try {
+        await patchResource(
+          'deployments',
+          deployment.metadata.name,
+          deployment.metadata.namespace,
+          {
+            spec: {
+              paused: nextPaused,
+            },
+          }
+        )
+        toast.success(
+          nextPaused
+            ? t('deploymentList.pauseInitiated')
+            : t('deploymentList.resumeInitiated')
+        )
+        await refreshDeploymentList()
+      } catch (error) {
+        toast.error(translateError(error, t))
+      } finally {
+        setIsPauseToggling(false)
+      }
+    },
+    [refreshDeploymentList, t]
+  )
+
+  const handleContainerEditorSave = useCallback(
+    async (updatedDeployment: Deployment) => {
+      if (
+        !imageDeploymentTarget?.metadata?.name ||
+        !imageDeploymentTarget.metadata?.namespace
+      ) {
+        return
+      }
+
+      await patchResource(
+        'deployments',
+        imageDeploymentTarget.metadata.name,
+        imageDeploymentTarget.metadata.namespace,
+        {
+          spec: {
+            template: updatedDeployment.spec?.template,
+          },
+        }
+      )
+      toast.success(t('deploymentList.imageUpdateInitiated'))
+      await refreshDeploymentList()
+    },
+    [imageDeploymentTarget, refreshDeploymentList, t]
+  )
+
   const getRowContextMenuItems = useCallback(
     (deployment: Deployment): RowContextMenuItem<Deployment>[] => {
       const detailPath = getDeploymentDetailPath(deployment)
+      const isPaused = deployment.spec?.paused === true
 
       return [
         {
@@ -411,18 +440,36 @@ export function DeploymentListPage() {
           icon: <FileCode2 className="h-4 w-4" />,
           onSelect: () => navigate(`${detailPath}?tab=yaml`),
         },
-        { type: 'separator', key: 'primary-actions-separator' },
         {
-          key: 'copy-name',
-          label: t('common.copyName', 'Copy name'),
-          icon: <Copy className="h-4 w-4" />,
-          onSelect: () => handleCopy(deployment.metadata?.name || ''),
+          key: 'edit-image',
+          label: t('deploymentList.editImage'),
+          icon: <Image className="h-4 w-4" />,
+          onSelect: () => setImageDeploymentTarget(deployment),
         },
         {
-          key: 'copy-namespace',
-          label: t('common.copyNamespace', 'Copy namespace'),
-          icon: <Copy className="h-4 w-4" />,
-          onSelect: () => handleCopy(deployment.metadata?.namespace || ''),
+          key: isPaused ? 'resume-orchestration' : 'pause-orchestration',
+          label: isPaused
+            ? t('deploymentList.resumeOrchestration')
+            : t('deploymentList.pauseOrchestration'),
+          icon: isPaused ? (
+            <Play className="h-4 w-4" />
+          ) : (
+            <Pause className="h-4 w-4" />
+          ),
+          disabled: isPauseToggling,
+          onSelect: () => handlePauseToggle(deployment),
+        },
+        {
+          key: 'rollout-restart',
+          label: t('deploymentList.rolloutRestart'),
+          icon: <RefreshCcw className="h-4 w-4" />,
+          onSelect: () => setRestartDeploymentTarget(deployment),
+        },
+        {
+          key: 'rollback',
+          label: t('deploymentList.rollback'),
+          icon: <History className="h-4 w-4" />,
+          onSelect: () => navigate(`${detailPath}?tab=history`),
         },
         { type: 'separator', key: 'metadata-actions-separator' },
         {
@@ -437,22 +484,16 @@ export function DeploymentListPage() {
           icon: <FileText className="h-4 w-4" />,
           onSelect: () => setAnnotationsDeployment(deployment),
         },
-        { type: 'separator', key: 'deployment-operations-separator' },
         {
-          key: 'scale-deployment',
-          label: t('detail.buttons.scale'),
-          icon: <Scaling className="h-4 w-4" />,
-          onSelect: () => openScaleDialog(deployment),
-        },
-        {
-          key: 'restart-deployment',
-          label: t('detail.buttons.restart'),
-          icon: <RefreshCcw className="h-4 w-4" />,
-          onSelect: () => setRestartDeploymentTarget(deployment),
+          key: 'delete-deployment',
+          label: t('common.delete'),
+          icon: <Trash2 className="h-4 w-4" />,
+          variant: 'destructive',
+          onSelect: () => setDeleteDeploymentTarget(deployment),
         },
       ]
     },
-    [getDeploymentDetailPath, handleCopy, navigate, openScaleDialog, t]
+    [getDeploymentDetailPath, handlePauseToggle, isPauseToggling, navigate, t]
   )
 
   return (
@@ -474,72 +515,6 @@ export function DeploymentListPage() {
         onOpenChange={setIsCreateDialogOpen}
         onSuccess={handleCreateSuccess}
       />
-
-      <Dialog
-        open={Boolean(scaleDeploymentTarget)}
-        onOpenChange={(open) => {
-          if (!open && !isScaling) {
-            setScaleDeploymentTarget(null)
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('detail.dialogs.scaleDeployment.title')}</DialogTitle>
-            <DialogDescription>
-              {t('detail.dialogs.scaleDeployment.description')}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="deployment-scale-replicas">
-              {t('detail.dialogs.scaleDeployment.replicas')}
-            </Label>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-9 w-9 p-0"
-                onClick={() => setScaleReplicas(Math.max(0, scaleReplicas - 1))}
-                disabled={scaleReplicas <= 0 || isScaling}
-              >
-                -
-              </Button>
-              <Input
-                id="deployment-scale-replicas"
-                type="number"
-                min="0"
-                value={scaleReplicas}
-                onChange={(event) =>
-                  setScaleReplicas(parseInt(event.target.value) || 0)
-                }
-                className="text-center"
-                disabled={isScaling}
-              />
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-9 w-9 p-0"
-                onClick={() => setScaleReplicas(scaleReplicas + 1)}
-                disabled={isScaling}
-              >
-                +
-              </Button>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setScaleDeploymentTarget(null)}
-              disabled={isScaling}
-            >
-              {t('detail.buttons.cancel')}
-            </Button>
-            <Button onClick={handleScale} disabled={isScaling}>
-              {t('detail.dialogs.scaleDeployment.scaleButton')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <Dialog
         open={Boolean(restartDeploymentTarget)}
@@ -595,6 +570,34 @@ export function DeploymentListPage() {
         resourceType="deployments"
         resource={annotationsDeployment}
         type="annotations"
+      />
+
+      {imageDeploymentTarget ? (
+        <ContainerEditDialog
+          open={Boolean(imageDeploymentTarget)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setImageDeploymentTarget(null)
+            }
+          }}
+          mode="deployment"
+          deployment={imageDeploymentTarget}
+          namespace={imageDeploymentTarget.metadata?.namespace || ''}
+          onSaveDeployment={handleContainerEditorSave}
+        />
+      ) : null}
+
+      <ResourceDeleteConfirmationDialog
+        open={Boolean(deleteDeploymentTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteDeploymentTarget(null)
+          }
+        }}
+        resourceName={deleteDeploymentTarget?.metadata?.name || ''}
+        resourceType="deployments"
+        namespace={deleteDeploymentTarget?.metadata?.namespace}
+        confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
       />
     </>
   )


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #92 

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment actions: pause/resume orchestration, edit container images, and delete deployments
  * Improved container selector UI in deployment editor with horizontal tabs layout
  * Enhanced node drain endpoint response format

* **Localization**
  * Added translation keys for new deployment management actions in English and Chinese

* **Tests**
  * Expanded test coverage for container editor dialog, deployment list actions, and node drain endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->