### PR TITLE
feat: add stateful set overview and management features

### DIFF
--- a/pkg/handlers/resources/event_handler.go
+++ b/pkg/handlers/resources/event_handler.go
@@ -121,7 +121,7 @@ func (h *EventHandler) appendStatefulSetPodEvents(
 	}
 
 	sort.SliceStable(merged, func(i, j int) bool {
-		return eventTimestamp(merged[i]).Time.After(eventTimestamp(merged[j]).Time)
+		return eventTimestamp(merged[i]).After(eventTimestamp(merged[j]).Time)
 	})
 
 	return merged, nil

--- a/pkg/handlers/resources/event_handler.go
+++ b/pkg/handlers/resources/event_handler.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/eryajf/kite-desktop/pkg/cluster"
 	"github.com/gin-gonic/gin"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +57,87 @@ func (h *EventHandler) ListResourceEvents(c *gin.Context) {
 		return
 	}
 
+	if kind == "StatefulSet" {
+		mergedEvents, err := h.appendStatefulSetPodEvents(c, cs, target, events.Items)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list related pod events: " + err.Error()})
+			return
+		}
+		events.Items = mergedEvents
+	}
+
 	c.JSON(http.StatusOK, events)
+}
+
+func (h *EventHandler) appendStatefulSetPodEvents(
+	c *gin.Context,
+	cs *cluster.ClientSet,
+	target interface{},
+	baseEvents []corev1.Event,
+) ([]corev1.Event, error) {
+	statefulSet, ok := target.(*appsv1.StatefulSet)
+	if !ok {
+		return baseEvents, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(statefulSet.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := cs.K8sClient.ClientSet.CoreV1().Pods(statefulSet.Namespace).List(
+		c.Request.Context(),
+		metav1.ListOptions{LabelSelector: selector.String()},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := append([]corev1.Event{}, baseEvents...)
+	seen := make(map[string]struct{}, len(merged))
+	for _, event := range merged {
+		seen[event.Namespace+"/"+event.Name] = struct{}{}
+	}
+
+	for _, pod := range pods.Items {
+		podEvents, err := cs.K8sClient.ClientSet.CoreV1().Events(pod.Namespace).List(
+			c.Request.Context(),
+			metav1.ListOptions{
+				FieldSelector: "involvedObject.kind=Pod,involvedObject.name=" + pod.Name,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, event := range podEvents.Items {
+			key := event.Namespace + "/" + event.Name
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, event)
+		}
+	}
+
+	sort.SliceStable(merged, func(i, j int) bool {
+		return eventTimestamp(merged[i]).Time.After(eventTimestamp(merged[j]).Time)
+	})
+
+	return merged, nil
+}
+
+func eventTimestamp(event corev1.Event) metav1.Time {
+	switch {
+	case !event.LastTimestamp.IsZero():
+		return event.LastTimestamp
+	case !event.FirstTimestamp.IsZero():
+		return event.FirstTimestamp
+	case !event.EventTime.IsZero():
+		return metav1.NewTime(event.EventTime.Time)
+	default:
+		return event.CreationTimestamp
+	}
 }
 
 func eventResourceKind(resource string, target interface{}) (string, error) {

--- a/ui/src/components/container-edit-dialog.tsx
+++ b/ui/src/components/container-edit-dialog.tsx
@@ -5,7 +5,10 @@ import { Container } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 
-import { useDeploymentContainerEditor } from '@/hooks/use-deployment-container-editor'
+import {
+  useDeploymentContainerEditor,
+  WorkloadWithPodTemplate,
+} from '@/hooks/use-deployment-container-editor'
 
 import {
   EnvironmentEditor,
@@ -38,10 +41,14 @@ interface SimpleContainerEditDialogProps extends BaseContainerEditDialogProps {
 
 interface DeploymentContainerEditDialogProps extends BaseContainerEditDialogProps {
   mode: 'deployment'
-  deployment: Deployment
+  deployment?: Deployment
+  workload?: WorkloadWithPodTemplate
   namespace: string
   initialContainerName?: string
-  onSaveDeployment: (updatedDeployment: Deployment) => Promise<void> | void
+  onSaveDeployment?: (updatedDeployment: Deployment) => Promise<void> | void
+  onSaveWorkload?: (
+    updatedWorkload: WorkloadWithPodTemplate
+  ) => Promise<void> | void
 }
 
 type ContainerEditDialogProps =
@@ -153,12 +160,15 @@ function SimpleContainerEditDialogContent({
 
 function DeploymentContainerEditDialogContent({
   deployment,
+  workload,
   namespace,
   initialContainerName,
   onOpenChange,
   onSaveDeployment,
+  onSaveWorkload,
 }: Omit<DeploymentContainerEditDialogProps, 'open' | 'mode'>) {
   const { t } = useTranslation()
+  const editableWorkload = workload || deployment
   const [isSaving, setIsSaving] = useState(false)
   const {
     activeTab,
@@ -178,7 +188,7 @@ function DeploymentContainerEditDialogContent({
     validationErrors,
     volumes,
   } = useDeploymentContainerEditor({
-    deployment,
+    deployment: editableWorkload!,
     open: true,
     initialContainerName,
   })
@@ -212,7 +222,11 @@ function DeploymentContainerEditDialogContent({
 
     setIsSaving(true)
     try {
-      await onSaveDeployment(draftDeployment)
+      if (onSaveWorkload) {
+        await onSaveWorkload(draftDeployment)
+      } else if (onSaveDeployment) {
+        await onSaveDeployment(draftDeployment as Deployment)
+      }
       onOpenChange(false)
     } finally {
       setIsSaving(false)
@@ -222,7 +236,7 @@ function DeploymentContainerEditDialogContent({
   const tabClassName = (hasErrors: boolean) =>
     hasErrors ? 'border-destructive/50 text-destructive' : undefined
 
-  if (!selectedContainer) {
+  if (!editableWorkload || !selectedContainer) {
     return null
   }
 

--- a/ui/src/components/resource-limits-summary.tsx
+++ b/ui/src/components/resource-limits-summary.tsx
@@ -1,0 +1,129 @@
+import type { Container } from 'kubernetes-types/core/v1'
+import { useTranslation } from 'react-i18next'
+
+import { aggregateContainerResources } from '@/lib/k8s'
+import { Badge } from '@/components/ui/badge'
+
+const cpuUnits: Record<string, number> = {
+  n: 1e-9,
+  u: 1e-6,
+  m: 1e-3,
+  '': 1,
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+}
+
+const binaryMemoryUnits: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+}
+
+const decimalMemoryUnits: Record<string, number> = {
+  '': 1,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+}
+
+function trimTrailingZeros(value: number, fractionDigits: number) {
+  return value.toFixed(fractionDigits).replace(/\.?0+$/, '')
+}
+
+function formatCpuAsCores(value?: string, coreUnitLabel = '核') {
+  if (!value) {
+    return undefined
+  }
+
+  const match = value.trim().match(/^([+-]?\d+(?:\.\d+)?)(n|u|m|k|M|G|T|P|E)?$/)
+  if (!match) {
+    return value
+  }
+
+  const amount = Number(match[1])
+  const suffix = match[2] ?? ''
+  const multiplier = cpuUnits[suffix]
+  if (Number.isNaN(amount) || multiplier === undefined) {
+    return value
+  }
+
+  const cores = amount * multiplier
+  return `${trimTrailingZeros(cores, 1)} ${coreUnitLabel}`
+}
+
+function formatMemoryAsGi(value?: string) {
+  if (!value) {
+    return undefined
+  }
+
+  const match = value
+    .trim()
+    .match(/^([+-]?\d+(?:\.\d+)?)(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$/)
+  if (!match) {
+    return value
+  }
+
+  const amount = Number(match[1])
+  const suffix = match[2] ?? ''
+  if (Number.isNaN(amount)) {
+    return value
+  }
+
+  const bytes =
+    suffix in binaryMemoryUnits
+      ? amount * binaryMemoryUnits[suffix]
+      : amount * (decimalMemoryUnits[suffix] ?? 1)
+
+  const gibibytes = bytes / binaryMemoryUnits.Gi
+  return `${trimTrailingZeros(gibibytes, 1)}Gi`
+}
+
+export function ResourceLimitsSummary(props: { containers?: Container[] }) {
+  const { t } = useTranslation()
+  const { containers } = props
+  const limits = aggregateContainerResources(containers).limits
+  const formattedCpu = formatCpuAsCores(
+    limits.cpu,
+    t('namespaceEditDialog.unitCpuCore', '核')
+  )
+  const formattedMemory = formatMemoryAsGi(limits.memory)
+
+  if (!formattedCpu && !formattedMemory) {
+    return <span className="text-sm text-muted-foreground">-</span>
+  }
+
+  return (
+    <div className="flex flex-nowrap items-center gap-1.5 whitespace-nowrap">
+      {formattedCpu ? (
+        <Badge
+          variant="secondary"
+          className="h-6 shrink-0 rounded-full px-2.5 font-mono tabular-nums whitespace-nowrap"
+        >
+          <span className="text-muted-foreground">CPU:</span>
+          <span className="sr-only"> </span>
+          <span className="text-foreground">{formattedCpu}</span>
+        </Badge>
+      ) : null}
+      {formattedMemory ? (
+        <Badge
+          variant="secondary"
+          className="h-6 shrink-0 rounded-full px-2.5 font-mono tabular-nums whitespace-nowrap"
+        >
+          <span className="text-muted-foreground">Memory:</span>
+          <span className="sr-only"> </span>
+          <span className="text-foreground">{formattedMemory}</span>
+        </Badge>
+      ) : null}
+    </div>
+  )
+}

--- a/ui/src/components/statefulset-overview-info-card.test.tsx
+++ b/ui/src/components/statefulset-overview-info-card.test.tsx
@@ -1,0 +1,103 @@
+import '@/i18n'
+
+import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StatefulSetOverviewViewModel } from '@/types/k8s'
+import { formatDate } from '@/lib/utils'
+
+import { StatefulSetOverviewInfoCard } from './statefulset-overview-info-card'
+
+const overview: StatefulSetOverviewViewModel = {
+  status: 'Available',
+  statusTone: 'success',
+  readyReplicas: 3,
+  specReplicas: 3,
+  currentReplicas: 3,
+  updatedReplicas: 3,
+  availableReplicas: 3,
+  isObserved: true,
+  updateStrategy: 'RollingUpdate',
+  podManagementPolicy: 'OrderedReady',
+  minReadySeconds: 0,
+  hostNetwork: false,
+  resourceRequests: {},
+  resourceLimits: {},
+  selectorLabels: {},
+  serviceLinksEnabled: true,
+  labels: {},
+  annotations: {},
+}
+
+describe('StatefulSetOverviewInfoCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-17T10:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows a unified empty-state label for unset overview fields', () => {
+    void i18n.changeLanguage('en')
+
+    render(<StatefulSetOverviewInfoCard overview={overview} />)
+
+    expect(screen.getAllByText('Not set').length).toBeGreaterThan(0)
+    expect(screen.getByTestId('statefulset-status')).toHaveTextContent(
+      'Available'
+    )
+    expect(screen.getByTestId('statefulset-replica-summary')).toHaveTextContent(
+      '3 / 3 / 3'
+    )
+  })
+
+  it('renders created time in a single line with exact relative age', () => {
+    void i18n.changeLanguage('zh')
+    const createdAt = '2026-03-05T18:12:05Z'
+
+    render(
+      <StatefulSetOverviewInfoCard
+        overview={{
+          ...overview,
+          createdAt,
+        }}
+      />
+    )
+
+    expect(
+      screen.getByText(`${formatDate(createdAt)} (42天前)`)
+    ).toBeInTheDocument()
+  })
+
+  it('keeps strategy, revisions, and resource summaries visible together', () => {
+    void i18n.changeLanguage('zh')
+
+    render(
+      <StatefulSetOverviewInfoCard
+        overview={{
+          ...overview,
+          selectorLabels: { app: 'mysql' },
+          resourceRequests: { cpu: '500m', memory: '1Gi' },
+          resourceLimits: { cpu: '1', memory: '2Gi' },
+          currentRevision: 'mysql-abc',
+          updateRevision: 'mysql-def',
+          pvcWhenDeleted: 'Retain',
+          pvcWhenScaled: 'Delete',
+        }}
+      />
+    )
+
+    expect(screen.getByText('当前修订版本')).toBeInTheDocument()
+    expect(screen.getByText('目标修订版本')).toBeInTheDocument()
+    expect(screen.getByText('PVC 保留策略')).toBeInTheDocument()
+    expect(screen.getByText('app: mysql')).toBeInTheDocument()
+    expect(screen.getByText('CPU: 500m')).toBeInTheDocument()
+    expect(screen.getByText('CPU: 1')).toBeInTheDocument()
+    expect(
+      screen.getByText('Deleted: Retain / Scaled: Delete')
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/statefulset-overview-info-card.tsx
+++ b/ui/src/components/statefulset-overview-info-card.tsx
@@ -1,0 +1,273 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  DatabaseZap,
+  PauseCircle,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { StatefulSetOverviewViewModel } from '@/types/k8s'
+import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
+
+import { Badge } from './ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { Label } from './ui/label'
+
+function InfoItem(props: {
+  label: string
+  value: React.ReactNode
+  testId?: string
+}) {
+  const { label, value, testId } = props
+
+  return (
+    <div>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div
+        className="mt-1 text-sm font-medium break-words"
+        data-testid={testId}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function BadgeGroup(props: {
+  items: Record<string, string>
+  emptyText: string
+  variant?: 'secondary' | 'outline'
+}) {
+  const { items, emptyText, variant = 'secondary' } = props
+
+  if (Object.keys(items).length === 0) {
+    return <span className="text-sm text-muted-foreground">{emptyText}</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {Object.entries(items).map(([key, value]) => (
+        <Badge
+          key={key}
+          variant={variant}
+          className="max-w-full text-xs font-normal break-all"
+        >
+          {key}: {value}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function ResourceBadges(props: {
+  value: StatefulSetOverviewViewModel['resourceRequests']
+  emptyText: string
+}) {
+  const { value, emptyText } = props
+
+  if (!value.cpu && !value.memory) {
+    return <span className="text-sm text-muted-foreground">{emptyText}</span>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {value.cpu ? <Badge variant="secondary">CPU: {value.cpu}</Badge> : null}
+      {value.memory ? (
+        <Badge variant="secondary">Memory: {value.memory}</Badge>
+      ) : null}
+    </div>
+  )
+}
+
+function formatRetentionPolicy(
+  whenDeleted: string | undefined,
+  whenScaled: string | undefined,
+  emptyText: string
+) {
+  if (!whenDeleted && !whenScaled) {
+    return emptyText
+  }
+
+  return `Deleted: ${whenDeleted || '-'} / Scaled: ${whenScaled || '-'}`
+}
+
+function StatusIcon(props: { status: StatefulSetOverviewViewModel['status'] }) {
+  const { status } = props
+
+  if (status === 'Available') {
+    return <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+  }
+
+  if (status === 'Scaled Down') {
+    return <PauseCircle className="h-4 w-4 text-slate-500" />
+  }
+
+  if (status === 'Pending') {
+    return <DatabaseZap className="h-4 w-4 text-sky-600" />
+  }
+
+  if (status === 'Progressing') {
+    return <Clock3 className="h-4 w-4 text-amber-600" />
+  }
+
+  return <AlertCircle className="h-4 w-4 text-rose-600" />
+}
+
+export function StatefulSetOverviewInfoCard(props: {
+  overview: StatefulSetOverviewViewModel
+}) {
+  const { overview } = props
+  const { t } = useTranslation()
+  const notSetText = t('statefulSetOverview.notSet')
+
+  return (
+    <Card className="gap-0">
+      <CardHeader className="border-b pb-4">
+        <CardTitle>{t('detail.sections.statefulSetInformation')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5 pt-5">
+        <div className="grid gap-x-8 gap-y-5 md:grid-cols-2 xl:grid-cols-3">
+          <InfoItem
+            label={t('statefulSetOverview.currentStatus')}
+            value={
+              <div
+                className="flex items-center gap-2"
+                data-testid="statefulset-status"
+              >
+                <StatusIcon status={overview.status} />
+                <span>{overview.status}</span>
+              </div>
+            }
+          />
+          <InfoItem
+            label={t('statefulSetOverview.replicaSummary')}
+            value={`${overview.readyReplicas} / ${overview.specReplicas} / ${overview.currentReplicas}`}
+            testId="statefulset-replica-summary"
+          />
+          <InfoItem
+            label={t('detail.fields.created')}
+            value={
+              overview.createdAt
+                ? `${formatDate(overview.createdAt)} (${formatRelativeTimeStrict(overview.createdAt)})`
+                : notSetText
+            }
+          />
+        </div>
+
+        <div className="grid gap-x-8 gap-y-5 border-t pt-5 md:grid-cols-2 xl:grid-cols-3">
+          <InfoItem
+            label={t('detail.fields.updateStrategy')}
+            value={overview.updateStrategy}
+            testId="statefulset-update-strategy"
+          />
+          <InfoItem
+            label={t('detail.fields.podManagementPolicy')}
+            value={overview.podManagementPolicy}
+            testId="statefulset-pod-management-policy"
+          />
+          <InfoItem
+            label={t('statefulSetOverview.minReadySeconds')}
+            value={String(overview.minReadySeconds)}
+            testId="statefulset-min-ready-seconds"
+          />
+          <InfoItem
+            label={t('detail.fields.selector')}
+            value={
+              <BadgeGroup
+                items={overview.selectorLabels}
+                emptyText={notSetText}
+              />
+            }
+          />
+          <InfoItem
+            label={t('deploymentOverview.resourceRequests')}
+            value={
+              <ResourceBadges
+                value={overview.resourceRequests}
+                emptyText={notSetText}
+              />
+            }
+          />
+          <InfoItem
+            label={t('deploymentOverview.resourceLimits')}
+            value={
+              <ResourceBadges
+                value={overview.resourceLimits}
+                emptyText={notSetText}
+              />
+            }
+          />
+        </div>
+
+        <div className="grid gap-x-8 gap-y-5 border-t pt-5 md:grid-cols-2 xl:grid-cols-3">
+          <InfoItem
+            label={t('statefulSetOverview.currentRevision')}
+            value={overview.currentRevision || notSetText}
+            testId="statefulset-current-revision"
+          />
+          <InfoItem
+            label={t('statefulSetOverview.updateRevision')}
+            value={overview.updateRevision || notSetText}
+            testId="statefulset-update-revision"
+          />
+          <InfoItem
+            label={t('statefulSetOverview.pvcRetentionPolicy')}
+            value={formatRetentionPolicy(
+              overview.pvcWhenDeleted,
+              overview.pvcWhenScaled,
+              notSetText
+            )}
+            testId="statefulset-pvc-retention"
+          />
+          <InfoItem
+            label={t('deploymentOverview.hostNetwork')}
+            value={
+              overview.hostNetwork
+                ? t('deploymentOverview.enabled')
+                : t('deploymentOverview.disabled')
+            }
+            testId="statefulset-host-network"
+          />
+          <InfoItem
+            label={t('deploymentOverview.scheduler')}
+            value={overview.schedulerName || notSetText}
+            testId="statefulset-scheduler"
+          />
+          <InfoItem
+            label={t('deploymentOverview.serviceLinks')}
+            value={
+              overview.serviceLinksEnabled
+                ? t('deploymentOverview.enabled')
+                : t('deploymentOverview.disabled')
+            }
+            testId="statefulset-service-links"
+          />
+        </div>
+
+        <div className="grid gap-x-8 gap-y-5 border-t pt-5 md:grid-cols-2">
+          <InfoItem
+            label={t('detail.fields.labels')}
+            value={
+              <BadgeGroup
+                items={overview.labels || {}}
+                emptyText={notSetText}
+                variant="outline"
+              />
+            }
+          />
+          <InfoItem
+            label={t('detail.fields.annotations')}
+            value={
+              <BadgeGroup
+                items={overview.annotations || {}}
+                emptyText={notSetText}
+                variant="outline"
+              />
+            }
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/hooks/use-deployment-container-editor.ts
+++ b/ui/src/hooks/use-deployment-container-editor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Deployment } from 'kubernetes-types/apps/v1'
+import { Deployment, StatefulSet } from 'kubernetes-types/apps/v1'
 import {
   Container,
   ExecAction,
@@ -23,27 +23,29 @@ export type RemoveVolumeResult =
   | { ok: false; volumeName: string; referencedBy: string[] }
 
 type UseDeploymentContainerEditorOptions = {
-  deployment: Deployment
+  deployment: WorkloadWithPodTemplate
   open: boolean
   initialContainerName?: string
 }
+
+export type WorkloadWithPodTemplate = Deployment | StatefulSet
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
 
-function getContainers(deployment: Deployment): Container[] {
+function getContainers(deployment: WorkloadWithPodTemplate): Container[] {
   return deployment.spec?.template?.spec?.containers || []
 }
 
-function getAllContainers(deployment: Deployment): Container[] {
+function getAllContainers(deployment: WorkloadWithPodTemplate): Container[] {
   return [
     ...(deployment.spec?.template?.spec?.containers || []),
     ...(deployment.spec?.template?.spec?.initContainers || []),
   ]
 }
 
-function getVolumes(deployment: Deployment): Volume[] {
+function getVolumes(deployment: WorkloadWithPodTemplate): Volume[] {
   return deployment.spec?.template?.spec?.volumes || []
 }
 
@@ -208,7 +210,7 @@ function validateProbe(
 }
 
 export function validateDeploymentContainerDraft(
-  deployment: Deployment
+  deployment: WorkloadWithPodTemplate
 ): ValidationErrors {
   const errors: ValidationErrors = {}
   const containers = getContainers(deployment)
@@ -336,9 +338,8 @@ export function useDeploymentContainerEditor({
   open,
   initialContainerName,
 }: UseDeploymentContainerEditorOptions) {
-  const [draftDeployment, setDraftDeployment] = useState<Deployment>(() =>
-    clone(deployment)
-  )
+  const [draftDeployment, setDraftDeployment] =
+    useState<WorkloadWithPodTemplate>(() => clone(deployment))
   const [selectedContainerName, setSelectedContainerName] = useState(
     initialContainerName || getContainers(deployment)[0]?.name || ''
   )

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -34,6 +34,8 @@
     "current": "Current",
     "viewDetails": "View details",
     "viewYaml": "View YAML",
+    "manageLabels": "Manage labels",
+    "manageAnnotations": "Manage annotations",
     "copyName": "Copy name",
     "copyImage": "Copy image",
     "available": "Available",
@@ -1488,6 +1490,16 @@
     "disabled": "Disabled",
     "editContainer": "Edit Container",
     "editContainers": "Edit Containers"
+  },
+  "statefulSetOverview": {
+    "currentStatus": "Current Status",
+    "replicaSummary": "Replicas (Ready / Desired / Current)",
+    "notSet": "Not set",
+    "age": "Age",
+    "currentRevision": "Current Revision",
+    "updateRevision": "Update Revision",
+    "pvcRetentionPolicy": "PVC Retention Policy",
+    "minReadySeconds": "Min Ready Seconds"
   },
   "containerEditor": {
     "title": "Edit Container: {{name}}",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -40,6 +40,8 @@
     "copied": "已复制到剪贴板",
     "viewDetails": "查看详情",
     "viewYaml": "查看 YAML",
+    "manageLabels": "管理标签",
+    "manageAnnotations": "管理注解",
     "copyName": "复制名称",
     "copyImage": "复制镜像",
     "desired": "期望",
@@ -1780,6 +1782,16 @@
     "disabled": "已禁用",
     "editContainer": "编辑容器",
     "editContainers": "编辑容器"
+  },
+  "statefulSetOverview": {
+    "currentStatus": "当前状态",
+    "replicaSummary": "副本数（Ready / Desired / Current）",
+    "notSet": "未指定",
+    "age": "运行时长",
+    "currentRevision": "当前修订版本",
+    "updateRevision": "目标修订版本",
+    "pvcRetentionPolicy": "PVC 保留策略",
+    "minReadySeconds": "最小就绪秒数"
   },
   "containerEditor": {
     "title": "编辑容器：{{name}}",

--- a/ui/src/lib/k8s.test.ts
+++ b/ui/src/lib/k8s.test.ts
@@ -7,6 +7,7 @@ import type { CustomResource } from '@/types/api'
 import {
   aggregateContainerResources,
   buildDeploymentOverviewViewModel,
+  buildStatefulSetOverviewViewModel,
   filterPodsOwnedByController,
   filterPodsOwnedByDeployment,
   filterReplicaSetsOwnedByDeployment,
@@ -178,6 +179,96 @@ describe('deployment overview helpers', () => {
     expect(overview.serviceLinksEnabled).toBe(false)
     expect(overview.resourceRequests.memory).toBe('384Mi')
     expect(overview.resourceLimits.cpu).toBe('1500m')
+  })
+})
+
+describe('statefulset overview helpers', () => {
+  const statefulSet = {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: {
+      name: 'db',
+      namespace: 'default',
+      creationTimestamp: '2026-04-15T12:00:00.000Z',
+      generation: 6,
+      labels: {
+        app: 'db',
+      },
+      annotations: {
+        note: 'critical',
+      },
+    },
+    spec: {
+      replicas: 3,
+      serviceName: 'db-headless',
+      podManagementPolicy: 'Parallel',
+      minReadySeconds: 15,
+      persistentVolumeClaimRetentionPolicy: {
+        whenDeleted: 'Retain',
+        whenScaled: 'Delete',
+      },
+      selector: {
+        matchLabels: {
+          app: 'db',
+        },
+      },
+      template: {
+        spec: {
+          hostNetwork: false,
+          schedulerName: 'storage-scheduler',
+          enableServiceLinks: false,
+          containers: [
+            {
+              name: 'db',
+              image: 'postgres:16',
+              resources: {
+                requests: {
+                  cpu: '500m',
+                  memory: '1Gi',
+                },
+                limits: {
+                  cpu: '1',
+                  memory: '2Gi',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    status: {
+      readyReplicas: 2,
+      updatedReplicas: 2,
+      availableReplicas: 2,
+      currentReplicas: 3,
+      replicas: 3,
+      observedGeneration: 5,
+      currentRevision: 'db-6d4f6f7f9',
+      updateRevision: 'db-78bd56fc9',
+    },
+  } as StatefulSet
+
+  it('builds the statefulset overview view model with rollout and pvc metadata', () => {
+    const overview = buildStatefulSetOverviewViewModel(statefulSet)
+
+    expect(overview.status).toBe('Progressing')
+    expect(overview.readyReplicas).toBe(2)
+    expect(overview.specReplicas).toBe(3)
+    expect(overview.currentReplicas).toBe(3)
+    expect(overview.observedGeneration).toBe(5)
+    expect(overview.generation).toBe(6)
+    expect(overview.isObserved).toBe(false)
+    expect(overview.serviceName).toBe('db-headless')
+    expect(overview.podManagementPolicy).toBe('Parallel')
+    expect(overview.minReadySeconds).toBe(15)
+    expect(overview.schedulerName).toBe('storage-scheduler')
+    expect(overview.currentRevision).toBe('db-6d4f6f7f9')
+    expect(overview.updateRevision).toBe('db-78bd56fc9')
+    expect(overview.pvcWhenDeleted).toBe('Retain')
+    expect(overview.pvcWhenScaled).toBe('Delete')
+    expect(overview.serviceLinksEnabled).toBe(false)
+    expect(overview.resourceRequests.memory).toBe('1Gi')
+    expect(overview.resourceLimits.cpu).toBe('1')
   })
 })
 

--- a/ui/src/lib/k8s.ts
+++ b/ui/src/lib/k8s.ts
@@ -20,6 +20,8 @@ import {
   DeploymentStatusType,
   PodStatus,
   SimpleContainer,
+  StatefulSetOverviewStatusType,
+  StatefulSetOverviewViewModel,
 } from '@/types/k8s'
 
 import { getAge } from './utils'
@@ -624,6 +626,113 @@ export function buildDeploymentOverviewViewModel(
       deployment.spec?.template?.spec?.enableServiceLinks !== false,
     labels: deployment.metadata?.labels || {},
     annotations: deployment.metadata?.annotations || {},
+  }
+}
+
+function getStatefulSetOverviewStatus(
+  statefulSet: StatefulSet
+): StatefulSetOverviewStatusType {
+  const desiredReplicas = statefulSet.spec?.replicas || 0
+  const actualReplicas = statefulSet.status?.replicas || 0
+  const readyReplicas = statefulSet.status?.readyReplicas || 0
+  const currentReplicas = statefulSet.status?.currentReplicas || 0
+  const updatedReplicas = statefulSet.status?.updatedReplicas || 0
+  const availableReplicas = statefulSet.status?.availableReplicas || 0
+
+  if (desiredReplicas === 0) {
+    return 'Scaled Down'
+  }
+
+  if (currentReplicas < desiredReplicas) {
+    return 'Pending'
+  }
+
+  if (
+    readyReplicas === desiredReplicas &&
+    updatedReplicas === desiredReplicas &&
+    availableReplicas === desiredReplicas
+  ) {
+    return 'Available'
+  }
+
+  if (
+    actualReplicas > 0 &&
+    (updatedReplicas < desiredReplicas || readyReplicas < desiredReplicas)
+  ) {
+    return 'Progressing'
+  }
+
+  if (actualReplicas === 0 && desiredReplicas > 0) {
+    return 'Not Available'
+  }
+
+  return 'Unknown'
+}
+
+function getStatefulSetStatusTone(
+  status: StatefulSetOverviewStatusType
+): DeploymentOverviewStatusTone {
+  switch (status) {
+    case 'Available':
+      return 'success'
+    case 'Progressing':
+    case 'Pending':
+      return 'warning'
+    case 'Not Available':
+      return 'danger'
+    case 'Scaled Down':
+    case 'Unknown':
+    default:
+      return 'muted'
+  }
+}
+
+export function buildStatefulSetOverviewViewModel(
+  statefulSet: StatefulSet
+): StatefulSetOverviewViewModel {
+  const status = getStatefulSetOverviewStatus(statefulSet)
+  const containers = statefulSet.spec?.template?.spec?.containers
+  const resources = aggregateContainerResources(containers)
+  const generation = statefulSet.metadata?.generation
+  const observedGeneration = statefulSet.status?.observedGeneration
+  const createdAt = statefulSet.metadata?.creationTimestamp
+  const pvcRetentionPolicy =
+    statefulSet.spec?.persistentVolumeClaimRetentionPolicy
+
+  return {
+    status,
+    statusTone: getStatefulSetStatusTone(status),
+    readyReplicas: statefulSet.status?.readyReplicas || 0,
+    specReplicas: statefulSet.spec?.replicas || 0,
+    currentReplicas: statefulSet.status?.currentReplicas || 0,
+    updatedReplicas: statefulSet.status?.updatedReplicas || 0,
+    availableReplicas: statefulSet.status?.availableReplicas || 0,
+    observedGeneration,
+    generation,
+    isObserved:
+      generation === undefined ||
+      observedGeneration === undefined ||
+      observedGeneration >= generation,
+    createdAt,
+    age: createdAt ? getAge(createdAt) : undefined,
+    serviceName: statefulSet.spec?.serviceName,
+    updateStrategy: statefulSet.spec?.updateStrategy?.type || 'RollingUpdate',
+    podManagementPolicy:
+      statefulSet.spec?.podManagementPolicy || 'OrderedReady',
+    minReadySeconds: statefulSet.spec?.minReadySeconds || 0,
+    hostNetwork: statefulSet.spec?.template?.spec?.hostNetwork === true,
+    schedulerName: statefulSet.spec?.template?.spec?.schedulerName,
+    resourceRequests: resources.requests,
+    resourceLimits: resources.limits,
+    selectorLabels: statefulSet.spec?.selector?.matchLabels || {},
+    currentRevision: statefulSet.status?.currentRevision,
+    updateRevision: statefulSet.status?.updateRevision,
+    serviceLinksEnabled:
+      statefulSet.spec?.template?.spec?.enableServiceLinks !== false,
+    pvcWhenDeleted: pvcRetentionPolicy?.whenDeleted,
+    pvcWhenScaled: pvcRetentionPolicy?.whenScaled,
+    labels: statefulSet.metadata?.labels || {},
+    annotations: statefulSet.metadata?.annotations || {},
   }
 }
 

--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Deployment } from 'kubernetes-types/apps/v1'
-import type { Container } from 'kubernetes-types/core/v1'
 import {
   FileCode2,
   FileText,
@@ -19,7 +18,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { patchResource } from '@/lib/api'
-import { aggregateContainerResources, getDeploymentStatus } from '@/lib/k8s'
+import { getDeploymentStatus } from '@/lib/k8s'
 import {
   formatDate,
   formatRelativeTimeStrict,
@@ -45,132 +44,9 @@ import {
   renderMetadataTooltipContent,
 } from '@/components/metadata-action-button'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
+import { ResourceLimitsSummary } from '@/components/resource-limits-summary'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
-
-const cpuUnits: Record<string, number> = {
-  n: 1e-9,
-  u: 1e-6,
-  m: 1e-3,
-  '': 1,
-  k: 1e3,
-  M: 1e6,
-  G: 1e9,
-  T: 1e12,
-  P: 1e15,
-  E: 1e18,
-}
-
-const binaryMemoryUnits: Record<string, number> = {
-  Ki: 1024,
-  Mi: 1024 ** 2,
-  Gi: 1024 ** 3,
-  Ti: 1024 ** 4,
-  Pi: 1024 ** 5,
-  Ei: 1024 ** 6,
-}
-
-const decimalMemoryUnits: Record<string, number> = {
-  '': 1,
-  K: 1e3,
-  M: 1e6,
-  G: 1e9,
-  T: 1e12,
-  P: 1e15,
-  E: 1e18,
-}
-
-function trimTrailingZeros(value: number, fractionDigits: number) {
-  return value.toFixed(fractionDigits).replace(/\.?0+$/, '')
-}
-
-function formatCpuAsCores(value?: string, coreUnitLabel = '核') {
-  if (!value) {
-    return undefined
-  }
-
-  const match = value.trim().match(/^([+-]?\d+(?:\.\d+)?)(n|u|m|k|M|G|T|P|E)?$/)
-  if (!match) {
-    return value
-  }
-
-  const amount = Number(match[1])
-  const suffix = match[2] ?? ''
-  const multiplier = cpuUnits[suffix]
-  if (Number.isNaN(amount) || multiplier === undefined) {
-    return value
-  }
-
-  const cores = amount * multiplier
-  return `${trimTrailingZeros(cores, 1)} ${coreUnitLabel}`
-}
-
-function formatMemoryAsGi(value?: string) {
-  if (!value) {
-    return undefined
-  }
-
-  const match = value
-    .trim()
-    .match(/^([+-]?\d+(?:\.\d+)?)(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$/)
-  if (!match) {
-    return value
-  }
-
-  const amount = Number(match[1])
-  const suffix = match[2] ?? ''
-  if (Number.isNaN(amount)) {
-    return value
-  }
-
-  const bytes =
-    suffix in binaryMemoryUnits
-      ? amount * binaryMemoryUnits[suffix]
-      : amount * (decimalMemoryUnits[suffix] ?? 1)
-
-  const gibibytes = bytes / binaryMemoryUnits.Gi
-  return `${trimTrailingZeros(gibibytes, 1)}Gi`
-}
-
-function ResourceLimitsSummary(props: { containers?: Container[] }) {
-  const { t } = useTranslation()
-  const { containers } = props
-  const limits = aggregateContainerResources(containers).limits
-  const formattedCpu = formatCpuAsCores(
-    limits.cpu,
-    t('namespaceEditDialog.unitCpuCore', '核')
-  )
-  const formattedMemory = formatMemoryAsGi(limits.memory)
-
-  if (!formattedCpu && !formattedMemory) {
-    return <span className="text-sm text-muted-foreground">-</span>
-  }
-
-  return (
-    <div className="flex flex-nowrap items-center gap-1.5 whitespace-nowrap">
-      {formattedCpu ? (
-        <Badge
-          variant="secondary"
-          className="h-6 shrink-0 rounded-full px-2.5 font-mono tabular-nums whitespace-nowrap"
-        >
-          <span className="text-muted-foreground">CPU:</span>
-          <span className="sr-only"> </span>
-          <span className="text-foreground">{formattedCpu}</span>
-        </Badge>
-      ) : null}
-      {formattedMemory ? (
-        <Badge
-          variant="secondary"
-          className="h-6 shrink-0 rounded-full px-2.5 font-mono tabular-nums whitespace-nowrap"
-        >
-          <span className="text-muted-foreground">Memory:</span>
-          <span className="sr-only"> </span>
-          <span className="text-foreground">{formattedMemory}</span>
-        </Badge>
-      ) : null}
-    </div>
-  )
-}
 
 function formatTimestampWithRelative(timestamp?: string) {
   if (!timestamp) {

--- a/ui/src/pages/statefulset-detail.tsx
+++ b/ui/src/pages/statefulset-detail.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
-  IconCircleCheckFilled,
-  IconExclamationCircle,
   IconLoader,
   IconReload,
   IconScale,
@@ -13,10 +11,14 @@ import { Container } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { updateResource, useResource, useResourcesWatch } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
-import { filterPodsOwnedByController } from '@/lib/k8s'
-import { formatDate, translateError } from '@/lib/utils'
+import { updateResource, useResource, useResourcesWatch } from '@/lib/api'
+import {
+  buildStatefulSetOverviewViewModel,
+  filterPodsOwnedByController,
+  toSimpleContainer,
+} from '@/lib/k8s'
+import { translateError } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -28,18 +30,18 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
-import { RefreshButton } from '@/components/refresh-button'
 import { ContainerTable } from '@/components/container-table'
 import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
-import { LabelsAnno } from '@/components/lables-anno'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
+import { StatefulSetOverviewInfoCard } from '@/components/statefulset-overview-info-card'
 import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
@@ -303,13 +305,7 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
   }
 
   const { metadata, spec, status } = statefulset
-  const readyReplicas = status?.readyReplicas || 0
-  const replicas = status?.replicas || 0
-  const currentReplicas = status?.currentReplicas || 0
-  const updatedReplicas = status?.updatedReplicas || 0
-
-  const isAvailable = readyReplicas === replicas && replicas > 0
-  const isPending = currentReplicas < replicas
+  const overview = buildStatefulSetOverviewViewModel(statefulset)
 
   return (
     <div className="space-y-2">
@@ -436,118 +432,16 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
             label: t('detail.tabs.overview'),
             content: (
               <div className="space-y-6">
-                {/* Status Overview */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle>{t('detail.sections.statusOverview')}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-4">
-                      <div className="flex items-center gap-3">
-                        <div className="flex items-center gap-2">
-                          {isPending ? (
-                            <IconExclamationCircle className="w-4 h-4 fill-gray-500" />
-                          ) : isAvailable ? (
-                            <IconCircleCheckFilled className="w-4 h-4 fill-green-500" />
-                          ) : (
-                            <IconLoader className="w-4 h-4 animate-spin fill-amber-500" />
-                          )}
-                        </div>
-                        <div>
-                          <p className="text-xs text-muted-foreground">
-                            {t('common.status')}
-                          </p>
-                          <p className="text-sm font-medium">
-                            {isPending
-                              ? 'Pending'
-                              : isAvailable
-                                ? t('deployments.available')
-                                : t('detail.status.inProgress')}
-                          </p>
-                        </div>
-                      </div>
-
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          {t('detail.fields.readyReplicas')}
-                        </p>
-                        <p className="text-sm font-medium">
-                          {readyReplicas} / {replicas}
-                        </p>
-                      </div>
-
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          {t('detail.fields.currentReplicas')}
-                        </p>
-                        <p className="text-sm font-medium">{currentReplicas}</p>
-                      </div>
-
-                      <div>
-                        <p className="text-xs text-muted-foreground">
-                          {t('detail.fields.updatedReplicas')}
-                        </p>
-                        <p className="text-sm font-medium">{updatedReplicas}</p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                {/* StatefulSet Information */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle>
-                      {t('detail.sections.statefulSetInformation')}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div>
-                        <Label className="text-sm font-medium">
-                          {t('detail.fields.created')}
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          {formatDate(metadata?.creationTimestamp || '')}
-                        </p>
-                      </div>
-                      <div>
-                        <Label className="text-sm font-medium">
-                          {t('detail.fields.serviceName')}
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          {spec?.serviceName || 'N/A'}
-                        </p>
-                      </div>
-                      <div>
-                        <Label className="text-sm font-medium">
-                          {t('detail.fields.updateStrategy')}
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          {spec?.updateStrategy?.type || 'RollingUpdate'}
-                        </p>
-                      </div>
-                      <div>
-                        <Label className="text-sm font-medium">
-                          {t('detail.fields.podManagementPolicy')}
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          {spec?.podManagementPolicy || 'OrderedReady'}
-                        </p>
-                      </div>
-                    </div>
-                    <LabelsAnno
-                      labels={metadata?.labels || {}}
-                      annotations={metadata?.annotations || {}}
-                    />
-                  </CardContent>
-                </Card>
+                <StatefulSetOverviewInfoCard overview={overview} />
 
                 {/* Init Containers */}
-                {spec?.template?.spec?.initContainers && (
+                {spec?.template?.spec?.initContainers &&
+                spec.template.spec.initContainers.length > 0 ? (
                   <Card>
                     <CardHeader>
                       <CardTitle>
-                        {t('detail.sections.initContainers')}
+                        {t('detail.sections.initContainers')} (
+                        {spec.template.spec.initContainers.length})
                       </CardTitle>
                     </CardHeader>
                     <CardContent>
@@ -567,13 +461,16 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
                       </div>
                     </CardContent>
                   </Card>
-                )}
+                ) : null}
 
                 {/* Containers */}
-                {spec?.template?.spec?.containers && (
+                {spec?.template?.spec?.containers ? (
                   <Card>
                     <CardHeader>
-                      <CardTitle>{t('detail.sections.containers')}</CardTitle>
+                      <CardTitle>
+                        {t('detail.sections.containers')} (
+                        {spec.template.spec.containers.length})
+                      </CardTitle>
                     </CardHeader>
                     <CardContent>
                       <div className="space-y-4">
@@ -589,7 +486,50 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
                       </div>
                     </CardContent>
                   </Card>
-                )}
+                ) : null}
+
+                {relatedPods ? (
+                  <PodTable
+                    pods={relatedPods}
+                    isLoading={isLoadingPods}
+                    labelSelector={labelSelector}
+                    title={
+                      <>
+                        Pods{' '}
+                        <Badge variant="secondary">{relatedPods.length}</Badge>
+                      </>
+                    }
+                  />
+                ) : null}
+
+                {status?.conditions && status.conditions.length > 0 ? (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>{t('detail.sections.conditions')}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-2">
+                        {status.conditions.map((condition, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center gap-3 rounded border p-2"
+                          >
+                            <Badge
+                              variant={
+                                condition.status === 'True'
+                                  ? 'default'
+                                  : 'secondary'
+                              }
+                            >
+                              {condition.type}
+                            </Badge>
+                            <span className="text-sm">{condition.message}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ) : null}
               </div>
             ),
           },
@@ -611,24 +551,6 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
           },
           ...(relatedPods
             ? [
-                {
-                  value: 'pods',
-                  label: (
-                    <>
-                      Pods{' '}
-                      {relatedPods && (
-                        <Badge variant="secondary">{relatedPods.length}</Badge>
-                      )}
-                    </>
-                  ),
-                  content: (
-                    <PodTable
-                      pods={relatedPods}
-                      isLoading={isLoadingPods}
-                      labelSelector={labelSelector}
-                    />
-                  ),
-                },
                 {
                   value: 'logs',
                   label: t('detail.tabs.logs'),
@@ -681,7 +603,10 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
                       <VolumeTable
                         namespace={namespace}
                         volumes={spec.template.spec?.volumes}
-                        containers={spec.template.spec?.containers}
+                        containers={toSimpleContainer(
+                          spec.template.spec?.initContainers,
+                          spec.template.spec?.containers
+                        )}
                         isLoading={isLoadingStatefulSet}
                       />
                     </div>

--- a/ui/src/pages/statefulset-list-page.test.tsx
+++ b/ui/src/pages/statefulset-list-page.test.tsx
@@ -186,7 +186,6 @@ describe('StatefulSetListPage', () => {
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
       'edit-image',
-      'pause-orchestration',
       'rollout-restart',
       'rollback',
       'metadata-actions-separator',
@@ -194,7 +193,7 @@ describe('StatefulSetListPage', () => {
       'manage-annotations',
       'delete-statefulset',
     ])
-    expect(items[4].label).toBe('deploymentList.rollback')
+    expect(items[3].label).toBe('deploymentList.rollback')
 
     await items[0].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -207,28 +206,28 @@ describe('StatefulSetListPage', () => {
     expect(screen.getByText('container-edit-dialog')).toBeInTheDocument()
 
     await act(async () => {
-      await items[6].onSelect?.()
+      await items[5].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-labels')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[7].onSelect?.()
+      await items[6].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-annotations')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[8].onSelect?.()
+      await items[7].onSelect?.()
     })
     expect(
       screen.getByText('resource-delete-confirmation-dialog')
     ).toBeInTheDocument()
   })
 
-  it('keeps pause orchestration disabled and patches image edits from row actions', async () => {
+  it('patches statefulset image edits from row actions', async () => {
     vi.useRealTimers()
     mockPatchResource.mockResolvedValue(undefined)
 
@@ -237,7 +236,6 @@ describe('StatefulSetListPage', () => {
     const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
       getRowContextMenuItems: (statefulSet: StatefulSet) => {
         key: string
-        disabled?: boolean
         onSelect?: () => void | Promise<void>
       }[]
     }
@@ -263,9 +261,6 @@ describe('StatefulSetListPage', () => {
     } as StatefulSet
 
     const items = resourceTableProps.getRowContextMenuItems(statefulSet)
-
-    expect(items[2].key).toBe('pause-orchestration')
-    expect(items[2].disabled).toBe(true)
 
     await act(async () => {
       await items[1].onSelect?.()

--- a/ui/src/pages/statefulset-list-page.test.tsx
+++ b/ui/src/pages/statefulset-list-page.test.tsx
@@ -1,0 +1,299 @@
+import { type ReactNode } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { StatefulSet } from 'kubernetes-types/apps/v1'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StatefulSetListPage } from './statefulset-list-page'
+
+const mockNavigate = vi.fn()
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+const mockInvalidateQueries = vi.fn()
+const mockPatchResource = vi.fn()
+const mockT = (key: string) => key
+const mockResourceTable = vi.fn(() => <div>statefulset-table</div>)
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: mockT,
+    }),
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: ReactNode; to: string }) => (
+      <a href={to}>{children}</a>
+    ),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query'
+  )
+
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  patchResource: (...args: unknown[]) => mockPatchResource(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (value: string) => mockToastSuccess(value),
+    error: (value: string) => mockToastError(value),
+  },
+}))
+
+vi.mock('@/components/resource-table', () => ({
+  ResourceTable: (props: unknown) => mockResourceTable(props),
+}))
+
+vi.mock('@/components/editors/resource-metadata-dialog', () => ({
+  ResourceMetadataDialog: ({
+    open,
+    type,
+    resource,
+  }: {
+    open: boolean
+    type: 'labels' | 'annotations'
+    resource?: { metadata?: { name?: string } } | null
+  }) =>
+    open ? (
+      <div>
+        <span>{`resource-metadata-dialog-${type}`}</span>
+        <span>{resource?.metadata?.name}</span>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/container-edit-dialog', () => ({
+  ContainerEditDialog: ({
+    open,
+    workload,
+    onSaveWorkload,
+  }: {
+    open: boolean
+    workload?: { metadata?: { name?: string } }
+    onSaveWorkload?: (statefulSet: StatefulSet) => void | Promise<void>
+  }) =>
+    open ? (
+      <div>
+        <span>container-edit-dialog</span>
+        <span>{workload?.metadata?.name}</span>
+        <button
+          onClick={() =>
+            onSaveWorkload?.({
+              metadata: workload?.metadata,
+              spec: {
+                template: {
+                  spec: {
+                    containers: [
+                      {
+                        name: 'mysql',
+                        image: 'mysql:8.4',
+                      },
+                    ],
+                  },
+                },
+              },
+            } as StatefulSet)
+          }
+        >
+          save-container-edit
+        </button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
+  ResourceDeleteConfirmationDialog: ({
+    open,
+    resourceName,
+  }: {
+    open: boolean
+    resourceName: string
+  }) =>
+    open ? (
+      <div>
+        <span>resource-delete-confirmation-dialog</span>
+        <span>{resourceName}</span>
+      </div>
+    ) : null,
+}))
+
+describe('StatefulSetListPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T10:00:00.000Z'))
+    mockNavigate.mockReset()
+    mockToastSuccess.mockReset()
+    mockToastError.mockReset()
+    mockInvalidateQueries.mockReset()
+    mockPatchResource.mockReset()
+    mockResourceTable.mockClear()
+  })
+
+  it('provides the requested row action sequence for statefulset rows', async () => {
+    render(<StatefulSetListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      getRowContextMenuItems: (statefulSet: StatefulSet) => {
+        key: string
+        label?: string
+        onSelect?: () => void | Promise<void>
+      }[]
+    }
+
+    const statefulSet = {
+      metadata: {
+        name: 'mysql',
+        namespace: 'default',
+      },
+      spec: {
+        paused: false,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'mysql',
+                image: 'mysql:8.0',
+              },
+            ],
+          },
+        },
+      },
+    } as StatefulSet
+
+    const items = resourceTableProps.getRowContextMenuItems(statefulSet)
+
+    expect(items.map((item) => item.key)).toEqual([
+      'view-yaml',
+      'edit-image',
+      'pause-orchestration',
+      'rollout-restart',
+      'rollback',
+      'metadata-actions-separator',
+      'manage-labels',
+      'manage-annotations',
+      'delete-statefulset',
+    ])
+    expect(items[4].label).toBe('deploymentList.rollback')
+
+    await items[0].onSelect?.()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/statefulsets/default/mysql?tab=yaml'
+    )
+
+    await act(async () => {
+      await items[1].onSelect?.()
+    })
+    expect(screen.getByText('container-edit-dialog')).toBeInTheDocument()
+
+    await act(async () => {
+      await items[6].onSelect?.()
+    })
+    expect(
+      screen.getByText('resource-metadata-dialog-labels')
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      await items[7].onSelect?.()
+    })
+    expect(
+      screen.getByText('resource-metadata-dialog-annotations')
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      await items[8].onSelect?.()
+    })
+    expect(
+      screen.getByText('resource-delete-confirmation-dialog')
+    ).toBeInTheDocument()
+  })
+
+  it('keeps pause orchestration disabled and patches image edits from row actions', async () => {
+    vi.useRealTimers()
+    mockPatchResource.mockResolvedValue(undefined)
+
+    render(<StatefulSetListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      getRowContextMenuItems: (statefulSet: StatefulSet) => {
+        key: string
+        disabled?: boolean
+        onSelect?: () => void | Promise<void>
+      }[]
+    }
+
+    const statefulSet = {
+      metadata: {
+        name: 'mysql',
+        namespace: 'default',
+      },
+      spec: {
+        paused: false,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'mysql',
+                image: 'mysql:8.0',
+              },
+            ],
+          },
+        },
+      },
+    } as StatefulSet
+
+    const items = resourceTableProps.getRowContextMenuItems(statefulSet)
+
+    expect(items[2].key).toBe('pause-orchestration')
+    expect(items[2].disabled).toBe(true)
+
+    await act(async () => {
+      await items[1].onSelect?.()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByText('save-container-edit'))
+    })
+    await waitFor(() => {
+      expect(mockPatchResource).toHaveBeenCalledWith(
+        'statefulsets',
+        'mysql',
+        'default',
+        {
+          spec: {
+            template: {
+              spec: {
+                containers: [
+                  {
+                    name: 'mysql',
+                    image: 'mysql:8.4',
+                  },
+                ],
+              },
+            },
+          },
+        }
+      )
+    })
+  })
+
+})

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -1,18 +1,69 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { IconCircleCheckFilled, IconLoader } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { StatefulSet } from 'kubernetes-types/apps/v1'
+import {
+  FileCode2,
+  FileText,
+  History,
+  RefreshCcw,
+  Tags,
+  Trash2,
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
 
-import { formatDate } from '@/lib/utils'
+import { patchResource } from '@/lib/api'
+import {
+  formatDate,
+  formatRelativeTimeStrict,
+  translateError,
+} from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ContainerImagesSummary } from '@/components/container-images-summary'
+import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
+import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
+import { ResourceLimitsSummary } from '@/components/resource-limits-summary'
 import { ResourceTable } from '@/components/resource-table'
+import { RowContextMenuItem } from '@/components/row-context-menu'
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
 
 export function StatefulSetListPage() {
   const { t } = useTranslation()
-  // Define column helper outside of any hooks
-  const columnHelper = createColumnHelper<StatefulSet>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [labelsStatefulSet, setLabelsStatefulSet] =
+    useState<StatefulSet | null>(null)
+  const [annotationsStatefulSet, setAnnotationsStatefulSet] =
+    useState<StatefulSet | null>(null)
+  const [restartStatefulSetTarget, setRestartStatefulSetTarget] =
+    useState<StatefulSet | null>(null)
+  const [deleteStatefulSetTarget, setDeleteStatefulSetTarget] =
+    useState<StatefulSet | null>(null)
+  const [isRestarting, setIsRestarting] = useState(false)
+  const columnHelper = useMemo(() => createColumnHelper<StatefulSet>(), [])
 
   // Define columns for the statefulset table
   const columns = useMemo(
@@ -81,13 +132,64 @@ export function StatefulSetListPage() {
         header: t('detail.fields.serviceName'),
         cell: ({ getValue }) => getValue() || '-',
       }),
+      columnHelper.display({
+        id: 'labels',
+        header: t('detail.fields.labels'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="labels"
+            ariaLabel={t('common.manageLabels', 'Manage labels')}
+            count={Object.keys(row.original.metadata?.labels || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.labels
+            )}
+            onClick={() => setLabelsStatefulSet(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'annotations',
+        header: t('detail.fields.annotations'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="annotations"
+            ariaLabel={t('common.manageAnnotations', 'Manage annotations')}
+            count={Object.keys(row.original.metadata?.annotations || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.annotations
+            )}
+            onClick={() => setAnnotationsStatefulSet(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'containers-and-images',
+        header: t('deploymentOverview.containersAndImages'),
+        cell: ({ row }) => (
+          <ContainerImagesSummary
+            containers={row.original.spec?.template?.spec?.containers}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'resource-limits',
+        header: t('deploymentOverview.resourceLimits'),
+        cell: ({ row }) => (
+          <ResourceLimitsSummary
+            containers={row.original.spec?.template?.spec?.containers}
+          />
+        ),
+      }),
       columnHelper.accessor('metadata.creationTimestamp', {
+        id: 'created',
         header: t('common.created'),
         cell: ({ getValue }) => {
-          const dateStr = formatDate(getValue() || '')
-
           return (
-            <span className="text-muted-foreground text-sm">{dateStr}</span>
+            <span className="text-muted-foreground text-sm">
+              {formatTimestampWithRelative(getValue())}
+            </span>
           )
         },
       }),
@@ -103,21 +205,203 @@ export function StatefulSetListPage() {
         (statefulSet.metadata!.namespace?.toLowerCase() || '').includes(
           query
         ) ||
-        (statefulSet.spec!.serviceName?.toLowerCase() || '').includes(query)
+        (statefulSet.spec!.serviceName?.toLowerCase() || '').includes(query) ||
+        Object.entries(statefulSet.metadata?.labels || {}).some(
+          ([key, value]) =>
+            key.toLowerCase().includes(query) ||
+            value.toLowerCase().includes(query)
+        ) ||
+        Object.entries(statefulSet.metadata?.annotations || {}).some(
+          ([key, value]) =>
+            key.toLowerCase().includes(query) ||
+            value.toLowerCase().includes(query)
+        ) ||
+        (statefulSet.spec?.template?.spec?.containers || []).some(
+          (container) =>
+            container.name.toLowerCase().includes(query) ||
+            (container.image || '').toLowerCase().includes(query)
+        )
       )
     },
     []
   )
 
+  const getStatefulSetDetailPath = useCallback((statefulSet: StatefulSet) => {
+    return `/statefulsets/${statefulSet.metadata!.namespace}/${statefulSet.metadata!.name}`
+  }, [])
+
+  const refreshStatefulSetList = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['statefulsets'] })
+  }, [queryClient])
+
+  const handleRestart = useCallback(async () => {
+    if (
+      !restartStatefulSetTarget?.metadata?.name ||
+      !restartStatefulSetTarget.metadata?.namespace
+    ) {
+      return
+    }
+
+    setIsRestarting(true)
+    try {
+      await patchResource(
+        'statefulsets',
+        restartStatefulSetTarget.metadata.name,
+        restartStatefulSetTarget.metadata.namespace,
+        {
+          spec: {
+            template: {
+              metadata: {
+                annotations: {
+                  'kite.kubernetes.io/restartedAt': new Date().toISOString(),
+                },
+              },
+            },
+          },
+        }
+      )
+      toast.success('StatefulSet restart initiated')
+      setRestartStatefulSetTarget(null)
+      await refreshStatefulSetList()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsRestarting(false)
+    }
+  }, [refreshStatefulSetList, restartStatefulSetTarget, t])
+
+  const getRowContextMenuItems = useCallback(
+    (statefulSet: StatefulSet): RowContextMenuItem<StatefulSet>[] => {
+      const detailPath = getStatefulSetDetailPath(statefulSet)
+
+      return [
+        {
+          key: 'view-yaml',
+          label: t('common.viewYaml', 'View YAML'),
+          icon: <FileCode2 className="h-4 w-4" />,
+          onSelect: () => navigate(`${detailPath}?tab=yaml`),
+        },
+        {
+          key: 'rollout-restart',
+          label: t('deploymentList.rolloutRestart'),
+          icon: <RefreshCcw className="h-4 w-4" />,
+          onSelect: () => setRestartStatefulSetTarget(statefulSet),
+        },
+        {
+          key: 'history',
+          label: t('detail.tabs.history'),
+          icon: <History className="h-4 w-4" />,
+          onSelect: () => navigate(`${detailPath}?tab=history`),
+        },
+        { type: 'separator', key: 'metadata-actions-separator' },
+        {
+          key: 'manage-labels',
+          label: t('common.manageLabels', 'Manage labels'),
+          icon: <Tags className="h-4 w-4" />,
+          onSelect: () => setLabelsStatefulSet(statefulSet),
+        },
+        {
+          key: 'manage-annotations',
+          label: t('common.manageAnnotations', 'Manage annotations'),
+          icon: <FileText className="h-4 w-4" />,
+          onSelect: () => setAnnotationsStatefulSet(statefulSet),
+        },
+        {
+          key: 'delete-statefulset',
+          label: t('common.delete'),
+          icon: <Trash2 className="h-4 w-4" />,
+          variant: 'destructive',
+          onSelect: () => setDeleteStatefulSetTarget(statefulSet),
+        },
+      ]
+    },
+    [getStatefulSetDetailPath, navigate, t]
+  )
+
   return (
-    <ResourceTable
-      resourceName={'StatefulSets'}
-      resourceType="statefulsets"
-      columns={columns}
-      searchQueryFilter={statefulSetSearchFilter}
-      batchDeleteConfirmationValue={t(
-        'deleteConfirmation.confirmDeleteKeyword'
-      )}
-    />
+    <>
+      <ResourceTable
+        resourceName={'StatefulSets'}
+        resourceType="statefulsets"
+        columns={columns}
+        searchQueryFilter={statefulSetSearchFilter}
+        getRowContextMenuItems={getRowContextMenuItems}
+        batchDeleteConfirmationValue={t(
+          'deleteConfirmation.confirmDeleteKeyword'
+        )}
+      />
+
+      <Dialog
+        open={Boolean(restartStatefulSetTarget)}
+        onOpenChange={(open) => {
+          if (!open && !isRestarting) {
+            setRestartStatefulSetTarget(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('aiChat.action.restart', {
+                target:
+                  restartStatefulSetTarget?.metadata?.name || 'StatefulSet',
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('detail.dialogs.restartDeployment.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRestartStatefulSetTarget(null)}
+              disabled={isRestarting}
+            >
+              {t('detail.buttons.cancel')}
+            </Button>
+            <Button onClick={handleRestart} disabled={isRestarting}>
+              {t('detail.dialogs.restartDeployment.restartButton')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ResourceMetadataDialog
+        open={Boolean(labelsStatefulSet)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setLabelsStatefulSet(null)
+          }
+        }}
+        resourceType="statefulsets"
+        resource={labelsStatefulSet}
+        type="labels"
+      />
+
+      <ResourceMetadataDialog
+        open={Boolean(annotationsStatefulSet)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAnnotationsStatefulSet(null)
+          }
+        }}
+        resourceType="statefulsets"
+        resource={annotationsStatefulSet}
+        type="annotations"
+      />
+
+      <ResourceDeleteConfirmationDialog
+        open={Boolean(deleteStatefulSetTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteStatefulSetTarget(null)
+          }
+        }}
+        resourceName={deleteStatefulSetTarget?.metadata?.name || ''}
+        resourceType="statefulsets"
+        namespace={deleteStatefulSetTarget?.metadata?.namespace}
+        confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
+      />
+    </>
   )
 }

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -8,7 +8,6 @@ import {
   FileText,
   History,
   Image,
-  Pause,
   RefreshCcw,
   Tags,
   Trash2,
@@ -317,13 +316,6 @@ export function StatefulSetListPage() {
           label: t('deploymentList.editImage'),
           icon: <Image className="h-4 w-4" />,
           onSelect: () => setImageStatefulSetTarget(statefulSet),
-        },
-        {
-          key: 'pause-orchestration',
-          label: t('deploymentList.pauseOrchestration'),
-          icon: <Pause className="h-4 w-4" />,
-          disabled: true,
-          onSelect: () => undefined,
         },
         {
           key: 'rollout-restart',

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -7,6 +7,8 @@ import {
   FileCode2,
   FileText,
   History,
+  Image,
+  Pause,
   RefreshCcw,
   Tags,
   Trash2,
@@ -21,6 +23,7 @@ import {
   formatRelativeTimeStrict,
   translateError,
 } from '@/lib/utils'
+import { WorkloadWithPodTemplate } from '@/hooks/use-deployment-container-editor'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -31,6 +34,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { ContainerEditDialog } from '@/components/container-edit-dialog'
 import { ContainerImagesSummary } from '@/components/container-images-summary'
 import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
 import {
@@ -59,6 +63,8 @@ export function StatefulSetListPage() {
   const [annotationsStatefulSet, setAnnotationsStatefulSet] =
     useState<StatefulSet | null>(null)
   const [restartStatefulSetTarget, setRestartStatefulSetTarget] =
+    useState<StatefulSet | null>(null)
+  const [imageStatefulSetTarget, setImageStatefulSetTarget] =
     useState<StatefulSet | null>(null)
   const [deleteStatefulSetTarget, setDeleteStatefulSetTarget] =
     useState<StatefulSet | null>(null)
@@ -270,6 +276,31 @@ export function StatefulSetListPage() {
     }
   }, [refreshStatefulSetList, restartStatefulSetTarget, t])
 
+  const handleContainerEditorSave = useCallback(
+    async (updatedWorkload: WorkloadWithPodTemplate) => {
+      if (
+        !imageStatefulSetTarget?.metadata?.name ||
+        !imageStatefulSetTarget.metadata?.namespace
+      ) {
+        return
+      }
+
+      await patchResource(
+        'statefulsets',
+        imageStatefulSetTarget.metadata.name,
+        imageStatefulSetTarget.metadata.namespace,
+        {
+          spec: {
+            template: updatedWorkload.spec?.template,
+          },
+        }
+      )
+      toast.success(t('deploymentList.imageUpdateInitiated'))
+      await refreshStatefulSetList()
+    },
+    [imageStatefulSetTarget, refreshStatefulSetList, t]
+  )
+
   const getRowContextMenuItems = useCallback(
     (statefulSet: StatefulSet): RowContextMenuItem<StatefulSet>[] => {
       const detailPath = getStatefulSetDetailPath(statefulSet)
@@ -282,14 +313,27 @@ export function StatefulSetListPage() {
           onSelect: () => navigate(`${detailPath}?tab=yaml`),
         },
         {
+          key: 'edit-image',
+          label: t('deploymentList.editImage'),
+          icon: <Image className="h-4 w-4" />,
+          onSelect: () => setImageStatefulSetTarget(statefulSet),
+        },
+        {
+          key: 'pause-orchestration',
+          label: t('deploymentList.pauseOrchestration'),
+          icon: <Pause className="h-4 w-4" />,
+          disabled: true,
+          onSelect: () => undefined,
+        },
+        {
           key: 'rollout-restart',
           label: t('deploymentList.rolloutRestart'),
           icon: <RefreshCcw className="h-4 w-4" />,
           onSelect: () => setRestartStatefulSetTarget(statefulSet),
         },
         {
-          key: 'history',
-          label: t('detail.tabs.history'),
+          key: 'rollback',
+          label: t('deploymentList.rollback'),
           icon: <History className="h-4 w-4" />,
           onSelect: () => navigate(`${detailPath}?tab=history`),
         },
@@ -389,6 +433,21 @@ export function StatefulSetListPage() {
         resource={annotationsStatefulSet}
         type="annotations"
       />
+
+      {imageStatefulSetTarget ? (
+        <ContainerEditDialog
+          open={Boolean(imageStatefulSetTarget)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setImageStatefulSetTarget(null)
+            }
+          }}
+          mode="deployment"
+          workload={imageStatefulSetTarget}
+          namespace={imageStatefulSetTarget.metadata?.namespace || ''}
+          onSaveWorkload={handleContainerEditorSave}
+        />
+      ) : null}
 
       <ResourceDeleteConfirmationDialog
         open={Boolean(deleteStatefulSetTarget)}

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -55,6 +55,45 @@ export type DeploymentOverviewViewModel = {
   annotations: Record<string, string>
 }
 
+export type StatefulSetOverviewStatusType =
+  | 'Available'
+  | 'Progressing'
+  | 'Pending'
+  | 'Scaled Down'
+  | 'Not Available'
+  | 'Unknown'
+
+export type StatefulSetOverviewViewModel = {
+  status: StatefulSetOverviewStatusType
+  statusTone: DeploymentOverviewStatusTone
+  readyReplicas: number
+  specReplicas: number
+  currentReplicas: number
+  updatedReplicas: number
+  availableReplicas: number
+  observedGeneration?: number
+  generation?: number
+  isObserved: boolean
+  createdAt?: string
+  age?: string
+  serviceName?: string
+  updateStrategy: string
+  podManagementPolicy: string
+  minReadySeconds: number
+  hostNetwork: boolean
+  schedulerName?: string
+  resourceRequests: DeploymentResourceSummaryValue
+  resourceLimits: DeploymentResourceSummaryValue
+  selectorLabels: Record<string, string>
+  currentRevision?: string
+  updateRevision?: string
+  serviceLinksEnabled: boolean
+  pvcWhenDeleted?: string
+  pvcWhenScaled?: string
+  labels: Record<string, string>
+  annotations: Record<string, string>
+}
+
 /**
  * @link https://kubernetes.io/docs/reference/node/node-status/#condition
  */


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StatefulSet overview card with status, replicas, revisions, resources and links
  * Expanded StatefulSet list: labels/annotations management, image editing, rollout restart, richer columns and improved search
  * Resource limits summary component for containers
  * Container edit dialog supports editing multiple workload types
* **Behavior**
  * Pod events are now merged into StatefulSet event listings (deduplicated, time‑sorted)
* **Localization**
  * Added i18n strings for stateful set overview and manage labels/annotations
* **Tests**
  * New unit tests for StatefulSet overview and list behaviors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/99)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->