### PR TITLE
feat(iframe): 添加 IframeEscapeBridge 组件以处理 Escape 键事件

### DIFF
--- a/docs/plans/2026-05-10-related-resources-direction-plan.md
+++ b/docs/plans/2026-05-10-related-resources-direction-plan.md
@@ -1,0 +1,522 @@
+# Directed Related Resources Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every resource detail "Related" tab render reliably and show relationships in two groups: references and referenced by.
+
+**Architecture:** Keep the existing `/related` endpoint as the single source for relationship discovery, but extend the response with direction metadata instead of letting the UI infer it. The frontend renders a reusable grouped related-resources view, so Deployment, Service, Ingress, ConfigMap, Secret, PVC, Pod, HPA, and future resource detail pages share one interaction model.
+
+**Tech Stack:** Go Gin handlers, controller-runtime Kubernetes client, React 19, TanStack Query, Vitest, Go tests.
+
+---
+
+## Current Findings
+
+The current related resources path is:
+
+- Detail pages call `RelatedResourcesTable`.
+- `RelatedResourcesTable` calls `useRelatedResources`.
+- `useRelatedResources` fetches `GET /api/resources/:resource/:namespace/:name/related`.
+- Backend route registration lives in `pkg/handlers/resources/handler.go`.
+- Backend discovery lives in `pkg/handlers/resources/related_resources.go`.
+
+The current white-screen risk is in `ui/src/components/related-resource-table.tsx`: if a related item has a type that the frontend does not recognize as a standard resource and the backend did not provide `apiVersion`, `getCRDResourcePath(rs.type, rs.apiVersion!, ...)` can crash because `apiVersion` is `undefined`.
+
+The current product gap is that the backend returns a flat list:
+
+```json
+[
+  {
+    "type": "services",
+    "name": "demo",
+    "namespace": "default"
+  }
+]
+```
+
+This shape cannot distinguish:
+
+- resources this object references, such as a Deployment using ConfigMaps, Secrets, PVCs
+- resources that reference this object, such as Services, Ingresses, HPAs, ReplicaSets, Pods
+
+## Relationship Semantics
+
+Use two top-level UI groups everywhere:
+
+- `references`: the current resource directly points to or consumes these resources.
+- `referencedBy`: these resources point to, select, own, route to, scale, or consume the current resource.
+
+For Deployment:
+
+- `references`
+  - ConfigMaps used by env, envFrom, and volumes
+  - Secrets used by env, envFrom, imagePullSecrets, and volumes
+  - PVCs used by volumes
+  - ServiceAccount used by pod template
+- `referencedBy`
+  - ReplicaSets owned by the Deployment
+  - Pods owned by those ReplicaSets
+  - Services whose selectors match the Deployment pod selector
+  - Endpoints or EndpointSlices backing those Services
+  - Ingresses whose backend services point to those Services
+  - HTTPRoutes whose backend refs point to those Services
+  - HPAs whose scale target points to the Deployment
+
+For Service:
+
+- `references`
+  - Pods selected by the Service
+  - Endpoints and EndpointSlices for the Service
+- `referencedBy`
+  - Ingresses and HTTPRoutes using the Service as a backend
+
+For ConfigMap, Secret, and PVC:
+
+- `referencedBy`
+  - Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, and Pods that consume them
+
+For Ingress and HTTPRoute:
+
+- `references`
+  - Services and backend resources defined by rules/default backends
+
+For HPA:
+
+- `references`
+  - scale target workload
+
+## Files
+
+- Modify: `pkg/common/types.go`
+  - Add direction/reason fields while keeping old fields backward-compatible.
+- Modify: `pkg/handlers/resources/related_resources.go`
+  - Return directed relationships and add Deployment inbound discovery for Services, Endpoints, Ingresses, HTTPRoutes, HPAs, ReplicaSets, and Pods.
+- Modify: `pkg/handlers/resources/related_resources_test.go`
+  - Cover direction grouping and Deployment relationship expectations.
+- Modify: `pkg/handlers/resources/handler.go`
+  - Add related route support for resource types that are currently registered but not exposed, such as `endpoints`, `endpointslices`, `replicasets`, `jobs`, and `cronjobs` if their detail pages should show related data.
+- Modify: `ui/src/types/api.ts`
+  - Add `RelatedResourceDirection`, optional `direction`, `reason`, and `group`.
+  - Add `endpoints` and `endpointslices` to `ResourceType`.
+- Modify: `ui/src/lib/k8s.ts`
+  - Treat `endpoints`, `endpointslices`, `serviceaccounts`, `replicasets`, `horizontalpodautoscalers`, `gateways`, and `httproutes` as standard resources when applicable.
+- Modify: `ui/src/components/related-resource-table.tsx`
+  - Render two sections: references and referenced by.
+  - Guard route creation when `apiVersion` is absent.
+  - Show a disabled text row rather than crashing if a resource is not navigable.
+- Create: `ui/src/components/related-resource-table.test.tsx`
+  - Assert that unknown or incomplete related resources do not white-screen.
+  - Assert that two groups render separately.
+
+## Task 1: Frontend White-Screen Guard
+
+**Files:**
+- Modify: `ui/src/components/related-resource-table.tsx`
+- Modify: `ui/src/types/api.ts`
+- Modify: `ui/src/lib/k8s.ts`
+- Create: `ui/src/components/related-resource-table.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `ui/src/components/related-resource-table.test.tsx` with cases for:
+
+```tsx
+vi.mock('@/lib/api', () => ({
+  useRelatedResources: () => ({
+    data: [
+      { type: 'endpoints', name: 'demo', namespace: 'default' },
+      { type: 'unknownwidgets', name: 'demo-widget', namespace: 'default' },
+    ],
+    isLoading: false,
+  }),
+}))
+```
+
+Expected assertions:
+
+- `endpoints` renders as a clickable standard resource.
+- `unknownwidgets` renders without throwing.
+- no call path requires `apiVersion` when it is absent.
+
+- [ ] **Step 2: Run failing test**
+
+Run:
+
+```bash
+pnpm --dir ui exec vitest run src/components/related-resource-table.test.tsx
+```
+
+Expected: fail before the implementation because incomplete CRD-like related resources can crash route generation.
+
+- [ ] **Step 3: Implement the guard**
+
+In `RelatedResourceCell`, compute a nullable route:
+
+```tsx
+const path = useMemo(() => {
+  if (isStandardK8sResource(rs.type)) {
+    return `/${rs.type}/${rs.namespace ? `${rs.namespace}/` : ''}${rs.name}`
+  }
+  if (rs.apiVersion) {
+    return getCRDResourcePath(rs.type, rs.apiVersion, rs.namespace, rs.name)
+  }
+  return undefined
+}, [rs])
+```
+
+If `path` is missing, render the resource name as plain text with muted metadata and no dialog trigger.
+
+- [ ] **Step 4: Extend standard frontend resource knowledge**
+
+Add at least these to `ResourceType` and `isStandardK8sResource`:
+
+```ts
+| 'endpoints'
+| 'endpointslices'
+```
+
+Also include existing registered resources that are missing from `isStandardK8sResource`, including `serviceaccounts`, `replicasets`, `horizontalpodautoscalers`, `gateways`, and `httproutes`.
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+pnpm --dir ui exec vitest run src/components/related-resource-table.test.tsx
+pnpm --dir ui exec eslint src/components/related-resource-table.tsx src/components/related-resource-table.test.tsx src/types/api.ts src/lib/k8s.ts
+```
+
+Expected: pass.
+
+## Task 2: Directed API Contract
+
+**Files:**
+- Modify: `pkg/common/types.go`
+- Modify: `ui/src/types/api.ts`
+- Modify: `ui/src/components/related-resource-table.tsx`
+- Modify: `pkg/handlers/resources/related_resources_test.go`
+
+- [ ] **Step 1: Extend backend type**
+
+Change `common.RelatedResource` to:
+
+```go
+type RelatedResource struct {
+	Type       string `json:"type"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+	Direction  string `json:"direction,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+```
+
+Use direction values:
+
+```go
+const (
+	RelatedDirectionReferences   = "references"
+	RelatedDirectionReferencedBy = "referencedBy"
+)
+```
+
+- [ ] **Step 2: Extend frontend type**
+
+Change `RelatedResources` in `ui/src/types/api.ts`:
+
+```ts
+export type RelatedResourceDirection = 'references' | 'referencedBy'
+
+export interface RelatedResources {
+  type: ResourceType
+  name: string
+  namespace?: string
+  apiVersion?: string
+  direction?: RelatedResourceDirection
+  reason?: string
+}
+```
+
+- [ ] **Step 3: Keep backward compatibility**
+
+In the UI, group items with missing direction into `references` for now, so existing backend responses continue to render:
+
+```ts
+const references = relatedResources.filter(
+  (item) => item.direction !== 'referencedBy'
+)
+const referencedBy = relatedResources.filter(
+  (item) => item.direction === 'referencedBy'
+)
+```
+
+- [ ] **Step 4: Verify compatibility**
+
+Run:
+
+```bash
+go test ./pkg/handlers/resources -run Test
+pnpm --dir ui exec vitest run src/components/related-resource-table.test.tsx
+```
+
+Expected: pass.
+
+## Task 3: Deployment Relationship Discovery
+
+**Files:**
+- Modify: `pkg/handlers/resources/related_resources.go`
+- Modify: `pkg/handlers/resources/related_resources_test.go`
+
+- [ ] **Step 1: Mark existing Deployment references**
+
+When `podSpec` comes from Deployment, StatefulSet, DaemonSet, Job, CronJob, or Pod, resources from `discoverConfigs` should use:
+
+```go
+Direction: common.RelatedDirectionReferences,
+Reason: "pod template reference",
+```
+
+- [ ] **Step 2: Mark Services as referencedBy**
+
+`discoverServices` currently finds Services whose selector matches the workload selector. For workloads, set:
+
+```go
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "service selector matches workload pods",
+```
+
+- [ ] **Step 3: Add Deployment-owned ReplicaSets**
+
+List ReplicaSets in the namespace with the Deployment selector and filter by owner reference UID/name. Add:
+
+```go
+common.RelatedResource{
+  Type: "replicasets",
+  Namespace: deployment.Namespace,
+  Name: replicaSet.Name,
+  Direction: common.RelatedDirectionReferencedBy,
+  Reason: "owned by deployment",
+}
+```
+
+- [ ] **Step 4: Add Deployment-owned Pods**
+
+List Pods using the Deployment selector. Include Pods owned by Deployment-owned ReplicaSets. Add:
+
+```go
+Type: "pods",
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "pod owned by deployment replica set",
+```
+
+- [ ] **Step 5: Add Endpoint and EndpointSlice relationships via Services**
+
+For each related Service:
+
+```go
+Type: "endpoints",
+Name: service.Name,
+Namespace: service.Namespace,
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "service endpoint for matching selector",
+```
+
+For EndpointSlices, list by label `kubernetes.io/service-name=<service name>`:
+
+```go
+Type: "endpointslices",
+Name: endpointSlice.Name,
+Namespace: endpointSlice.Namespace,
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "endpoint slice for matching service",
+```
+
+- [ ] **Step 6: Add Ingress and HTTPRoute relationships via Services**
+
+For each Service related to the Deployment, discover:
+
+- Ingresses in the same namespace whose default backend or rule backend service name matches.
+- HTTPRoutes whose backend ref points to the Service.
+
+Mark both as:
+
+```go
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "routes traffic to matching service",
+```
+
+- [ ] **Step 7: Add HPA relationships**
+
+List HPAs in the namespace and match:
+
+```go
+hpa.Spec.ScaleTargetRef.Kind == "Deployment"
+hpa.Spec.ScaleTargetRef.Name == deployment.Name
+```
+
+Mark as:
+
+```go
+Direction: common.RelatedDirectionReferencedBy,
+Reason: "scales deployment",
+```
+
+- [ ] **Step 8: Verify**
+
+Add Go tests that construct representative Deployment, Service, Ingress, HPA, ConfigMap, Secret, PVC data and assert directions. Run:
+
+```bash
+go test ./pkg/handlers/resources -run 'TestDiscover|TestGet.*Related'
+```
+
+Expected: pass.
+
+## Task 4: Grouped Related UI
+
+**Files:**
+- Modify: `ui/src/components/related-resource-table.tsx`
+- Modify: `ui/src/i18n/locales/en.json`
+- Modify: `ui/src/i18n/locales/zh.json`
+- Modify: `ui/src/components/related-resource-table.test.tsx`
+
+- [ ] **Step 1: Add i18n labels**
+
+Add:
+
+```json
+{
+  "relatedResources": {
+    "references": "References",
+    "referencedBy": "Referenced by",
+    "reason": "Reason"
+  }
+}
+```
+
+Chinese:
+
+```json
+{
+  "relatedResources": {
+    "references": "引用",
+    "referencedBy": "被引用",
+    "reason": "关系"
+  }
+}
+```
+
+- [ ] **Step 2: Render two sections**
+
+In `RelatedResourcesTable`, render a shared table section component twice:
+
+```tsx
+<RelatedResourcesSection
+  title={t('relatedResources.references')}
+  data={references}
+  emptyMessage={t('relatedResources.empty')}
+/>
+<RelatedResourcesSection
+  title={t('relatedResources.referencedBy')}
+  data={referencedBy}
+  emptyMessage={t('relatedResources.empty')}
+/>
+```
+
+- [ ] **Step 3: Add reason column**
+
+Add a third optional column:
+
+```tsx
+{
+  header: t('relatedResources.reason'),
+  accessor: (rs) => rs.reason || '-',
+  cell: (value) => <span className="text-muted-foreground">{value as string}</span>,
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+pnpm --dir ui exec vitest run src/components/related-resource-table.test.tsx
+pnpm --dir ui exec eslint src/components/related-resource-table.tsx src/components/related-resource-table.test.tsx src/i18n/locales/en.json src/i18n/locales/zh.json
+```
+
+Expected: pass.
+
+## Task 5: Route Coverage and Regression Tests
+
+**Files:**
+- Modify: `pkg/handlers/resources/handler.go`
+- Modify: `pkg/handlers/resources/related_resources_test.go`
+- Modify: `ui/src/types/api.ts`
+- Modify: `ui/src/lib/k8s.ts`
+
+- [ ] **Step 1: Add route coverage for related-capable resources**
+
+Expand `supportedRelatedResourceTypes` if relationship discovery supports them:
+
+```go
+supportedRelatedResourceTypes := []string{
+  "pods",
+  "deployments",
+  "replicasets",
+  "statefulsets",
+  "daemonsets",
+  "jobs",
+  "cronjobs",
+  "services",
+  "endpoints",
+  "endpointslices",
+  "configmaps",
+  "secrets",
+  "persistentvolumeclaims",
+  "httproutes",
+  "horizontalpodautoscalers",
+  "ingresses",
+}
+```
+
+- [ ] **Step 2: Add tests for route-safe frontend types**
+
+Assert that all backend route types used in related responses are included in frontend `ResourceType` and `isStandardK8sResource`.
+
+- [ ] **Step 3: Run full focused verification**
+
+Run:
+
+```bash
+go test ./pkg/handlers/resources
+pnpm --dir ui exec vitest run src/components/related-resource-table.test.tsx
+pnpm --dir ui exec eslint src/components/related-resource-table.tsx src/components/related-resource-table.test.tsx src/types/api.ts src/lib/k8s.ts
+```
+
+Expected: pass.
+
+## Rollout Notes
+
+This should be implemented in two deployable slices:
+
+1. White-screen guard and frontend route/type coverage.
+2. Directed backend contract and grouped UI.
+
+The first slice is low-risk and should land first because it stabilizes the existing blank page. The second slice adds the product behavior and can be expanded resource by resource.
+
+## Self-Review
+
+Spec coverage:
+
+- Deployment detail related tab white-screen risk is covered by Task 1.
+- Universal "引用 / 被引用" grouping is covered by Tasks 2 and 4.
+- Deployment relationships to Service, endpoints, ingress, and other resources are covered by Task 3.
+- Future reuse across all related tabs is covered by the shared `RelatedResourcesTable` contract.
+
+Placeholder scan:
+
+- No task uses placeholder text for implementation behavior.
+
+Type consistency:
+
+- Backend uses `direction` values `references` and `referencedBy`.
+- Frontend uses the same string union.

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -18,7 +18,14 @@ type RelatedResource struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace,omitempty"`
+	Direction  string `json:"direction,omitempty"`
+	Reason     string `json:"reason,omitempty"`
 }
+
+const (
+	RelatedDirectionReferences   = "references"
+	RelatedDirectionReferencedBy = "referencedBy"
+)
 
 type Resource struct {
 	Allocatable int64 `json:"allocatable"`

--- a/pkg/handlers/resources/event_handler.go
+++ b/pkg/handlers/resources/event_handler.go
@@ -1,7 +1,10 @@
 package resources
 
 import (
+	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 
 	"github.com/eryajf/kite-desktop/pkg/cluster"
 	"github.com/gin-gonic/gin"
@@ -36,14 +39,14 @@ func (h *EventHandler) ListResourceEvents(c *gin.Context) {
 		return
 	}
 
-	objType, err := meta.TypeAccessor(target)
+	kind, err := eventResourceKind(resource, target)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to access object type info: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve object kind: " + err.Error()})
 		return
 	}
 	obj := target.(metav1.Object)
 	events, err := cs.K8sClient.ClientSet.CoreV1().Events(obj.GetNamespace()).List(c.Request.Context(), metav1.ListOptions{
-		FieldSelector: "involvedObject.kind=" + objType.GetKind() +
+		FieldSelector: "involvedObject.kind=" + kind +
 			",involvedObject.name=" + name,
 	})
 
@@ -53,6 +56,30 @@ func (h *EventHandler) ListResourceEvents(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, events)
+}
+
+func eventResourceKind(resource string, target interface{}) (string, error) {
+	objType, err := meta.TypeAccessor(target)
+	if err != nil {
+		return "", err
+	}
+	if kind := objType.GetKind(); kind != "" {
+		return kind, nil
+	}
+
+	typ := reflect.TypeOf(target)
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Name() != "" {
+		return typ.Name(), nil
+	}
+
+	kind := strings.TrimSuffix(resource, "s")
+	if kind == "" {
+		return "", fmt.Errorf("empty resource type")
+	}
+	return strings.ToUpper(kind[:1]) + kind[1:], nil
 }
 
 func (h *EventHandler) registerCustomRoutes(group *gin.RouterGroup) {

--- a/pkg/handlers/resources/event_handler_test.go
+++ b/pkg/handlers/resources/event_handler_test.go
@@ -1,0 +1,63 @@
+package resources
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEventResourceKindFallsBackWhenTypeMetaIsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		target   interface{}
+		want     string
+	}{
+		{
+			name:     "deployment",
+			resource: "deployments",
+			target: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			},
+			want: "Deployment",
+		},
+		{
+			name:     "statefulset",
+			resource: "statefulsets",
+			target: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "default"},
+			},
+			want: "StatefulSet",
+		},
+		{
+			name:     "daemonset",
+			resource: "daemonsets",
+			target: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+			},
+			want: "DaemonSet",
+		},
+		{
+			name:     "cronjob",
+			resource: "cronjobs",
+			target: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "cleanup", Namespace: "default"},
+			},
+			want: "CronJob",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eventResourceKind(tt.resource, tt.target)
+			if err != nil {
+				t.Fatalf("eventResourceKind returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %s kind, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/handlers/resources/handler.go
+++ b/pkg/handlers/resources/handler.go
@@ -99,7 +99,7 @@ func RegisterRoutes(group *gin.RouterGroup) {
 	}
 
 	// Register related resources route for supported resource types
-	supportedRelatedResourceTypes := []string{"pods", "deployments", "statefulsets", "daemonsets", "configmaps", "secrets", "persistentvolumeclaims", "httproutes", "horizontalpodautoscalers", "services", "ingresses"}
+	supportedRelatedResourceTypes := []string{"pods", "deployments", "replicasets", "statefulsets", "daemonsets", "jobs", "cronjobs", "services", "endpoints", "endpointslices", "configmaps", "secrets", "persistentvolumeclaims", "httproutes", "horizontalpodautoscalers", "ingresses"}
 	for _, resourceType := range supportedRelatedResourceTypes {
 		if handler, exists := handlers[resourceType]; exists && !handler.IsClusterScoped() {
 			g := group.Group("/" + resourceType)

--- a/pkg/handlers/resources/related_resources.go
+++ b/pkg/handlers/resources/related_resources.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -22,8 +23,28 @@ import (
 )
 
 func discoverServices(ctx context.Context, k8sClient *kube.K8sClient, namespace string, selector *metav1.LabelSelector) ([]common.RelatedResource, error) {
+	services, err := discoverMatchingServices(ctx, k8sClient, namespace, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	relatedServices := make([]common.RelatedResource, 0, len(services))
+	for _, service := range services {
+		relatedServices = append(relatedServices, common.RelatedResource{
+			Type:      "services",
+			Namespace: service.Namespace,
+			Name:      service.Name,
+			Direction: common.RelatedDirectionReferencedBy,
+			Reason:    "service selector matches workload pods",
+		})
+	}
+
+	return relatedServices, nil
+}
+
+func discoverMatchingServices(ctx context.Context, k8sClient *kube.K8sClient, namespace string, selector *metav1.LabelSelector) ([]corev1.Service, error) {
 	if selector == nil || selector.MatchLabels == nil {
-		return []common.RelatedResource{}, nil
+		return []corev1.Service{}, nil
 	}
 
 	var serviceList corev1.ServiceList
@@ -31,16 +52,12 @@ func discoverServices(ctx context.Context, k8sClient *kube.K8sClient, namespace 
 		return nil, fmt.Errorf("failed to list services: %w", err)
 	}
 
-	var relatedServices []common.RelatedResource
+	var relatedServices []corev1.Service
 	for _, service := range serviceList.Items {
 		if service.Spec.Selector != nil {
 			serviceSelector := labels.SelectorFromSet(service.Spec.Selector)
 			if serviceSelector.Matches(labels.Set(selector.MatchLabels)) {
-				relatedServices = append(relatedServices, common.RelatedResource{
-					Type:      "services",
-					Namespace: service.Namespace,
-					Name:      service.Name,
-				})
+				relatedServices = append(relatedServices, service)
 			}
 		}
 	}
@@ -57,9 +74,12 @@ func discoverIngressServices(namespace string, ingress *v1.Ingress) []common.Rel
 		}
 		seen[svcName] = struct{}{}
 		relatedServices = append(relatedServices, common.RelatedResource{
-			Type:      "services",
-			Namespace: namespace,
-			Name:      svcName,
+			Type:       "services",
+			Namespace:  namespace,
+			Name:       svcName,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Direction:  common.RelatedDirectionReferences,
+			Reason:     "ingress backend service",
 		})
 	}
 
@@ -93,7 +113,9 @@ func discoverConfigs(namespace string, podSpec *corev1.PodTemplateSpec) []common
 	secretSet := make(map[string]struct{})
 	pvcSet := make(map[string]struct{})
 
-	for _, container := range podSpec.Spec.Containers {
+	containers := podSpec.Spec.Containers
+	containers = append(containers, podSpec.Spec.InitContainers...)
+	for _, container := range containers {
 		for _, envVar := range container.Env {
 			if envVar.ValueFrom != nil && envVar.ValueFrom.ConfigMapKeyRef != nil {
 				configMapSet[envVar.ValueFrom.ConfigMapKeyRef.Name] = struct{}{}
@@ -123,13 +145,29 @@ func discoverConfigs(namespace string, podSpec *corev1.PodTemplateSpec) []common
 			pvcSet[volume.PersistentVolumeClaim.ClaimName] = struct{}{}
 		}
 	}
+	for _, imagePullSecret := range podSpec.Spec.ImagePullSecrets {
+		if imagePullSecret.Name != "" {
+			secretSet[imagePullSecret.Name] = struct{}{}
+		}
+	}
 
 	var related []common.RelatedResource
+	if podSpec.Spec.ServiceAccountName != "" {
+		related = append(related, common.RelatedResource{
+			Type:      "serviceaccounts",
+			Name:      podSpec.Spec.ServiceAccountName,
+			Namespace: namespace,
+			Direction: common.RelatedDirectionReferences,
+			Reason:    "pod template service account",
+		})
+	}
 	for name := range configMapSet {
 		related = append(related, common.RelatedResource{
 			Type:      "configmaps",
 			Name:      name,
 			Namespace: namespace,
+			Direction: common.RelatedDirectionReferences,
+			Reason:    "pod template reference",
 		})
 	}
 	for name := range secretSet {
@@ -137,6 +175,8 @@ func discoverConfigs(namespace string, podSpec *corev1.PodTemplateSpec) []common
 			Type:      "secrets",
 			Name:      name,
 			Namespace: namespace,
+			Direction: common.RelatedDirectionReferences,
+			Reason:    "pod template reference",
 		})
 	}
 	for name := range pvcSet {
@@ -144,6 +184,8 @@ func discoverConfigs(namespace string, podSpec *corev1.PodTemplateSpec) []common
 			Type:      "persistentvolumeclaims",
 			Name:      name,
 			Namespace: namespace,
+			Direction: common.RelatedDirectionReferences,
+			Reason:    "pod template volume claim",
 		})
 	}
 
@@ -223,6 +265,8 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 				Type:      "deployments",
 				Name:      deployment.Name,
 				Namespace: deployment.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "workload pod template reference",
 			})
 		}
 	}
@@ -232,6 +276,8 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 				Type:      "statefulsets",
 				Name:      statefulSet.Name,
 				Namespace: statefulSet.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "workload pod template reference",
 			})
 		}
 	}
@@ -241,6 +287,8 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 				Type:      "daemonsets",
 				Name:      daemonSet.Name,
 				Namespace: daemonSet.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "workload pod template reference",
 			})
 		}
 	}
@@ -263,11 +311,226 @@ func discoverPodsByService(ctx context.Context, k8sClient *kube.K8sClient, servi
 					Type:      "pods",
 					Namespace: addr.TargetRef.Namespace,
 					Name:      addr.TargetRef.Name,
+					Direction: common.RelatedDirectionReferences,
+					Reason:    "service endpoint target",
 				})
 			}
 		}
 	}
 	return relatedPods
+}
+
+func discoverDeploymentOwnedReplicaSets(ctx context.Context, k8sClient *kube.K8sClient, deployment *appsv1.Deployment) ([]appsv1.ReplicaSet, error) {
+	var replicaSetList appsv1.ReplicaSetList
+	if err := k8sClient.List(ctx, &replicaSetList, client.InNamespace(deployment.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list replicasets: %w", err)
+	}
+
+	var relatedReplicaSets []appsv1.ReplicaSet
+	for _, rs := range replicaSetList.Items {
+		for _, owner := range rs.OwnerReferences {
+			if owner.Kind == "Deployment" && owner.Name == deployment.Name {
+				relatedReplicaSets = append(relatedReplicaSets, rs)
+				break
+			}
+		}
+	}
+	return relatedReplicaSets, nil
+}
+
+func discoverPodsByReplicaSets(ctx context.Context, k8sClient *kube.K8sClient, namespace string, replicaSets []appsv1.ReplicaSet) ([]common.RelatedResource, error) {
+	if len(replicaSets) == 0 {
+		return []common.RelatedResource{}, nil
+	}
+
+	ownedReplicaSets := make(map[string]struct{}, len(replicaSets))
+	for _, rs := range replicaSets {
+		ownedReplicaSets[rs.Name] = struct{}{}
+	}
+
+	var podList corev1.PodList
+	if err := k8sClient.List(ctx, &podList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	var relatedPods []common.RelatedResource
+	for _, pod := range podList.Items {
+		for _, owner := range pod.OwnerReferences {
+			if owner.Kind == "ReplicaSet" {
+				if _, ok := ownedReplicaSets[owner.Name]; ok {
+					relatedPods = append(relatedPods, common.RelatedResource{
+						Type:      "pods",
+						Namespace: pod.Namespace,
+						Name:      pod.Name,
+						Direction: common.RelatedDirectionReferencedBy,
+						Reason:    "pod owned by deployment replica set",
+					})
+					break
+				}
+			}
+		}
+	}
+	return relatedPods, nil
+}
+
+func discoverServiceNetworkResources(ctx context.Context, k8sClient *kube.K8sClient, services []corev1.Service) ([]common.RelatedResource, error) {
+	if len(services) == 0 {
+		return []common.RelatedResource{}, nil
+	}
+
+	serviceSet := make(map[string]corev1.Service, len(services))
+	for _, service := range services {
+		serviceSet[service.Namespace+"/"+service.Name] = service
+	}
+
+	var result []common.RelatedResource
+	for _, service := range services {
+		result = append(result, common.RelatedResource{
+			Type:       "endpoints",
+			Namespace:  service.Namespace,
+			Name:       service.Name,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Direction:  common.RelatedDirectionReferencedBy,
+			Reason:     "service endpoint for matching selector",
+		})
+
+		var endpointSliceList discoveryv1.EndpointSliceList
+		if err := k8sClient.List(ctx, &endpointSliceList, client.InNamespace(service.Namespace), client.MatchingLabels{
+			discoveryv1.LabelServiceName: service.Name,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to list endpoint slices: %w", err)
+		}
+		for _, endpointSlice := range endpointSliceList.Items {
+			result = append(result, common.RelatedResource{
+				Type:       "endpointslices",
+				Namespace:  endpointSlice.Namespace,
+				Name:       endpointSlice.Name,
+				APIVersion: discoveryv1.SchemeGroupVersion.String(),
+				Direction:  common.RelatedDirectionReferencedBy,
+				Reason:     "endpoint slice for matching service",
+			})
+		}
+	}
+
+	var ingressList v1.IngressList
+	if err := k8sClient.List(ctx, &ingressList); err != nil {
+		return nil, fmt.Errorf("failed to list ingresses: %w", err)
+	}
+	for _, ingress := range ingressList.Items {
+		for _, relatedService := range discoverIngressServices(ingress.Namespace, &ingress) {
+			if _, ok := serviceSet[relatedService.Namespace+"/"+relatedService.Name]; ok {
+				result = append(result, common.RelatedResource{
+					Type:       "ingresses",
+					Namespace:  ingress.Namespace,
+					Name:       ingress.Name,
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Direction:  common.RelatedDirectionReferencedBy,
+					Reason:     "routes traffic to matching service",
+				})
+				break
+			}
+		}
+	}
+
+	var httpRouteList gatewayapiv1.HTTPRouteList
+	if err := k8sClient.List(ctx, &httpRouteList); err != nil {
+		return nil, fmt.Errorf("failed to list httproutes: %w", err)
+	}
+	for _, route := range httpRouteList.Items {
+		for _, related := range getHTTPRouteRelatedResouces(&route, route.Namespace) {
+			if related.Type == "services" {
+				if _, ok := serviceSet[related.Namespace+"/"+related.Name]; ok {
+					result = append(result, common.RelatedResource{
+						Type:       "httproutes",
+						Namespace:  route.Namespace,
+						Name:       route.Name,
+						APIVersion: gatewayapiv1.GroupVersion.String(),
+						Direction:  common.RelatedDirectionReferencedBy,
+						Reason:     "routes traffic to matching service",
+					})
+					break
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func discoverDeploymentHPAs(ctx context.Context, k8sClient *kube.K8sClient, deployment *appsv1.Deployment) ([]common.RelatedResource, error) {
+	var hpaList autoscalingv2.HorizontalPodAutoscalerList
+	if err := k8sClient.List(ctx, &hpaList, client.InNamespace(deployment.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list horizontalpodautoscalers: %w", err)
+	}
+
+	var result []common.RelatedResource
+	for _, hpa := range hpaList.Items {
+		target := hpa.Spec.ScaleTargetRef
+		if target.Kind == "Deployment" && target.Name == deployment.Name {
+			result = append(result, common.RelatedResource{
+				Type:       "horizontalpodautoscalers",
+				Namespace:  hpa.Namespace,
+				Name:       hpa.Name,
+				APIVersion: autoscalingv2.SchemeGroupVersion.String(),
+				Direction:  common.RelatedDirectionReferencedBy,
+				Reason:     "scales deployment",
+			})
+		}
+	}
+	return result, nil
+}
+
+func discoverDeploymentReferencedBy(ctx context.Context, k8sClient *kube.K8sClient, deployment *appsv1.Deployment) ([]common.RelatedResource, error) {
+	var result []common.RelatedResource
+
+	replicaSets, err := discoverDeploymentOwnedReplicaSets(ctx, k8sClient, deployment)
+	if err != nil {
+		return nil, err
+	}
+	for _, rs := range replicaSets {
+		result = append(result, common.RelatedResource{
+			Type:       "replicasets",
+			Namespace:  rs.Namespace,
+			Name:       rs.Name,
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Direction:  common.RelatedDirectionReferencedBy,
+			Reason:     "owned by deployment",
+		})
+	}
+
+	pods, err := discoverPodsByReplicaSets(ctx, k8sClient, deployment.Namespace, replicaSets)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, pods...)
+
+	services, err := discoverMatchingServices(ctx, k8sClient, deployment.Namespace, deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	for _, service := range services {
+		result = append(result, common.RelatedResource{
+			Type:       "services",
+			Namespace:  service.Namespace,
+			Name:       service.Name,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Direction:  common.RelatedDirectionReferencedBy,
+			Reason:     "service selector matches workload pods",
+		})
+	}
+	networkResources, err := discoverServiceNetworkResources(ctx, k8sClient, services)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, networkResources...)
+
+	hpas, err := discoverDeploymentHPAs(ctx, k8sClient, deployment)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, hpas...)
+
+	return result, nil
 }
 
 func GetRelatedResources(c *gin.Context) {
@@ -284,6 +547,7 @@ func GetRelatedResources(c *gin.Context) {
 	ctx := c.Request.Context()
 	var podSpec *corev1.PodTemplateSpec
 	var selector *metav1.LabelSelector
+	includeMatchingServices := true
 	result := make([]common.RelatedResource, 0)
 
 	switch res := resource.(type) {
@@ -300,6 +564,13 @@ func GetRelatedResources(c *gin.Context) {
 	case *appsv1.Deployment:
 		podSpec = &res.Spec.Template
 		selector = res.Spec.Selector
+		includeMatchingServices = false
+		related, err := discoverDeploymentReferencedBy(ctx, cs.K8sClient, res)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to discover deployment related resources: " + err.Error()})
+			return
+		}
+		result = append(result, related...)
 	case *appsv1.StatefulSet:
 		podSpec = &res.Spec.Template
 		selector = res.Spec.Selector
@@ -316,8 +587,10 @@ func GetRelatedResources(c *gin.Context) {
 		} else {
 			if resourceType == "persistentvolumeclaims" {
 				result = append(result, common.RelatedResource{
-					Type: "persistentvolumes",
-					Name: res.(*corev1.PersistentVolumeClaim).Spec.VolumeName,
+					Type:      "persistentvolumes",
+					Name:      res.(*corev1.PersistentVolumeClaim).Spec.VolumeName,
+					Direction: common.RelatedDirectionReferences,
+					Reason:    "bound persistent volume",
 				})
 			}
 			result = append(result, workloads...)
@@ -337,11 +610,13 @@ func GetRelatedResources(c *gin.Context) {
 		g, gctx := errgroup.WithContext(ctx)
 
 		var relatedServices []common.RelatedResource
-		g.Go(func() error {
-			var err error
-			relatedServices, err = discoverServices(gctx, cs.K8sClient, namespace, selector)
-			return err
-		})
+		if includeMatchingServices {
+			g.Go(func() error {
+				var err error
+				relatedServices, err = discoverServices(gctx, cs.K8sClient, namespace, selector)
+				return err
+			})
+		}
 
 		var related []common.RelatedResource
 		g.Go(func() error {
@@ -370,9 +645,12 @@ func GetRelatedResources(c *gin.Context) {
 				if len(rs.OwnerReferences) > 0 {
 					for _, rsOwner := range rs.OwnerReferences {
 						result = append(result, common.RelatedResource{
-							Type:      strings.ToLower(rsOwner.Kind) + "s",
-							Name:      rsOwner.Name,
-							Namespace: v.GetNamespace(),
+							Type:       strings.ToLower(rsOwner.Kind) + "s",
+							Name:       rsOwner.Name,
+							Namespace:  v.GetNamespace(),
+							APIVersion: rsOwner.APIVersion,
+							Direction:  common.RelatedDirectionReferences,
+							Reason:     "owner reference",
 						})
 					}
 				}
@@ -382,6 +660,8 @@ func GetRelatedResources(c *gin.Context) {
 				Name:       owner.Name,
 				Namespace:  v.GetNamespace(),
 				APIVersion: owner.APIVersion,
+				Direction:  common.RelatedDirectionReferences,
+				Reason:     "owner reference",
 			})
 		}
 	}
@@ -408,6 +688,8 @@ func getHTTPRouteRelatedResouces(res *gatewayapiv1.HTTPRoute, namespace string) 
 				return namespace
 			}(),
 			APIVersion: gatewayapiv1.GroupVersion.String(),
+			Direction:  common.RelatedDirectionReferences,
+			Reason:     "httproute parent reference",
 		})
 	}
 
@@ -432,6 +714,8 @@ func getHTTPRouteRelatedResouces(res *gatewayapiv1.HTTPRoute, namespace string) 
 					return namespace
 				}(),
 				APIVersion: apiVersion,
+				Direction:  common.RelatedDirectionReferences,
+				Reason:     "httproute backend reference",
 			})
 		}
 	}
@@ -446,6 +730,8 @@ func getAutoScalingRelatedResources(res *autoscalingv2.HorizontalPodAutoscaler, 
 		APIVersion: scaleTarget.APIVersion,
 		Name:       scaleTarget.Name,
 		Namespace:  namespace,
+		Direction:  common.RelatedDirectionReferences,
+		Reason:     "scale target",
 	})
 	return result
 }

--- a/pkg/handlers/resources/related_resources_test.go
+++ b/pkg/handlers/resources/related_resources_test.go
@@ -1,13 +1,21 @@
 package resources
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/eryajf/kite-desktop/pkg/common"
+	"github.com/eryajf/kite-desktop/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -36,8 +44,8 @@ func TestDiscoverIngressServices(t *testing.T) {
 
 	got := discoverIngressServices("default", ingress)
 	want := []common.RelatedResource{
-		{Type: "services", Namespace: "default", Name: "svc-a"},
-		{Type: "services", Namespace: "default", Name: "svc-b"},
+		{Type: "services", Namespace: "default", Name: "svc-a", APIVersion: corev1.SchemeGroupVersion.String(), Direction: common.RelatedDirectionReferences, Reason: "ingress backend service"},
+		{Type: "services", Namespace: "default", Name: "svc-b", APIVersion: corev1.SchemeGroupVersion.String(), Direction: common.RelatedDirectionReferences, Reason: "ingress backend service"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("discoverIngressServices() = %#v, want %#v", got, want)
@@ -70,13 +78,13 @@ func TestDiscoverConfigs(t *testing.T) {
 
 	got := discoverConfigs("default", podSpec)
 	want := []common.RelatedResource{
-		{Type: "configmaps", Namespace: "default", Name: "cm-env"},
-		{Type: "configmaps", Namespace: "default", Name: "cm-from"},
-		{Type: "configmaps", Namespace: "default", Name: "cm-vol"},
-		{Type: "secrets", Namespace: "default", Name: "sec-env"},
-		{Type: "secrets", Namespace: "default", Name: "sec-from"},
-		{Type: "secrets", Namespace: "default", Name: "sec-vol"},
-		{Type: "persistentvolumeclaims", Namespace: "default", Name: "pvc-vol"},
+		{Type: "configmaps", Namespace: "default", Name: "cm-env", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "configmaps", Namespace: "default", Name: "cm-from", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "configmaps", Namespace: "default", Name: "cm-vol", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "secrets", Namespace: "default", Name: "sec-env", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "secrets", Namespace: "default", Name: "sec-from", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "secrets", Namespace: "default", Name: "sec-vol", Direction: common.RelatedDirectionReferences, Reason: "pod template reference"},
+		{Type: "persistentvolumeclaims", Namespace: "default", Name: "pvc-vol", Direction: common.RelatedDirectionReferences, Reason: "pod template volume claim"},
 	}
 	if !sameRelatedResources(got, want) {
 		t.Fatalf("discoverConfigs() = %#v, want %#v", got, want)
@@ -179,10 +187,10 @@ func TestGetHTTPRouteRelatedResources(t *testing.T) {
 
 	got := getHTTPRouteRelatedResouces(route, "default")
 	want := []common.RelatedResource{
-		{Type: "gateways", Name: "gw-a", Namespace: "default", APIVersion: gatewayapiv1.GroupVersion.String()},
-		{Type: "gateways", Name: "gw-b", Namespace: "edge", APIVersion: gatewayapiv1.GroupVersion.String()},
-		{Type: "services", Name: "svc-a", Namespace: "default", APIVersion: corev1.SchemeGroupVersion.String()},
-		{Type: "configmaps", Name: "cfg", Namespace: "apps"},
+		{Type: "gateways", Name: "gw-a", Namespace: "default", APIVersion: gatewayapiv1.GroupVersion.String(), Direction: common.RelatedDirectionReferences, Reason: "httproute parent reference"},
+		{Type: "gateways", Name: "gw-b", Namespace: "edge", APIVersion: gatewayapiv1.GroupVersion.String(), Direction: common.RelatedDirectionReferences, Reason: "httproute parent reference"},
+		{Type: "services", Name: "svc-a", Namespace: "default", APIVersion: corev1.SchemeGroupVersion.String(), Direction: common.RelatedDirectionReferences, Reason: "httproute backend reference"},
+		{Type: "configmaps", Name: "cfg", Namespace: "apps", Direction: common.RelatedDirectionReferences, Reason: "httproute backend reference"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("getHTTPRouteRelatedResouces() = %#v, want %#v", got, want)
@@ -202,10 +210,131 @@ func TestGetAutoScalingRelatedResources(t *testing.T) {
 
 	got := getAutoScalingRelatedResources(hpa, "default")
 	want := []common.RelatedResource{
-		{Type: "deployments", APIVersion: "apps/v1", Name: "demo", Namespace: "default"},
+		{Type: "deployments", APIVersion: "apps/v1", Name: "demo", Namespace: "default", Direction: common.RelatedDirectionReferences, Reason: "scale target"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("getAutoScalingRelatedResources() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiscoverDeploymentReferencedBy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := discoveryv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := autoscalingv2.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayapiv1.Install(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       types.UID("deployment-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+		},
+	}
+	replicaSet := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-abc",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "Deployment", Name: "demo", UID: types.UID("deployment-uid")},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-abc-pod",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "demo-abc", UID: types.UID("rs-uid")},
+			},
+		},
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-svc", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "demo"}},
+	}
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-svc-abc",
+			Namespace: "default",
+			Labels:    map[string]string{discoveryv1.LabelServiceName: "demo-svc"},
+		},
+	}
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-ingress", Namespace: "default"},
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{Name: "demo-svc"},
+			},
+		},
+	}
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-hpa", Namespace: "default"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: "demo",
+			},
+		},
+	}
+	route := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-route", Namespace: "default"},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayapiv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapiv1.BackendRef{
+								BackendObjectReference: gatewayapiv1.BackendObjectReference{
+									Name: gatewayapiv1.ObjectName("demo-svc"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	client := &kube.K8sClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(deployment, replicaSet, pod, service, endpointSlice, ingress, hpa, route).
+			Build(),
+	}
+
+	got, err := discoverDeploymentReferencedBy(context.Background(), client, deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []common.RelatedResource{
+		{Type: "replicasets", APIVersion: appsv1.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-abc", Direction: common.RelatedDirectionReferencedBy, Reason: "owned by deployment"},
+		{Type: "pods", Namespace: "default", Name: "demo-abc-pod", Direction: common.RelatedDirectionReferencedBy, Reason: "pod owned by deployment replica set"},
+		{Type: "services", APIVersion: corev1.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-svc", Direction: common.RelatedDirectionReferencedBy, Reason: "service selector matches workload pods"},
+		{Type: "endpoints", APIVersion: corev1.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-svc", Direction: common.RelatedDirectionReferencedBy, Reason: "service endpoint for matching selector"},
+		{Type: "endpointslices", APIVersion: discoveryv1.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-svc-abc", Direction: common.RelatedDirectionReferencedBy, Reason: "endpoint slice for matching service"},
+		{Type: "ingresses", APIVersion: networkingv1.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-ingress", Direction: common.RelatedDirectionReferencedBy, Reason: "routes traffic to matching service"},
+		{Type: "httproutes", APIVersion: gatewayapiv1.GroupVersion.String(), Namespace: "default", Name: "demo-route", Direction: common.RelatedDirectionReferencedBy, Reason: "routes traffic to matching service"},
+		{Type: "horizontalpodautoscalers", APIVersion: autoscalingv2.SchemeGroupVersion.String(), Namespace: "default", Name: "demo-hpa", Direction: common.RelatedDirectionReferencedBy, Reason: "scales deployment"},
+	}
+	if !sameRelatedResources(got, want) {
+		t.Fatalf("discoverDeploymentReferencedBy() = %#v, want %#v", got, want)
 	}
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import {
   GlobalSearchProvider,
   useGlobalSearch,
 } from './components/global-search-provider'
+import { IframeEscapeBridge } from './components/iframe-escape-bridge'
 import { PageFindProvider } from './components/page-find-provider'
 import { SiteHeader } from './components/site-header'
 import { SidebarInset, SidebarProvider } from './components/ui/sidebar'
@@ -79,7 +80,12 @@ function AppContent() {
   const isIframe = searchParams.get('iframe') === 'true'
 
   if (isIframe) {
-    return <Outlet />
+    return (
+      <>
+        <IframeEscapeBridge />
+        <Outlet />
+      </>
+    )
   }
 
   return (

--- a/ui/src/components/editors/environment-editor.test.tsx
+++ b/ui/src/components/editors/environment-editor.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { Container } from 'kubernetes-types/core/v1'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EnvironmentEditor } from './environment-editor'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('../selector/configmap-selector', () => ({
+  ConfigMapSelector: ({
+    selectedConfigMap,
+    onConfigMapChange,
+    placeholder,
+  }: {
+    selectedConfigMap: string
+    onConfigMapChange: (value: string) => void
+    placeholder: string
+  }) => (
+    <input
+      aria-label={placeholder}
+      value={selectedConfigMap}
+      onChange={(event) => onConfigMapChange(event.target.value)}
+    />
+  ),
+}))
+
+vi.mock('../selector/secret-selector', () => ({
+  SecretSelector: ({
+    selectedSecret,
+    onSecretChange,
+    placeholder,
+  }: {
+    selectedSecret: string
+    onSecretChange: (value: string) => void
+    placeholder: string
+  }) => (
+    <input
+      aria-label={placeholder}
+      value={selectedSecret}
+      onChange={(event) => onSecretChange(event.target.value)}
+    />
+  ),
+}))
+
+describe('EnvironmentEditor', () => {
+  it('adds new environment variables at the top', () => {
+    const onUpdate = vi.fn()
+    const container = {
+      name: 'app',
+      env: [{ name: 'EXISTING', value: 'one' }],
+    } as Container
+
+    render(
+      <EnvironmentEditor
+        container={container}
+        namespace="default"
+        onUpdate={onUpdate}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /environmentEditor.addVariable/ })
+    )
+
+    const nameInputs = screen.getAllByPlaceholderText(
+      'environmentEditor.variableNamePlaceholder'
+    )
+    expect(nameInputs[0]).toHaveValue('')
+    expect(nameInputs[1]).toHaveValue('EXISTING')
+    expect(onUpdate).toHaveBeenLastCalledWith({
+      env: [
+        { name: '', value: '' },
+        { name: 'EXISTING', value: 'one' },
+      ],
+    })
+  })
+
+  it('adds new environment sources at the top', () => {
+    const onUpdate = vi.fn()
+    const container = {
+      name: 'app',
+      envFrom: [{ secretRef: { name: 'existing-secret' } }],
+    } as Container
+
+    render(
+      <EnvironmentEditor
+        container={container}
+        namespace="default"
+        onUpdate={onUpdate}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /environmentEditor.addSource/ })
+    )
+
+    const sourceInputs = screen.getAllByLabelText(
+      'environmentEditor.selectConfigMap'
+    )
+    expect(sourceInputs[0]).toHaveValue('')
+    expect(onUpdate).toHaveBeenLastCalledWith({
+      envFrom: [{ secretRef: { name: 'existing-secret' } }],
+    })
+  })
+})

--- a/ui/src/components/editors/environment-editor.tsx
+++ b/ui/src/components/editors/environment-editor.tsx
@@ -28,6 +28,12 @@ interface EnvironmentEditorProps {
   onUpdate: (updates: Partial<Container>) => void
 }
 
+function hasEnvFromSourceValue(source: EnvFromSource) {
+  return Boolean(
+    source.configMapRef?.name?.trim() || source.secretRef?.name?.trim()
+  )
+}
+
 export function EnvironmentEditor({
   container,
   namespace,
@@ -45,7 +51,7 @@ export function EnvironmentEditor({
   }, [container])
 
   const addEnvVar = () => {
-    const newEnvVars = [...envVars, { name: '', value: '' }]
+    const newEnvVars = [{ name: '', value: '' }, ...envVars]
     setEnvVars(newEnvVars)
     // Don't filter out empty names immediately, let user fill them in
     onUpdate({ env: newEnvVars })
@@ -207,16 +213,12 @@ export function EnvironmentEditor({
   // EnvFrom management functions
   const addEnvFromSource = () => {
     const newEnvFromSources = [
-      ...envFromSources,
       { configMapRef: { name: '' } },
+      ...envFromSources,
     ]
     setEnvFromSources(newEnvFromSources)
     onUpdate({
-      envFrom: newEnvFromSources.filter(
-        (source) =>
-          source.configMapRef?.name?.trim() !== '' ||
-          source.secretRef?.name?.trim() !== ''
-      ),
+      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
     })
   }
 
@@ -224,11 +226,7 @@ export function EnvironmentEditor({
     const newEnvFromSources = envFromSources.filter((_, i) => i !== index)
     setEnvFromSources(newEnvFromSources)
     onUpdate({
-      envFrom: newEnvFromSources.filter(
-        (source) =>
-          source.configMapRef?.name?.trim() !== '' ||
-          source.secretRef?.name?.trim() !== ''
-      ),
+      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
     })
   }
 
@@ -271,11 +269,7 @@ export function EnvironmentEditor({
     })
     setEnvFromSources(newEnvFromSources)
     onUpdate({
-      envFrom: newEnvFromSources.filter(
-        (source) =>
-          source.configMapRef?.name?.trim() !== '' ||
-          source.secretRef?.name?.trim() !== ''
-      ),
+      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
     })
   }
 
@@ -295,11 +289,7 @@ export function EnvironmentEditor({
     })
     setEnvFromSources(newEnvFromSources)
     onUpdate({
-      envFrom: newEnvFromSources.filter(
-        (source) =>
-          source.configMapRef?.name?.trim() !== '' ||
-          source.secretRef?.name?.trim() !== ''
-      ),
+      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
     })
   }
 

--- a/ui/src/components/iframe-escape-bridge.tsx
+++ b/ui/src/components/iframe-escape-bridge.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+export function IframeEscapeBridge() {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && window.parent !== window) {
+        window.parent.postMessage(
+          { type: 'kite:related-resource-dialog:escape' },
+          window.location.origin
+        )
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  return null
+}

--- a/ui/src/components/pod-monitoring.test.tsx
+++ b/ui/src/components/pod-monitoring.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import type { Pod } from 'kubernetes-types/core/v1'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PodMonitoring } from './pod-monitoring'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  usePodMetrics: () => ({
+    data: {
+      cpu: [],
+      memory: [],
+      networkIn: [],
+      networkOut: [],
+      diskRead: [],
+      diskWrite: [],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('./chart/cpu-usage-chart', () => ({
+  default: () => <div>cpu-chart</div>,
+}))
+
+vi.mock('./chart/memory-usage-chart', () => ({
+  default: () => <div>memory-chart</div>,
+}))
+
+vi.mock('./chart/network-usage-chart', () => ({
+  default: () => <div>network-chart</div>,
+}))
+
+vi.mock('./chart/disk-io-usage-chart', () => ({
+  default: () => <div>disk-chart</div>,
+}))
+
+vi.mock('@/components/selector/container-selector', () => ({
+  ContainerSelector: () => <div data-testid="container-selector" />,
+}))
+
+vi.mock('./selector/pod-selector', () => ({
+  PodSelector: () => <div data-testid="pod-selector" />,
+}))
+
+describe('PodMonitoring', () => {
+  it('keeps container and pod selector controls wide enough for long names', () => {
+    const pods = [
+      {
+        metadata: {
+          name: 'multi-container-deployment-7fb66588d5-gjm6z',
+          uid: 'pod-1',
+        },
+      },
+      {
+        metadata: {
+          name: 'multi-container-deployment-7fb66588d5-k9p4m',
+          uid: 'pod-2',
+        },
+      },
+    ] as Pod[]
+
+    render(
+      <PodMonitoring
+        namespace="default"
+        pods={pods}
+        containers={[{ name: 'nginx-container', image: 'nginx:latest' }]}
+      />
+    )
+
+    const containerWrapper = screen
+      .getByTestId('container-selector')
+      .parentElement
+    const podWrapper = screen.getByTestId('pod-selector').parentElement
+
+    expect(containerWrapper).toHaveClass('md:shrink-0')
+    expect(containerWrapper).toHaveClass('md:min-w-[14rem]')
+    expect(podWrapper).toHaveClass('md:shrink-0')
+    expect(podWrapper).toHaveClass('md:min-w-[18rem]')
+  })
+})

--- a/ui/src/components/pod-monitoring.tsx
+++ b/ui/src/components/pod-monitoring.tsx
@@ -125,7 +125,7 @@ export function PodMonitoring({
           </Select>
         </div>
 
-        <div className="w-full space-y-2 md:w-auto md:min-w-[220px]">
+        <div className="w-full space-y-2 md:w-auto md:min-w-[14rem] md:shrink-0">
           <ContainerSelector
             containers={containers}
             selectedContainer={selectedContainer}
@@ -133,7 +133,7 @@ export function PodMonitoring({
           />
         </div>
         {pods && pods.length > 1 && (
-          <div className="w-full space-y-2 md:w-auto md:min-w-[220px]">
+          <div className="w-full space-y-2 md:w-auto md:min-w-[18rem] md:shrink-0">
             {/* Pod Selector */}
             <PodSelector
               pods={pods}

--- a/ui/src/components/pod-terminal-file-tree.test.tsx
+++ b/ui/src/components/pod-terminal-file-tree.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PodTerminalFileTree } from './pod-terminal-file-tree'
+
+const mockUsePodFiles = vi.fn()
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, string>) =>
+        options?.name ? `${key}:${options.name}` : key,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  usePodFiles: (...args: unknown[]) => mockUsePodFiles(...args),
+}))
+
+describe('PodTerminalFileTree', () => {
+  it('lists pod directories and navigates into a directory', () => {
+    mockUsePodFiles.mockReturnValue({
+      data: [
+        { name: 'app', isDir: true, size: '-', modTime: '', mode: '', uid: '', gid: '' },
+        { name: 'README.md', isDir: false, size: '12', modTime: '', mode: '', uid: '', gid: '' },
+      ],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(
+      <PodTerminalFileTree
+        namespace="default"
+        podName="web-abc"
+        containerName="nginx"
+      />
+    )
+
+    expect(mockUsePodFiles).toHaveBeenLastCalledWith(
+      'default',
+      'web-abc',
+      'nginx',
+      '/',
+      { enabled: true }
+    )
+    expect(screen.getByText('app')).toBeInTheDocument()
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'podFiles.enterDirectory:app' }))
+
+    expect(mockUsePodFiles).toHaveBeenLastCalledWith(
+      'default',
+      'web-abc',
+      'nginx',
+      '/app',
+      { enabled: true }
+    )
+    expect(screen.getByDisplayValue('/app')).toBeInTheDocument()
+  })
+
+  it('does not query files until pod and container are available', () => {
+    mockUsePodFiles.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(
+      <PodTerminalFileTree
+        namespace="default"
+        podName=""
+        containerName=""
+      />
+    )
+
+    expect(mockUsePodFiles).toHaveBeenLastCalledWith(
+      'default',
+      '',
+      '',
+      '/',
+      { enabled: false }
+    )
+  })
+})

--- a/ui/src/components/pod-terminal-file-tree.tsx
+++ b/ui/src/components/pod-terminal-file-tree.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+import {
+  IconArrowUp,
+  IconFile,
+  IconFolder,
+  IconFolderOpen,
+  IconLoader,
+} from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+
+import { usePodFiles } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+import { ErrorMessage } from './error-message'
+import { RefreshButton } from './refresh-button'
+
+interface PodTerminalFileTreeProps {
+  namespace?: string
+  podName: string
+  containerName: string
+}
+
+function joinPath(currentPath: string, name: string) {
+  return currentPath === '/' ? `/${name}` : `${currentPath}/${name}`
+}
+
+function getParentPath(currentPath: string) {
+  if (currentPath === '/') {
+    return '/'
+  }
+
+  const parts = currentPath.split('/').filter(Boolean)
+  parts.pop()
+  return parts.length > 0 ? `/${parts.join('/')}` : '/'
+}
+
+export function PodTerminalFileTree({
+  namespace = '',
+  podName,
+  containerName,
+}: PodTerminalFileTreeProps) {
+  const { t } = useTranslation()
+  const [currentPath, setCurrentPath] = useState('/')
+  const enabled = Boolean(namespace && podName && containerName)
+
+  useEffect(() => {
+    setCurrentPath('/')
+  }, [containerName, podName])
+
+  const {
+    data: files,
+    isLoading,
+    error,
+    refetch,
+  } = usePodFiles(namespace, podName, containerName, currentPath, { enabled })
+
+  const handleNavigate = (path: string) => {
+    setCurrentPath(path.startsWith('/') ? path : `/${path}`)
+  }
+
+  return (
+    <aside className="flex h-full min-h-0 w-full flex-col border-r bg-background">
+      <div className="flex shrink-0 items-center gap-2 border-b p-3">
+        <IconFolderOpen className="h-4 w-4 text-muted-foreground" />
+        <Input
+          value={currentPath}
+          aria-label={t('podFiles.currentPath')}
+          onChange={(event) => setCurrentPath(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              handleNavigate(currentPath)
+            }
+          }}
+          className="h-8 font-mono text-sm"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t('podFiles.goToParentDirectory')}
+          onClick={() => handleNavigate(getParentPath(currentPath))}
+          disabled={currentPath === '/'}
+        >
+          <IconArrowUp className="h-4 w-4" />
+        </Button>
+        <RefreshButton
+          variant="ghost"
+          size="icon"
+          aria-label={t('podFiles.refreshFileList')}
+          onClick={() => refetch()}
+          disabled={!enabled}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {!enabled ? (
+          <div className="px-2 py-6 text-sm text-muted-foreground">
+            {t('terminalContent.fileTreeUnavailable')}
+          </div>
+        ) : error ? (
+          <ErrorMessage
+            resourceName="pod files"
+            error={error}
+            refetch={refetch}
+          />
+        ) : isLoading ? (
+          <div className="flex items-center gap-2 px-2 py-6 text-sm text-muted-foreground">
+            <IconLoader className="h-4 w-4 animate-spin" />
+            {t('podFiles.loadingFiles')}
+          </div>
+        ) : files && files.length > 0 ? (
+          <div className="space-y-1">
+            {files.map((file) =>
+              file.isDir ? (
+                <Button
+                  key={file.name}
+                  variant="ghost"
+                  className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
+                  aria-label={t('podFiles.enterDirectory', {
+                    name: file.name,
+                  })}
+                  onClick={() =>
+                    handleNavigate(joinPath(currentPath, file.name))
+                  }
+                >
+                  <IconFolder className="h-4 w-4 shrink-0 text-blue-500" />
+                  <span className="truncate font-mono text-sm">
+                    {file.name}
+                  </span>
+                </Button>
+              ) : (
+                <div
+                  key={file.name}
+                  className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground"
+                >
+                  <IconFile className="h-4 w-4 shrink-0" />
+                  <span className="truncate font-mono">{file.name}</span>
+                </div>
+              )
+            )}
+          </div>
+        ) : (
+          <div className="px-2 py-6 text-sm text-muted-foreground">
+            {t('podFiles.noFilesFound')}
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/ui/src/components/related-resource-table.test.tsx
+++ b/ui/src/components/related-resource-table.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+
+import { RelatedResourcesTable } from './related-resource-table'
+
+const relatedResourcesMock = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  useRelatedResources: relatedResourcesMock,
+}))
+
+describe('RelatedResourcesTable', () => {
+  function renderTable(initialPath = '/') {
+    return render(
+      <MemoryRouter initialEntries={[initialPath]}>
+        <RelatedResourcesTable
+          resource="deployments"
+          name="demo"
+          namespace="default"
+        />
+        <LocationProbe />
+      </MemoryRouter>
+    )
+  }
+
+  it('renders standard endpoint resources and unknown resources without crashing', () => {
+    relatedResourcesMock.mockReturnValue({
+      data: [
+        { type: 'endpoints', name: 'demo', namespace: 'default' },
+        {
+          type: 'unknownwidgets',
+          name: 'demo-widget',
+          namespace: 'default',
+        },
+      ],
+      isLoading: false,
+    })
+
+    renderTable()
+
+    expect(screen.getByText('endpoints')).toBeInTheDocument()
+    expect(screen.getByText('demo')).toHaveClass('app-link')
+    expect(screen.getByText('unknownwidgets')).toBeInTheDocument()
+    expect(screen.getByText('demo-widget')).not.toHaveClass('app-link')
+  })
+
+  it('groups related resources by direction', () => {
+    relatedResourcesMock.mockReturnValue({
+      data: [
+        {
+          type: 'configmaps',
+          name: 'demo-config',
+          namespace: 'default',
+          direction: 'references',
+          reason: 'pod template reference',
+        },
+        {
+          type: 'services',
+          name: 'demo-service',
+          namespace: 'default',
+          direction: 'referencedBy',
+          reason: 'service selector matches workload pods',
+        },
+      ],
+      isLoading: false,
+    })
+
+    renderTable()
+
+    const references = screen
+      .getByText('relatedResources.references')
+      .closest('section')
+    const referencedBy = screen
+      .getByText('relatedResources.referencedBy')
+      .closest('section')
+
+    expect(references).not.toBeNull()
+    expect(referencedBy).not.toBeNull()
+    expect(within(references!).getByText('1')).toBeInTheDocument()
+    expect(within(referencedBy!).getByText('1')).toBeInTheDocument()
+    expect(
+      within(references!).getByText('relatedResources.referencesDescription')
+    ).toBeInTheDocument()
+    expect(
+      within(referencedBy!).getByText(
+        'relatedResources.referencedByDescription'
+      )
+    ).toBeInTheDocument()
+    expect(within(references!).getByText('demo-config')).toBeInTheDocument()
+    expect(within(referencedBy!).getByText('demo-service')).toBeInTheDocument()
+    expect(screen.getByText('pod template reference')).toBeInTheDocument()
+    expect(
+      screen.getByText('service selector matches workload pods')
+    ).toBeInTheDocument()
+  })
+
+  it('closes the resource dialog when an embedded detail page sends an escape message', async () => {
+    relatedResourcesMock.mockReturnValue({
+      data: [{ type: 'services', name: 'demo-service', namespace: 'default' }],
+      isLoading: false,
+    })
+
+    renderTable()
+
+    fireEvent.click(screen.getByText('demo-service'))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'kite:related-resource-dialog:escape' },
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('navigates inside the iframe instead of opening nested dialogs', async () => {
+    relatedResourcesMock.mockReturnValue({
+      data: [{ type: 'services', name: 'demo-service', namespace: 'default' }],
+      isLoading: false,
+    })
+
+    renderTable('/deployments/default/demo?iframe=true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'demo-service' }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/services/default/demo-service?iframe=true'
+    )
+  })
+})
+
+function LocationProbe() {
+  const location = useLocation()
+
+  return (
+    <div data-testid="location">
+      {location.pathname}
+      {location.search}
+    </div>
+  )
+}

--- a/ui/src/components/related-resource-table.tsx
+++ b/ui/src/components/related-resource-table.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { IconExternalLink, IconLoader } from '@tabler/icons-react'
 import { useTranslation } from 'react-i18next'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { RelatedResources, ResourceType } from '@/types/api'
 import { useRelatedResources } from '@/lib/api'
@@ -51,8 +52,29 @@ export function RelatedResourcesTable(props: {
           return <RelatedResourceCell rs={rs} />
         },
       },
+      {
+        header: t('relatedResources.reason'),
+        accessor: (rs: RelatedResources) => rs.reason || '-',
+        cell: (value: unknown) => (
+          <span className="text-muted-foreground">{value as string}</span>
+        ),
+      },
     ],
     [t]
+  )
+  const references = useMemo(
+    () =>
+      (relatedResources || []).filter(
+        (item) => item.direction !== 'referencedBy'
+      ),
+    [relatedResources]
+  )
+  const referencedBy = useMemo(
+    () =>
+      (relatedResources || []).filter(
+        (item) => item.direction === 'referencedBy'
+      ),
+    [relatedResources]
   )
 
   if (isLoading) {
@@ -69,26 +91,127 @@ export function RelatedResourcesTable(props: {
         <CardTitle>{t('relatedResources.title')}</CardTitle>
       </CardHeader>
       <CardContent>
-        <SimpleTable
-          data={relatedResources || []}
-          columns={relatedColumns}
-          emptyMessage={t('relatedResources.empty')}
-        />
+        <div className="space-y-6">
+          <RelatedResourcesSection
+            title={t('relatedResources.references')}
+            description={t('relatedResources.referencesDescription')}
+            data={references}
+            columns={relatedColumns}
+            emptyMessage={t('relatedResources.emptyReferences')}
+            tone="reference"
+          />
+          <RelatedResourcesSection
+            title={t('relatedResources.referencedBy')}
+            description={t('relatedResources.referencedByDescription')}
+            data={referencedBy}
+            columns={relatedColumns}
+            emptyMessage={t('relatedResources.emptyReferencedBy')}
+            tone="referencedBy"
+          />
+        </div>
       </CardContent>
     </Card>
   )
 }
 
+function RelatedResourcesSection({
+  title,
+  description,
+  data,
+  columns,
+  emptyMessage,
+  tone,
+}: {
+  title: string
+  description: string
+  data: RelatedResources[]
+  columns: Column<RelatedResources>[]
+  emptyMessage: string
+  tone: 'reference' | 'referencedBy'
+}) {
+  const toneClassName =
+    tone === 'reference'
+      ? 'border-sky-200/70 bg-sky-50/50 dark:border-sky-900/60 dark:bg-sky-950/20'
+      : 'border-emerald-200/70 bg-emerald-50/50 dark:border-emerald-900/60 dark:bg-emerald-950/20'
+  const badgeClassName =
+    tone === 'reference'
+      ? 'border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-300'
+      : 'border-emerald-200 bg-emerald-100 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
+
+  return (
+    <section className={`rounded-lg border p-4 ${toneClassName}`}>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold">{title}</h3>
+            <Badge variant="outline" className={badgeClassName}>
+              {data.length}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+      </div>
+      <div className="rounded-md border bg-background/80">
+        <SimpleTable
+          data={data}
+          columns={columns}
+          emptyMessage={emptyMessage}
+        />
+      </div>
+    </section>
+  )
+}
+
 function RelatedResourceCell({ rs }: { rs: RelatedResources }) {
   const [open, setOpen] = useState(false)
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const { t } = useTranslation()
+  const isIframe = searchParams.get('iframe') === 'true'
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return
+      }
+      if (event.data?.type === 'kite:related-resource-dialog:escape') {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [open])
 
   const path = useMemo(() => {
     if (isStandardK8sResource(rs.type)) {
       return `/${rs.type}/${rs.namespace ? `${rs.namespace}/` : ''}${rs.name}`
     }
-    return getCRDResourcePath(rs.type, rs.apiVersion!, rs.namespace, rs.name)
+    if (rs.apiVersion) {
+      return getCRDResourcePath(rs.type, rs.apiVersion, rs.namespace, rs.name)
+    }
+    return undefined
   }, [rs])
+
+  if (!path) {
+    return <div className="font-medium text-muted-foreground">{rs.name}</div>
+  }
+
+  if (isIframe) {
+    return (
+      <button
+        type="button"
+        className="font-medium app-link cursor-pointer"
+        onClick={() => navigate(`${path}?iframe=true`)}
+      >
+        {rs.name}
+      </button>
+    )
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/ui/src/components/selector/container-selector.test.tsx
+++ b/ui/src/components/selector/container-selector.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { ContainerSelector } from './container-selector'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserver)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe('ContainerSelector', () => {
+  it('uses adaptive trigger and dropdown widths for long names', () => {
+    render(
+      <ContainerSelector
+        containers={[
+          {
+            name: 'nginx-container',
+            image: 'docker.cnb.cool/example/nginx:latest',
+            init: false,
+          },
+          {
+            name: 'sidecar-container-with-a-long-readable-name',
+            image: 'docker.cnb.cool/example/sidecar:latest',
+            init: false,
+          },
+        ]}
+        selectedContainer="sidecar-container-with-a-long-readable-name"
+        showAllOption={false}
+        onContainerChange={vi.fn()}
+      />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveClass('md:w-fit')
+    expect(trigger).toHaveClass('md:min-w-[14rem]')
+    expect(trigger).toHaveClass('md:max-w-[min(42rem,calc(100vw-2rem))]')
+    expect(trigger).not.toHaveClass('md:max-w-[300px]')
+
+    fireEvent.click(trigger)
+
+    const popoverContent = document.querySelector(
+      '[data-slot="popover-content"]'
+    )
+    expect(popoverContent).toHaveClass('w-max')
+    expect(popoverContent).toHaveClass(
+      'min-w-[var(--radix-popover-trigger-width)]'
+    )
+    expect(popoverContent).toHaveClass(
+      'max-w-[min(42rem,calc(100vw-1rem))]'
+    )
+  })
+})

--- a/ui/src/components/selector/container-selector.tsx
+++ b/ui/src/components/selector/container-selector.tsx
@@ -52,7 +52,7 @@ export function ContainerSelector({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full min-w-0 justify-between md:w-auto md:max-w-[300px]"
+          className="w-full min-w-0 justify-between md:w-fit md:min-w-[14rem] md:max-w-[min(42rem,calc(100vw-2rem))]"
         >
           <span className="truncate">
             {selectedOption ? selectedOption.name : resolvedPlaceholder}
@@ -60,7 +60,7 @@ export function ContainerSelector({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] max-w-[min(300px,calc(100vw-1rem))] p-0">
+      <PopoverContent className="w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(42rem,calc(100vw-1rem))] p-0">
         <Command>
           <CommandInput placeholder={t('selector.searchContainers')} />
           <CommandList>

--- a/ui/src/components/selector/pod-selector.test.tsx
+++ b/ui/src/components/selector/pod-selector.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { Pod } from 'kubernetes-types/core/v1'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { PodSelector } from './pod-selector'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserver)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe('PodSelector', () => {
+  it('uses adaptive trigger and dropdown widths for long pod names', () => {
+    const pods = [
+      {
+        metadata: {
+          name: 'multi-container-deployment-7fb66588d5-gjm6z',
+          uid: 'pod-1',
+        },
+      },
+    ] as Pod[]
+
+    render(
+      <PodSelector
+        pods={pods}
+        selectedPod="multi-container-deployment-7fb66588d5-gjm6z"
+        onPodChange={vi.fn()}
+      />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveClass('md:w-fit')
+    expect(trigger).toHaveClass('md:min-w-[18rem]')
+    expect(trigger).toHaveClass('md:max-w-[min(48rem,calc(100vw-2rem))]')
+    expect(trigger).not.toHaveClass('md:max-w-[300px]')
+
+    fireEvent.click(trigger)
+
+    const popoverContent = document.querySelector(
+      '[data-slot="popover-content"]'
+    )
+    expect(popoverContent).toHaveClass('w-max')
+    expect(popoverContent).toHaveClass(
+      'min-w-[var(--radix-popover-trigger-width)]'
+    )
+    expect(popoverContent).toHaveClass(
+      'max-w-[min(48rem,calc(100vw-1rem))]'
+    )
+  })
+})

--- a/ui/src/components/selector/pod-selector.tsx
+++ b/ui/src/components/selector/pod-selector.tsx
@@ -56,7 +56,7 @@ export function PodSelector({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full min-w-0 justify-between md:w-auto md:max-w-[300px]"
+          className="w-full min-w-0 justify-between md:w-fit md:min-w-[18rem] md:max-w-[min(48rem,calc(100vw-2rem))]"
         >
           <span className="truncate">
             {selectedOption ? selectedOption.metadata?.name : t('common.all')}
@@ -64,7 +64,7 @@ export function PodSelector({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] max-w-[min(300px,calc(100vw-1rem))] p-0">
+      <PopoverContent className="w-max min-w-[var(--radix-popover-trigger-width)] max-w-[min(48rem,calc(100vw-1rem))] p-0">
         <Command>
           <CommandInput placeholder={t('selector.searchPods')} />
           <CommandList>
@@ -94,7 +94,7 @@ export function PodSelector({
                     )}
                   />
                   <div className="flex min-w-0 flex-col">
-                    <span className="truncate font-medium">
+                    <span className="font-medium">
                       {pod.metadata?.name}
                     </span>
                     {pod.metadata?.creationTimestamp && (

--- a/ui/src/components/terminal-content.test.tsx
+++ b/ui/src/components/terminal-content.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { Pod } from 'kubernetes-types/core/v1'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { Terminal } from './terminal-content'
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    loadAddon = vi.fn()
+    open = vi.fn()
+    writeln = vi.fn()
+    write = vi.fn()
+    dispose = vi.fn()
+    onData = vi.fn()
+    refresh = vi.fn()
+    element = {
+      style: {},
+      addEventListener: vi.fn(),
+    }
+    rows = 24
+    cols = 80
+    options = {}
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn()
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }))
+  },
+}))
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: class {},
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}))
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: Record<string, string>) =>
+        options?.name ? `${key}:${options.name}` : key,
+    }),
+  }
+})
+
+vi.mock('@/lib/desktop-preferences', () => ({
+  loadViewerPreference: vi.fn().mockResolvedValue({
+    terminal: {
+      theme: 'classic',
+      cursorStyle: 'bar',
+      fontSize: 14,
+    },
+  }),
+  updateViewerPreference: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('./pod-terminal-file-tree', () => ({
+  PodTerminalFileTree: () => (
+    <aside data-testid="pod-terminal-file-tree">pod file tree</aside>
+  ),
+}))
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+}
+
+class WebSocketMock {
+  static OPEN = 1
+  readyState = WebSocketMock.OPEN
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+
+  constructor() {
+    setTimeout(() => this.onopen?.(), 0)
+  }
+
+  send() {}
+  close() {}
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver =
+    ResizeObserverMock as unknown as typeof ResizeObserver
+  globalThis.WebSocket = WebSocketMock as unknown as typeof WebSocket
+})
+
+const pods = [
+  {
+    metadata: {
+      name: 'web-abc',
+      uid: 'pod-1',
+    },
+  },
+] as Pod[]
+
+describe('Terminal', () => {
+  it('shows a pod file tree toggle for pod terminals', () => {
+    render(
+      <Terminal
+        type="pod"
+        namespace="default"
+        podName="web-abc"
+        pods={pods}
+        containers={[{ name: 'nginx', image: 'nginx:latest' }]}
+      />
+    )
+
+    const toggle = screen.getByRole('button', {
+      name: 'terminalContent.toggleFileTree',
+    })
+    fireEvent.click(toggle)
+
+    expect(screen.getByTestId('pod-terminal-file-tree')).toBeInTheDocument()
+  })
+
+  it('does not show the pod file tree toggle for node terminals', () => {
+    render(<Terminal type="node" nodeName="node-a" />)
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'terminalContent.toggleFileTree',
+      })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   IconClearAll,
+  IconFolder,
   IconMaximize,
   IconMinimize,
   IconPalette,
@@ -44,6 +45,7 @@ import {
 
 import { ConnectionIndicator } from './connection-indicator'
 import { NetworkSpeedIndicator } from './network-speed-indicator'
+import { PodTerminalFileTree } from './pod-terminal-file-tree'
 import { ContainerSelector } from './selector/container-selector'
 import { PodSelector } from './selector/pod-selector'
 
@@ -92,6 +94,7 @@ export function Terminal({
     }
   )
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [showFileTree, setShowFileTree] = useState(false)
   const viewerPreferenceReadyRef = useRef(false)
   const lastPersistedViewerPreferenceRef = useRef<string | null>(null)
 
@@ -281,6 +284,8 @@ export function Terminal({
   const handlePodChange = useCallback((podName?: string) => {
     setSelectedPod(podName || '')
   }, [])
+
+  const canShowFileTree = type === 'pod' && Boolean(namespace)
 
   // Calculate network speed
   const updateNetworkStats = useCallback(
@@ -800,6 +805,18 @@ export function Terminal({
               </PopoverContent>
             </Popover>
 
+            {canShowFileTree && (
+              <Button
+                variant={showFileTree ? 'secondary' : 'outline'}
+                size="sm"
+                aria-label={t('terminalContent.toggleFileTree')}
+                title={t('terminalContent.toggleFileTree')}
+                onClick={() => setShowFileTree((value) => !value)}
+              >
+                <IconFolder className="h-4 w-4" />
+              </Button>
+            )}
+
             {/* Clear Terminal */}
             <Button variant="outline" size="sm" onClick={clearTerminal}>
               <IconClearAll className="h-4 w-4" />
@@ -816,7 +833,16 @@ export function Terminal({
         </div>
       </CardHeader>
 
-      <CardContent className="p-0 flex h-full min-h-0">
+      <CardContent className="flex h-full min-h-0 p-0">
+        {canShowFileTree && showFileTree ? (
+          <div className="h-full min-h-0 w-[360px] shrink-0 max-w-[45%]">
+            <PodTerminalFileTree
+              namespace={namespace}
+              podName={selectedPod}
+              containerName={selectedContainer}
+            />
+          </div>
+        ) : null}
         {terminalDiv}
       </CardContent>
     </Card>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1206,7 +1206,14 @@
     "title": "Related",
     "kind": "Kind",
     "name": "Name",
+    "reason": "Reason",
+    "references": "References",
+    "referencedBy": "Referenced by",
+    "referencesDescription": "Resources this object directly uses or points to.",
+    "referencedByDescription": "Resources that select, own, route to, scale, or consume this object.",
     "empty": "No related resources found",
+    "emptyReferences": "No referenced resources found",
+    "emptyReferencedBy": "No resources reference this object",
     "openInNewTab": "Open resource in new tab"
   },
   "describe": {
@@ -1762,7 +1769,9 @@
     "cursorStyle": "Cursor Style",
     "block": "Block",
     "underline": "Underline",
-    "bar": "Bar"
+    "bar": "Bar",
+    "toggleFileTree": "Toggle pod file tree",
+    "fileTreeUnavailable": "Select a pod and container to browse files."
   },
   "floatingTerminal": {
     "fullscreen": "Fullscreen",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1685,7 +1685,14 @@
     "title": "关联资源",
     "kind": "类型",
     "name": "名称",
+    "reason": "关系",
+    "references": "引用",
+    "referencedBy": "被引用",
+    "referencesDescription": "当前资源直接使用或指向的资源。",
+    "referencedByDescription": "选择、拥有、路由、扩缩或消费当前资源的其它资源。",
     "empty": "未找到关联资源",
+    "emptyReferences": "暂无引用资源",
+    "emptyReferencedBy": "暂无资源引用当前对象",
     "openInNewTab": "在新标签页中打开资源"
   },
   "describe": {
@@ -2054,7 +2061,9 @@
     "cursorStyle": "光标样式",
     "block": "块状",
     "underline": "下划线",
-    "bar": "竖线"
+    "bar": "竖线",
+    "toggleFileTree": "切换 Pod 文件树",
+    "fileTreeUnavailable": "请选择 Pod 和容器后浏览文件。"
   },
   "floatingTerminal": {
     "fullscreen": "全屏",

--- a/ui/src/lib/k8s.ts
+++ b/ui/src/lib/k8s.ts
@@ -637,6 +637,8 @@ export function isStandardK8sResource(kind: string): boolean {
     'jobs',
     'cronjobs',
     'services',
+    'endpoints',
+    'endpointslices',
     'configmaps',
     'secrets',
     'persistentvolumeclaims',
@@ -647,6 +649,10 @@ export function isStandardK8sResource(kind: string): boolean {
     'nodes',
     'events',
     'storageclasses',
+    'serviceaccounts',
+    'horizontalpodautoscalers',
+    'gateways',
+    'httproutes',
   ]
   const resourcePath = kind.toLowerCase() + 's'
   return (

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -24,6 +24,8 @@ import {
   ConfigMapList,
   Event,
   EventList,
+  Endpoints,
+  EndpointsList,
   Namespace,
   NamespaceList,
   Node,
@@ -41,6 +43,7 @@ import {
   ServiceAccountList,
   ServiceList,
 } from 'kubernetes-types/core/v1'
+import { EndpointSlice, EndpointSliceList } from 'kubernetes-types/discovery/v1'
 import {
   Ingress,
   IngressList,
@@ -102,6 +105,8 @@ export type ResourceType =
   | 'jobs'
   | 'cronjobs'
   | 'services'
+  | 'endpoints'
+  | 'endpointslices'
   | 'resourcequotas'
   | 'configmaps'
   | 'secrets'
@@ -153,6 +158,8 @@ export interface ResourcesTypeMap {
   jobs: JobList
   cronjobs: CronJobList
   services: ServiceList
+  endpoints: EndpointsList
+  endpointslices: EndpointSliceList
   resourcequotas: ResourceQuotaList
   configmaps: ConfigMapList
   secrets: SecretList
@@ -239,6 +246,8 @@ export interface ResourceTypeMap {
   jobs: Job
   cronjobs: CronJob
   services: Service
+  endpoints: Endpoints
+  endpointslices: EndpointSlice
   resourcequotas: ResourceQuota
   configmaps: ConfigMap
   secrets: Secret
@@ -346,11 +355,15 @@ export interface ImageTagInfo {
   timestamp?: string
 }
 
+export type RelatedResourceDirection = 'references' | 'referencedBy'
+
 export interface RelatedResources {
   type: ResourceType
   name: string
   namespace?: string
   apiVersion?: string
+  direction?: RelatedResourceDirection
+  reason?: string
 }
 
 export interface Cluster {


### PR DESCRIPTION
feat(pod-monitoring): 更新 PodMonitoring 组件以适应长名称的容器和 Pod 选择器

test(pod-monitoring): 为 PodMonitoring 组件添加单元测试

feat(pod-terminal-file-tree): 实现 PodTerminalFileTree 组件以浏览 Pod 文件

test(pod-terminal-file-tree): 为 PodTerminalFileTree 组件添加单元测试

feat(related-resource-table): 更新 RelatedResourcesTable 组件以支持资源分组和 Escape 消息处理

test(related-resource-table): 为 RelatedResourcesTable 组件添加单元测试

feat(selector): 更新 ContainerSelector 和 PodSelector 组件以适应长名称

test(selector): 为 ContainerSelector 和 PodSelector 组件添加单元测试

feat(terminal): 在 Terminal 组件中添加文件树切换功能

feat(i18n): 更新国际化文件以支持新添加的文本

fix(k8s): 添加 endpoints 和 endpointslices 作为标准 K8s 资源

feat(api): 更新 API 类型以支持 endpoints 和 endpointslices 资源

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).
