### PR TITLE
feat(cluster): 添加集群连接测试功能和相关逻辑

### DIFF
--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -20,6 +20,7 @@ import (
 )
 
 type clusterRequest struct {
+	ID            uint   `json:"id"`
 	Name          string `json:"name"`
 	Description   string `json:"description"`
 	Config        string `json:"config"`
@@ -386,20 +387,38 @@ func (cm *ClusterManager) TestClusterConnection(c *gin.Context) {
 	}
 
 	config := strings.TrimSpace(req.Config)
-	if !req.InCluster && config == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "config is required when inCluster is false"})
-		return
-	}
 
 	clusterName := strings.TrimSpace(req.Name)
 	if clusterName == "" {
 		clusterName = "test-connection"
 	}
 
+	prometheusURL := strings.TrimSpace(req.PrometheusURL)
+	if !req.InCluster && config == "" && req.ID > 0 {
+		existingCluster, err := model.GetClusterByID(req.ID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "cluster not found"})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		config = strings.TrimSpace(string(existingCluster.Config))
+		if prometheusURL == "" {
+			prometheusURL = existingCluster.PrometheusURL
+		}
+	}
+
+	if !req.InCluster && config == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "config is required when inCluster is false"})
+		return
+	}
+
 	cluster := &model.Cluster{
 		Name:          clusterName,
 		Config:        model.SecretString(config),
-		PrometheusURL: strings.TrimSpace(req.PrometheusURL),
+		PrometheusURL: prometheusURL,
 		InCluster:     req.InCluster,
 	}
 

--- a/pkg/cluster/cluster_handler_test.go
+++ b/pkg/cluster/cluster_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -168,5 +169,55 @@ func TestTestClusterConnectionReturnsReadableError(t *testing.T) {
 	}
 	if response.ErrorDetail == "" {
 		t.Fatalf("expected errorDetail, got empty response: %+v", response)
+	}
+}
+
+func TestTestClusterConnectionUsesExistingConfigWhenEditing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	restoreDB := useClusterManagerTestDB(t)
+	defer restoreDB()
+
+	cluster := &model.Cluster{
+		Name:          "demo",
+		Config:        model.SecretString("apiVersion: v1\nclusters: []"),
+		PrometheusURL: "http://old-prometheus.example",
+		Enable:        true,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("add cluster: %v", err)
+	}
+
+	originalTester := clusterConnectionTester
+	t.Cleanup(func() {
+		clusterConnectionTester = originalTester
+	})
+
+	clusterConnectionTester = func(cluster *model.Cluster) (*ClientSet, error) {
+		if cluster.Name != "demo" {
+			t.Fatalf("cluster.Name = %q, want %q", cluster.Name, "demo")
+		}
+		if string(cluster.Config) != "apiVersion: v1\nclusters: []" {
+			t.Fatalf("cluster.Config = %q, want persisted config", string(cluster.Config))
+		}
+		if cluster.PrometheusURL != "http://new-prometheus.example" {
+			t.Fatalf("cluster.PrometheusURL = %q, want request override", cluster.PrometheusURL)
+		}
+		return &ClientSet{Version: "v1.31.0"}, nil
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/admin/clusters/test",
+		strings.NewReader(`{"id":`+strconv.FormatUint(uint64(cluster.ID), 10)+`,"name":"demo","prometheusURL":"http://new-prometheus.example"}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	(&ClusterManager{}).TestClusterConnection(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
 }

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -48,6 +48,11 @@ var (
 	}
 )
 
+var (
+	clusterClientRequestTimeout = clusterConnectionTestTimeout
+	clusterBuildTimeout         = 25 * time.Second
+)
+
 func createClientSetInCluster(name, prometheusURL string) (*ClientSet, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -73,6 +78,11 @@ func createClientSetFromConfig(name, content, prometheusURL string) (*ClientSet,
 }
 
 func newClientSet(name string, k8sConfig *rest.Config, prometheusURL string) (*ClientSet, error) {
+	k8sConfig = rest.CopyConfig(k8sConfig)
+	if k8sConfig.Timeout <= 0 {
+		k8sConfig.Timeout = clusterClientRequestTimeout
+	}
+
 	cs := &ClientSet{
 		Name:          name,
 		prometheusURL: prometheusURL,
@@ -291,8 +301,10 @@ func syncClusters(cm *ClusterManager) error {
 		}
 	}
 	results := make(chan buildResult, len(buildQueue))
+	pending := make(map[string]*model.Cluster, len(buildQueue))
 	var wg sync.WaitGroup
 	for _, cluster := range buildQueue {
+		pending[cluster.Name] = cluster
 		wg.Add(1)
 		go func(cluster *model.Cluster) {
 			defer wg.Done()
@@ -304,16 +316,37 @@ func syncClusters(cm *ClusterManager) error {
 			}
 		}(cluster)
 	}
-	wg.Wait()
-	close(results)
-	for result := range results {
-		if result.err != nil {
-			klog.Errorf("Failed to build k8s client for cluster %s, in cluster: %t, err: %v", result.cluster.Name, result.cluster.InCluster, result.err)
-			cm.errors[result.cluster.Name] = result.err.Error()
-			continue
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	timer := time.NewTimer(clusterBuildTimeout)
+	defer timer.Stop()
+	for len(pending) > 0 {
+		select {
+		case result, ok := <-results:
+			if !ok {
+				pending = nil
+				continue
+			}
+			delete(pending, result.cluster.Name)
+			if result.err != nil {
+				klog.Errorf("Failed to build k8s client for cluster %s, in cluster: %t, err: %v", result.cluster.Name, result.cluster.InCluster, result.err)
+				cm.errors[result.cluster.Name] = result.err.Error()
+				continue
+			}
+			delete(cm.errors, result.cluster.Name)
+			cm.clusters[result.cluster.Name] = result.clientSet
+		case <-timer.C:
+			for name, cluster := range pending {
+				message := fmt.Sprintf("Cluster client build timed out after %s.", clusterBuildTimeout)
+				err := fmt.Errorf("%s", message)
+				klog.Errorf("Failed to build k8s client for cluster %s, in cluster: %t, err: %v", cluster.Name, cluster.InCluster, err)
+				cm.errors[name] = message
+			}
+			pending = nil
 		}
-		delete(cm.errors, result.cluster.Name)
-		cm.clusters[result.cluster.Name] = result.clientSet
 	}
 	for name, clientSet := range cm.clusters {
 		if _, ok := dbClusterMap[name]; !ok {

--- a/pkg/cluster/cluster_manager_test.go
+++ b/pkg/cluster/cluster_manager_test.go
@@ -1,11 +1,15 @@
 package cluster
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/eryajf/kite-desktop/pkg/kube"
 	"github.com/eryajf/kite-desktop/pkg/model"
+	"github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -153,4 +157,128 @@ func Test_shouldUpdateCluster(t *testing.T) {
 		got := shouldUpdateCluster(cs, cluster)
 		assert.False(t, got, "expected no update when all the same")
 	})
+}
+
+func TestSyncClustersDoesNotBlockOnStalledClusterBuild(t *testing.T) {
+	restoreDB := useClusterManagerTestDB(t)
+	defer restoreDB()
+
+	if err := model.AddCluster(&model.Cluster{Name: "healthy", Enable: true}); err != nil {
+		t.Fatalf("add healthy cluster: %v", err)
+	}
+	if err := model.AddCluster(&model.Cluster{Name: "stalled", Enable: true}); err != nil {
+		t.Fatalf("add stalled cluster: %v", err)
+	}
+
+	originalBuilder := createClientSetFromConfigFunc
+	originalTimeout := clusterBuildTimeout
+	t.Cleanup(func() {
+		createClientSetFromConfigFunc = originalBuilder
+		clusterBuildTimeout = originalTimeout
+	})
+	clusterBuildTimeout = 20 * time.Millisecond
+	createClientSetFromConfigFunc = func(name, content, prometheusURL string) (*ClientSet, error) {
+		if name == "stalled" {
+			select {}
+		}
+		return &ClientSet{
+			Name:      name,
+			Version:   "v1.30.0",
+			K8sClient: &kube.K8sClient{ClientSet: &kubernetes.Clientset{}},
+		}, nil
+	}
+
+	cm := &ClusterManager{
+		clusters: make(map[string]*ClientSet),
+		errors:   make(map[string]string),
+	}
+
+	start := time.Now()
+	if err := syncClusters(cm); err != nil {
+		t.Fatalf("syncClusters error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("syncClusters blocked for %s", elapsed)
+	}
+	if _, ok := cm.clusters["healthy"]; !ok {
+		t.Fatalf("healthy cluster was not loaded: %#v", cm.clusters)
+	}
+	stalledError := cm.errors["stalled"]
+	if !strings.Contains(stalledError, "timed out") {
+		t.Fatalf("stalled cluster error = %q, want timeout message", stalledError)
+	}
+}
+
+func TestSyncClustersRetriesClusterAfterPreviousBuildError(t *testing.T) {
+	restoreDB := useClusterManagerTestDB(t)
+	defer restoreDB()
+
+	if err := model.AddCluster(&model.Cluster{Name: "recovering", Enable: true}); err != nil {
+		t.Fatalf("add recovering cluster: %v", err)
+	}
+
+	originalBuilder := createClientSetFromConfigFunc
+	t.Cleanup(func() {
+		createClientSetFromConfigFunc = originalBuilder
+	})
+	buildAttempts := 0
+	createClientSetFromConfigFunc = func(name, content, prometheusURL string) (*ClientSet, error) {
+		buildAttempts++
+		if buildAttempts == 1 {
+			return nil, assert.AnError
+		}
+		return &ClientSet{
+			Name:      name,
+			Version:   "v1.31.0",
+			K8sClient: &kube.K8sClient{ClientSet: &kubernetes.Clientset{}},
+		}, nil
+	}
+
+	cm := &ClusterManager{
+		clusters: make(map[string]*ClientSet),
+		errors:   make(map[string]string),
+	}
+
+	if err := syncClusters(cm); err != nil {
+		t.Fatalf("first syncClusters error = %v", err)
+	}
+	if _, ok := cm.errors["recovering"]; !ok {
+		t.Fatalf("expected recovering cluster to have initial error: %#v", cm.errors)
+	}
+
+	if err := syncClusters(cm); err != nil {
+		t.Fatalf("second syncClusters error = %v", err)
+	}
+	if _, ok := cm.errors["recovering"]; ok {
+		t.Fatalf("expected recovering cluster error to be cleared: %#v", cm.errors)
+	}
+	if got := cm.clusters["recovering"]; got == nil || got.Version != "v1.31.0" {
+		t.Fatalf("recovering cluster was not rebuilt: %#v", cm.clusters["recovering"])
+	}
+	if buildAttempts != 2 {
+		t.Fatalf("buildAttempts = %d, want 2", buildAttempts)
+	}
+}
+
+func useClusterManagerTestDB(t *testing.T) func() {
+	t.Helper()
+
+	originalDB := model.DB
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+
+	model.DB = db
+	if err := model.DB.AutoMigrate(&model.Cluster{}); err != nil {
+		t.Fatalf("migrate cluster model: %v", err)
+	}
+
+	return func() {
+		sqlDB, dbErr := db.DB()
+		if dbErr == nil {
+			_ = sqlDB.Close()
+		}
+		model.DB = originalDB
+	}
 }

--- a/ui/src/components/settings/cluster-dialog.test.tsx
+++ b/ui/src/components/settings/cluster-dialog.test.tsx
@@ -102,4 +102,52 @@ describe('ClusterDialog', () => {
       expect(screen.getByRole('button', { name: 'Add Cluster' })).toBeDisabled()
     )
   })
+
+  it('requires and runs connection test when editing an existing cluster', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    const onTestConnection = vi
+      .fn()
+      .mockResolvedValue({ message: 'ok', version: 'v1.31.0' })
+
+    render(
+      <ClusterDialog
+        open
+        cluster={{
+          id: 42,
+          name: 'prod',
+          description: 'Production',
+          enabled: true,
+          inCluster: false,
+          isDefault: false,
+          createdAt: '',
+          updatedAt: '',
+          prometheusURL: 'https://prometheus.example.com',
+        }}
+        onOpenChange={() => {}}
+        onSubmit={onSubmit}
+        onTestConnection={onTestConnection}
+      />
+    )
+
+    const saveButton = screen.getByRole('button', { name: 'Save Changes' })
+    const testButton = screen.getByRole('button', { name: 'Test Connection' })
+
+    expect(testButton).toBeEnabled()
+    expect(saveButton).toBeDisabled()
+
+    await user.click(testButton)
+
+    await waitFor(() =>
+      expect(onTestConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 42,
+          name: 'prod',
+          config: '',
+          prometheusURL: 'https://prometheus.example.com',
+        })
+      )
+    )
+    await waitFor(() => expect(saveButton).toBeEnabled())
+  })
 })

--- a/ui/src/components/settings/cluster-dialog.tsx
+++ b/ui/src/components/settings/cluster-dialog.tsx
@@ -42,6 +42,7 @@ interface ClusterDialogProps {
 
 function createClusterFormData(cluster?: Cluster | null) {
   return {
+    id: cluster?.id,
     name: cluster?.name || '',
     description: cluster?.description || '',
     config: cluster?.config || '',
@@ -101,11 +102,11 @@ function ClusterDialogContent({
   )
 
   const canTestConnection =
-    !!onTestConnection && (formData.inCluster || !!formData.config.trim())
+    !!onTestConnection &&
+    (formData.inCluster || !!formData.config.trim() || isEditMode)
+  const isTestingConnection = testStatus === 'testing'
   const isConnectionVerified =
-    !isEditMode &&
-    testStatus === 'success' &&
-    testedSignature === connectionSignature
+    testStatus === 'success' && testedSignature === connectionSignature
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -358,7 +359,7 @@ function ClusterDialogContent({
           </div>
         )}
 
-        {!isEditMode && onTestConnection && (
+        {onTestConnection && (
           <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-sm">
               {testStatus === 'success' && (
@@ -370,8 +371,12 @@ function ClusterDialogContent({
               {testStatus === 'idle' && (
                 <p className="text-muted-foreground">
                   {t(
-                    'clusterManagement.messages.testRequired',
-                    'Test the cluster connection before adding it.'
+                    isEditMode
+                      ? 'clusterManagement.messages.editTestRequired'
+                      : 'clusterManagement.messages.testRequired',
+                    isEditMode
+                      ? 'Test the cluster connection before saving changes.'
+                      : 'Test the cluster connection before adding it.'
                   )}
                 </p>
               )}
@@ -388,9 +393,9 @@ function ClusterDialogContent({
               type="button"
               variant="outline"
               onClick={handleTestConnection}
-              disabled={!canTestConnection || testStatus === 'testing'}
+              disabled={!canTestConnection || isTestingConnection}
             >
-              {testStatus === 'testing'
+              {isTestingConnection
                 ? t('clusterManagement.actions.testingConnection', 'Testing...')
                 : t(
                     'clusterManagement.actions.testConnection',
@@ -413,8 +418,8 @@ function ClusterDialogContent({
             disabled={
               !formData.name.trim() ||
               (!isEditMode && !formData.inCluster && !formData.config.trim()) ||
-              (!isEditMode && !isConnectionVerified) ||
-              testStatus === 'testing'
+              !isConnectionVerified ||
+              isTestingConnection
             }
           >
             {isEditMode

--- a/ui/src/components/settings/cluster-management.test.tsx
+++ b/ui/src/components/settings/cluster-management.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  invalidateClusterQueries,
+  testClusterConnection,
+  toastSuccess,
+  useClusterList,
+  useMutation,
+} = vi.hoisted(() => ({
+  invalidateClusterQueries: vi.fn(),
+  testClusterConnection: vi.fn(),
+  toastSuccess: vi.fn(),
+  useClusterList: vi.fn(),
+  useMutation: vi.fn(),
+}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (
+        key: string,
+        fallbackOrOptions?: string | { defaultValue?: string }
+      ) => {
+        if (typeof fallbackOrOptions === 'string') {
+          return fallbackOrOptions
+        }
+        return fallbackOrOptions?.defaultValue ?? key
+      },
+    }),
+  }
+})
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation,
+  useQueryClient: () => ({}),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: toastSuccess,
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  createCluster: vi.fn(),
+  deleteCluster: vi.fn(),
+  testClusterConnection,
+  updateCluster: vi.fn(),
+  useClusterList,
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  trackDesktopEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/cluster-query', () => ({
+  invalidateClusterQueries,
+}))
+
+vi.mock('./cluster-dialog', () => ({
+  ClusterDialog: () => null,
+}))
+
+vi.mock('@/components/delete-confirmation-dialog', () => ({
+  DeleteConfirmationDialog: () => null,
+}))
+
+vi.mock('../action-table', () => ({
+  ActionTable: ({
+    columns,
+    data,
+  }: {
+    columns: Array<{
+      id?: string
+      header?: React.ReactNode
+      cell?: (context: { row: { original: unknown } }) => React.ReactNode
+    }>
+    data: unknown[]
+  }) => (
+    <table>
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th key={column.id}>{column.header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((item, rowIndex) => (
+          <tr key={rowIndex}>
+            {columns.map((column) => (
+              <td key={column.id}>
+                {column.cell?.({ row: { original: item } })}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}))
+
+import { ClusterManagement } from './cluster-management'
+
+describe('ClusterManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useClusterList.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: 'healthy',
+          version: 'v1.31.0',
+          enabled: true,
+          inCluster: false,
+          isDefault: false,
+        },
+        {
+          id: 2,
+          name: 'broken',
+          error: 'Cluster client build timed out.',
+          enabled: true,
+          inCluster: false,
+          isDefault: false,
+        },
+      ],
+      error: null,
+      isLoading: false,
+    })
+    useMutation.mockReturnValue({ mutate: vi.fn(), isPending: false })
+    testClusterConnection.mockResolvedValue({ message: 'ok', version: 'v1.31.0' })
+  })
+
+  it('renders a connection status column with row test buttons', () => {
+    render(<ClusterManagement />)
+
+    expect(screen.getByRole('columnheader', { name: 'Connection' })).toBeInTheDocument()
+    expect(screen.getByText('Reachable')).toBeInTheDocument()
+    expect(screen.getByText('Unreachable')).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('button', { name: 'Test Connection' })
+    ).toHaveLength(2)
+  })
+
+  it('tests the selected cluster and refreshes cluster queries', async () => {
+    const user = userEvent.setup()
+
+    render(<ClusterManagement />)
+
+    await user.click(screen.getAllByRole('button', { name: 'Test Connection' })[1])
+
+    await waitFor(() =>
+      expect(testClusterConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 2,
+          name: 'broken',
+        })
+      )
+    )
+    await waitFor(() => expect(invalidateClusterQueries).toHaveBeenCalledTimes(1))
+    expect(toastSuccess).toHaveBeenCalledWith('Cluster connection is reachable.')
+  })
+})

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useMemo, useState } from 'react'
-import { IconEdit, IconPlus, IconServer, IconTrash } from '@tabler/icons-react'
+import {
+  IconEdit,
+  IconPlugConnected,
+  IconPlus,
+  IconRefresh,
+  IconServer,
+  IconTrash,
+} from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
@@ -18,6 +25,7 @@ import {
 } from '@/lib/api'
 import { trackDesktopEvent } from '@/lib/analytics'
 import { invalidateClusterQueries } from '@/lib/cluster-query'
+import { translateClusterConnectionError } from '@/lib/cluster-connection-errors'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -42,6 +50,20 @@ function getClusterAnalyticsPayload(
   }
 }
 
+function getClusterConnectionTestPayload(
+  cluster: Cluster
+): ClusterCreateRequest {
+  return {
+    id: cluster.id,
+    name: cluster.name,
+    description: cluster.description,
+    config: '',
+    prometheusURL: cluster.prometheusURL,
+    inCluster: cluster.inCluster,
+    isDefault: cluster.isDefault,
+  }
+}
+
 export function ClusterManagement() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -51,6 +73,7 @@ export function ClusterManagement() {
   const [showClusterDialog, setShowClusterDialog] = useState(false)
   const [editingCluster, setEditingCluster] = useState<Cluster | null>(null)
   const [deletingCluster, setDeletingCluster] = useState<Cluster | null>(null)
+  const [testingClusterId, setTestingClusterId] = useState<number | null>(null)
 
   const getClusterTypeBadge = useCallback(
     (cluster: Cluster) => {
@@ -92,6 +115,77 @@ export function ClusterManagement() {
       )
     },
     [t]
+  )
+
+  const getConnectionStatusBadge = useCallback(
+    (cluster: Cluster) => {
+      if (cluster.error) {
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge variant="destructive">
+                {t('clusterManagement.connection.unreachable', 'Unreachable')}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-xs break-all">{cluster.error}</p>
+            </TooltipContent>
+          </Tooltip>
+        )
+      }
+
+      if (cluster.version) {
+        return (
+          <Badge
+            variant="outline"
+            className="border-emerald-200 bg-emerald-50 text-emerald-700"
+          >
+            {t('clusterManagement.connection.reachable', 'Reachable')}
+          </Badge>
+        )
+      }
+
+      return (
+        <Badge variant="secondary">
+          {t('clusterManagement.connection.unknown', 'Not checked')}
+        </Badge>
+      )
+    },
+    [t]
+  )
+
+  const handleTestClusterRowConnection = useCallback(
+    async (cluster: Cluster) => {
+      setTestingClusterId(cluster.id)
+      const payload = getClusterConnectionTestPayload(cluster)
+
+      try {
+        await testClusterConnection(payload)
+        trackDesktopEvent('cluster_management_test_connection', {
+          result: 'success',
+          source: 'list',
+          ...getClusterAnalyticsPayload(payload),
+        })
+        await invalidateClusterQueries(queryClient)
+        toast.success(
+          t(
+            'clusterManagement.messages.connectionReachable',
+            'Cluster connection is reachable.'
+          )
+        )
+      } catch (error) {
+        trackDesktopEvent('cluster_management_test_connection', {
+          result: 'error',
+          source: 'list',
+          ...getClusterAnalyticsPayload(payload),
+        })
+        await invalidateClusterQueries(queryClient)
+        toast.error(translateClusterConnectionError(error, t))
+      } finally {
+        setTestingClusterId(null)
+      }
+    },
+    [queryClient, t]
   )
 
   const columns = useMemo<ColumnDef<Cluster>[]>(
@@ -153,6 +247,43 @@ export function ClusterManagement() {
         ),
       },
       {
+        id: 'connection',
+        header: t('clusterManagement.table.connection', 'Connection'),
+        cell: ({ row: { original: cluster } }) => {
+          const isTesting = testingClusterId === cluster.id
+          const testConnectionLabel = isTesting
+            ? t('clusterManagement.actions.testingConnection', 'Testing...')
+            : t('clusterManagement.actions.testConnection', 'Test Connection')
+
+          return (
+            <div className="flex items-center gap-2">
+              {getConnectionStatusBadge(cluster)}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={testConnectionLabel}
+                    title={testConnectionLabel}
+                    onClick={() => void handleTestClusterRowConnection(cluster)}
+                    disabled={isTesting}
+                  >
+                    {isTesting ? (
+                      <IconRefresh className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <IconPlugConnected className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{testConnectionLabel}</TooltipContent>
+              </Tooltip>
+            </div>
+          )
+        },
+      },
+      {
         id: 'Prometheus',
         header: t('clusterManagement.table.prometheus', 'Prometheus'),
         cell: ({ row: { original: cluster } }) => (
@@ -164,7 +295,14 @@ export function ClusterManagement() {
         ),
       },
     ],
-    [getClusterTypeBadge, getStatusBadge, t]
+    [
+      getClusterTypeBadge,
+      getConnectionStatusBadge,
+      getStatusBadge,
+      handleTestClusterRowConnection,
+      t,
+      testingClusterId,
+    ]
   )
 
   const actions = useMemo<Action<Cluster>[]>(

--- a/ui/src/contexts/cluster-context.test.tsx
+++ b/ui/src/contexts/cluster-context.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act } from 'react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { trackEvent } = vi.hoisted(() => ({
   trackEvent: vi.fn(),
@@ -18,7 +19,8 @@ function ClusterStateProbe() {
     <ClusterContext.Consumer>
       {(value) => (
         <div data-testid="cluster-state">
-          {value?.currentCluster ?? 'none'}|{String(value?.isLoading)}
+          {value?.currentCluster ?? 'none'}|{String(value?.isLoading)}|
+          {String(value?.isSwitching)}
         </div>
       )}
     </ClusterContext.Consumer>
@@ -35,6 +37,22 @@ function ClusterSwitchProbe() {
         >
           switch
         </button>
+      )}
+    </ClusterContext.Consumer>
+  )
+}
+
+function ClusterListProbe() {
+  return (
+    <ClusterContext.Consumer>
+      {(value) => (
+        <div data-testid="cluster-list">
+          {value?.clusters
+            .map((cluster) =>
+              [cluster.name, cluster.error || cluster.version || 'ready'].join(':')
+            )
+            .join('|') ?? ''}
+        </div>
       )}
     </ClusterContext.Consumer>
   )
@@ -62,6 +80,13 @@ function renderClusterProvider() {
 describe('ClusterProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+    vi.useRealTimers()
   })
 
   it('clears stale cluster state and does not auto-select when clusters are empty', async () => {
@@ -179,6 +204,157 @@ describe('ClusterProvider', () => {
     expect(trackEvent).not.toHaveBeenCalledWith(
       'cluster_switch',
       expect.objectContaining({ clusterName: 'cluster-b' })
+    )
+  })
+
+  it('clears switching state when query invalidation fails', async () => {
+    const user = userEvent.setup()
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/v1/preferences/workspace')) {
+        if (init?.method === 'PUT') {
+          return {
+            ok: true,
+            status: 204,
+            headers: new Headers(),
+            json: async () => ({}),
+            text: async () => '',
+          }
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            currentCluster: 'cluster-a',
+            recentClusters: ['cluster-a'],
+            selectedNamespaceByCluster: {},
+          }),
+          text: async () =>
+            JSON.stringify({
+              currentCluster: 'cluster-a',
+              recentClusters: ['cluster-a'],
+              selectedNamespaceByCluster: {},
+            }),
+        }
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [
+          { name: 'cluster-a', isDefault: true },
+          { name: 'cluster-b', isDefault: false },
+        ],
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    queryClient.setQueryData(['resource'], 'stale')
+    vi.spyOn(queryClient, 'invalidateQueries').mockRejectedValueOnce(
+      new Error('resource refresh failed')
+    )
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ClusterProvider>
+          <ClusterStateProbe />
+          <ClusterSwitchProbe />
+        </ClusterProvider>
+      </QueryClientProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cluster-state')).toHaveTextContent(
+        '|false|false'
+      )
+    )
+
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('cluster-state')).toHaveTextContent(
+        'cluster-b|false|false'
+      )
+    )
+  })
+
+  it('refreshes cluster list so a recovered cluster becomes usable', async () => {
+    vi.useFakeTimers()
+
+    let clusterListRequests = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/v1/preferences/workspace')) {
+        return {
+          ok: true,
+          status: init?.method === 'PUT' ? 204 : 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            currentCluster: '',
+            recentClusters: [],
+            selectedNamespaceByCluster: {},
+          }),
+          text: async () => '',
+        }
+      }
+
+      clusterListRequests += 1
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () =>
+          clusterListRequests === 1
+            ? [{ name: 'recovering', error: 'Cluster client build timed out.' }]
+            : [{ name: 'recovering', version: 'v1.31.0' }],
+        text: async () => '',
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ClusterProvider>
+          <ClusterListProbe />
+        </ClusterProvider>
+      </QueryClientProvider>
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(screen.getByTestId('cluster-list')).toHaveTextContent(
+      'recovering:Cluster client build timed out.'
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_001)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId('cluster-list')).toHaveTextContent(
+      'recovering:v1.31.0'
     )
   })
 })

--- a/ui/src/contexts/cluster-context.tsx
+++ b/ui/src/contexts/cluster-context.tsx
@@ -15,6 +15,8 @@ import { clusterQueryKey } from '@/lib/cluster-query'
 import { withSubPath } from '@/lib/subpath'
 
 const recentClustersStorageKey = 'recent-clusters'
+const clusterListRefetchIntervalMs = 60 * 1000
+const clusterListErrorRefetchIntervalMs = 15 * 1000
 
 interface ClusterContextType {
   clusters: Cluster[]
@@ -111,6 +113,13 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
       return response.json()
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
+    refetchInterval: (query) => {
+      const clusters = query.state.data as Cluster[] | undefined
+      return clusters?.some((cluster) => cluster.error)
+        ? clusterListErrorRefetchIntervalMs
+        : clusterListRefetchIntervalMs
+    },
+    refetchIntervalInBackground: true,
   })
 
   // Set default cluster if none is selected
@@ -191,16 +200,24 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
           page: getCurrentAnalyticsPageKey(),
         })
         setTimeout(async () => {
-          await queryClient.invalidateQueries({
-            predicate: (query) => {
-              const key = query.queryKey[0] as string
-              return !['user', 'auth', 'clusters'].includes(key)
-            },
-          })
-          setIsSwitching(false)
-          toast.success(`Switched to cluster: ${clusterName}`, {
-            id: 'cluster-switch',
-          })
+          try {
+            await queryClient.invalidateQueries({
+              predicate: (query) => {
+                const key = query.queryKey[0] as string
+                return !['user', 'auth', 'clusters'].includes(key)
+              },
+            })
+            toast.success(`Switched to cluster: ${clusterName}`, {
+              id: 'cluster-switch',
+            })
+          } catch (error) {
+            console.error('Failed to refresh data after cluster switch:', error)
+            toast.error('Switched cluster, but failed to refresh data', {
+              id: 'cluster-switch',
+            })
+          } finally {
+            setIsSwitching(false)
+          }
         }, 300)
       } catch (error) {
         console.error('Failed to switch cluster:', error)

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -727,6 +727,7 @@
       "name": "Name",
       "type": "Type",
       "status": "Status",
+      "connection": "Connection",
       "prometheus": "Prometheus",
       "actions": "Actions"
     },
@@ -748,8 +749,10 @@
       "deleted": "Cluster deleted successfully",
       "testing": "Testing cluster connection...",
       "testRequired": "Test the cluster connection before adding it.",
+      "editTestRequired": "Test the cluster connection before saving changes.",
       "testSuccess": "Connection successful.",
       "testSuccessWithVersion": "Connection successful. Kubernetes version: {{version}}",
+      "connectionReachable": "Cluster connection is reachable.",
       "testErrorWithDetail": "{{message}} Details: {{detail}}",
       "testError": "Cluster connection test failed",
       "testErrors": {
@@ -768,6 +771,11 @@
     },
     "errors": {
       "loadFailed": "Failed to load clusters"
+    },
+    "connection": {
+      "reachable": "Reachable",
+      "unreachable": "Unreachable",
+      "unknown": "Not checked"
     },
     "deleteConfirmation": "This action will only remove the current cluster's configuration in kite and will not delete any cluster resources.",
     "form": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -862,6 +862,7 @@
       "name": "名称",
       "type": "类型",
       "status": "状态",
+      "connection": "连接状态",
       "prometheus": "Prometheus",
       "actions": "操作"
     },
@@ -883,8 +884,10 @@
       "deleted": "集群删除成功",
       "testing": "正在测试集群连接...",
       "testRequired": "添加前请先测试集群连接。",
+      "editTestRequired": "保存更改前请先测试集群连接。",
       "testSuccess": "连接成功。",
       "testSuccessWithVersion": "连接成功，Kubernetes 版本：{{version}}",
+      "connectionReachable": "集群连接可用。",
       "testErrorWithDetail": "{{message}} 详细信息：{{detail}}",
       "testError": "集群连接测试失败",
       "testErrors": {
@@ -903,6 +906,11 @@
     },
     "errors": {
       "loadFailed": "加载集群失败"
+    },
+    "connection": {
+      "reachable": "可连接",
+      "unreachable": "不可连接",
+      "unknown": "未检测"
     },
     "deleteConfirmation": "此操作只会移除 kite 中的集群配置，不会删除任何集群资源。",
     "dialog": {

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -15,6 +15,7 @@ import { apiClient, APIError } from '../api-client'
 import { fetchAPI } from './shared'
 
 export interface ClusterCreateRequest {
+  id?: number
   name: string
   description?: string
   config?: string


### PR DESCRIPTION
- 在 ClusterDialog 中添加编辑现有集群时的连接测试功能。
- 在 ClusterManagement 中实现集群连接状态的显示和测试按钮。
- 更新相关的 API 请求和状态管理逻辑。
- 添加中文和英文的国际化支持。

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #89 

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection testing for editing existing clusters (previously only available when adding new clusters)
  * Added "Connection" status column to the cluster management table displaying reachable/unreachable status
  * Added per-cluster "Test Connection" buttons for quick connectivity verification
  * Cluster list now refreshes more frequently when connection errors are present, enabling faster error recovery

* **Improvements**
  * Connection verification is now required before saving cluster edits, matching add behavior
  * Enhanced error handling and timeout management for cluster connectivity tests

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/95)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->