### PR TITLE
feat: add YAML diff dialog for reviewing changes before saving

### DIFF
--- a/ui/src/components/global-search-provider.test.tsx
+++ b/ui/src/components/global-search-provider.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { GlobalSearchProvider, useGlobalSearch } from './global-search-provider'
+
 const { trackDesktopEvent } = vi.hoisted(() => ({
   trackDesktopEvent: vi.fn(),
 }))
@@ -8,8 +10,6 @@ const { trackDesktopEvent } = vi.hoisted(() => ({
 vi.mock('@/lib/analytics', () => ({
   trackDesktopEvent,
 }))
-
-import { GlobalSearchProvider, useGlobalSearch } from './global-search-provider'
 
 function createStorage() {
   let store: Record<string, string> = {}
@@ -51,6 +51,10 @@ function GlobalSearchConsumer() {
       <button type="button" onClick={closeSearch}>
         close
       </button>
+      <textarea
+        aria-label="event-trap"
+        onKeyDown={(event) => event.stopPropagation()}
+      />
     </div>
   )
 }
@@ -94,6 +98,28 @@ describe('GlobalSearchProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('state')).toHaveTextContent('closed')
       expect(screen.getByTestId('mode')).toHaveTextContent('all')
+    })
+  })
+
+  it('opens global search before focused content can stop keydown bubbling', async () => {
+    trackDesktopEvent.mockReset()
+    render(
+      <GlobalSearchProvider>
+        <GlobalSearchConsumer />
+      </GlobalSearchProvider>
+    )
+
+    const trappedInput = screen.getByLabelText('event-trap')
+    trappedInput.focus()
+    fireEvent.keyDown(trappedInput, { key: 'k', metaKey: true })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state')).toHaveTextContent('open')
+      expect(screen.getByTestId('mode')).toHaveTextContent('all')
+    })
+    expect(trackDesktopEvent).toHaveBeenCalledWith('global_search_open', {
+      mode: 'all',
+      entry: 'shortcut',
     })
   })
 })

--- a/ui/src/components/global-search-provider.tsx
+++ b/ui/src/components/global-search-provider.tsx
@@ -79,7 +79,11 @@ export function GlobalSearchProvider({ children }: GlobalSearchProviderProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Command+Shift+K or Ctrl+Shift+K to open cluster switcher
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'k') {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === 'k'
+      ) {
         e.preventDefault()
         openSearch('cluster', 'shortcut')
         return
@@ -98,8 +102,8 @@ export function GlobalSearchProvider({ children }: GlobalSearchProviderProps) {
       }
     }
 
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
   }, [closeSearch, isOpen, openSearch])
 
   const value = {

--- a/ui/src/components/yaml-diff-dialog.tsx
+++ b/ui/src/components/yaml-diff-dialog.tsx
@@ -1,0 +1,126 @@
+import { Suspense } from 'react'
+import type { editor as monacoEditor } from 'monaco-editor'
+import { useTranslation } from 'react-i18next'
+
+import { MonacoDiffEditor } from '@/lib/monaco-loader'
+import {
+  defineMonacoBackgroundThemes,
+  useMonacoBackgroundColor,
+} from '@/lib/monaco-theme'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+import { useAppearance } from './appearance-provider'
+
+interface YamlDiffDialogProps {
+  open: boolean
+  original: string
+  modified: string
+  isSaving?: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  onContinueEditing: () => void
+}
+
+export function YamlDiffDialog({
+  open,
+  original,
+  modified,
+  isSaving = false,
+  onOpenChange,
+  onConfirm,
+  onContinueEditing,
+}: YamlDiffDialogProps) {
+  const { t } = useTranslation()
+  const { actualTheme, colorTheme } = useAppearance()
+  const themeMode = actualTheme === 'dark' ? 'dark' : 'light'
+  const backgroundColor = useMonacoBackgroundColor(
+    '--background',
+    themeMode,
+    colorTheme
+  )
+
+  const handleEditorDidMount = (editor: monacoEditor.IStandaloneDiffEditor) => {
+    editor.updateOptions({ readOnly: true })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="!max-w-6xl sm:!max-w-6xl max-h-[85vh] flex min-h-0 flex-col">
+        <DialogHeader>
+          <DialogTitle>{t('yamlEditor.diffTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('yamlEditor.diffDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-hidden rounded-md border">
+          <Suspense
+            fallback={
+              <div className="flex h-[60vh] items-center justify-center text-muted-foreground">
+                {t('yamlEditor.loadingEditor')}
+              </div>
+            }
+          >
+            <MonacoDiffEditor
+              key={`yaml-save-diff-${colorTheme}-${actualTheme}-${backgroundColor}`}
+              height="60vh"
+              language="yaml"
+              beforeMount={(monaco) => {
+                defineMonacoBackgroundThemes(monaco, {
+                  darkThemeName: `custom-dark-${colorTheme}`,
+                  lightThemeName: `custom-vs-${colorTheme}`,
+                  backgroundColor,
+                })
+              }}
+              theme={
+                actualTheme === 'dark'
+                  ? `custom-dark-${colorTheme}`
+                  : `custom-vs-${colorTheme}`
+              }
+              original={original}
+              modified={modified}
+              onMount={handleEditorDidMount}
+              options={{
+                readOnly: true,
+                minimap: { enabled: true },
+                scrollBeyondLastLine: false,
+                wordWrap: 'on',
+                folding: true,
+                lineNumbers: 'on',
+                fontSize: 14,
+                fontFamily:
+                  "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
+                renderSideBySide: true,
+                enableSplitViewResizing: true,
+                renderOverviewRuler: true,
+                overviewRulerBorder: true,
+                overviewRulerLanes: 2,
+                automaticLayout: true,
+              }}
+            />
+          </Suspense>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onContinueEditing}
+            disabled={isSaving}
+          >
+            {t('yamlEditor.continueEditing')}
+          </Button>
+          <Button type="button" onClick={onConfirm} disabled={isSaving}>
+            {isSaving ? t('yamlEditor.saving') : t('yamlEditor.confirmSave')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/yaml-editor.test.tsx
+++ b/ui/src/components/yaml-editor.test.tsx
@@ -1,0 +1,172 @@
+import '@/i18n'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { YamlEditor } from './yaml-editor'
+
+const originalYaml =
+  'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n'
+
+vi.mock('@/lib/monaco-loader', () => ({
+  MonacoEditor: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value: string
+    onChange?: (value: string | undefined) => void
+    options?: { readOnly?: boolean }
+  }) => (
+    <textarea
+      aria-label="yaml-editor"
+      readOnly={options?.readOnly}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+  MonacoDiffEditor: ({
+    original,
+    modified,
+  }: {
+    original: string
+    modified: string
+  }) => (
+    <div aria-label="yaml-diff-editor">
+      <pre data-testid="diff-original">{original}</pre>
+      <pre data-testid="diff-modified">{modified}</pre>
+    </div>
+  ),
+}))
+
+describe('YamlEditor', () => {
+  it('opens in view mode and switches to edit mode from the edit button', () => {
+    render(<YamlEditor<'configmaps'> value={originalYaml} />)
+
+    expect(screen.getByLabelText('yaml-editor')).toHaveAttribute('readonly')
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /save/i })
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+    expect(screen.getByLabelText('yaml-editor')).not.toHaveAttribute('readonly')
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('restores the original YAML when editing is canceled', () => {
+    const handleChange = vi.fn()
+
+    render(
+      <YamlEditor<'configmaps'> value={originalYaml} onChange={handleChange} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('yaml-editor'), {
+      target: {
+        value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n',
+      },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(screen.getByLabelText('yaml-editor')).toHaveValue(originalYaml)
+    expect(handleChange).toHaveBeenLastCalledWith(originalYaml)
+    expect(screen.getByLabelText('yaml-editor')).toHaveAttribute('readonly')
+  })
+
+  it('shows a diff before saving changed YAML and saves after confirmation', async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined)
+    const modifiedYaml =
+      'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n'
+
+    render(
+      <YamlEditor<'configmaps'> value={originalYaml} onSave={handleSave} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('yaml-editor'), {
+      target: { value: modifiedYaml },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(handleSave).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('diff-original').textContent).toBe(originalYaml)
+    expect(screen.getByTestId('diff-modified').textContent).toBe(modifiedYaml)
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm save/i }))
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ name: 'changed' }),
+        })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('yaml-editor')).toHaveAttribute('readonly')
+    })
+  })
+
+  it('continues editing from the diff dialog without saving', () => {
+    const handleSave = vi.fn()
+
+    render(
+      <YamlEditor<'configmaps'> value={originalYaml} onSave={handleSave} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('yaml-editor'), {
+      target: {
+        value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n',
+      },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue editing/i }))
+
+    expect(handleSave).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('yaml-editor')).not.toHaveAttribute('readonly')
+  })
+
+  it('keeps the diff open and stays editable when save returns false', async () => {
+    const handleSave = vi.fn().mockResolvedValue(false)
+
+    render(
+      <YamlEditor<'configmaps'> value={originalYaml} onSave={handleSave} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('yaml-editor'), {
+      target: {
+        value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n',
+      },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm save/i }))
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalled()
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByLabelText('yaml-editor')).not.toHaveAttribute('readonly')
+  })
+
+  it('exits edit mode without opening diff when YAML is unchanged', () => {
+    const handleSave = vi.fn()
+
+    render(
+      <YamlEditor<'configmaps'> value={originalYaml} onSave={handleSave} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(handleSave).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('yaml-editor')).toHaveAttribute('readonly')
+  })
+})

--- a/ui/src/components/yaml-editor.tsx
+++ b/ui/src/components/yaml-editor.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 import { useAppearance } from './appearance-provider'
+import { YamlDiffDialog } from './yaml-diff-dialog'
 
 interface YamlEditorProps<T extends ResourceType> {
   /** The YAML content to edit */
@@ -28,8 +29,10 @@ interface YamlEditorProps<T extends ResourceType> {
   minHeight?: number
   /** Callback when YAML content changes */
   onChange?: (value: string) => void
-  /** Callback when save is clicked */
-  onSave?: (value: ResourceTypeMap[T]) => void
+  /** Callback when save is confirmed. Return false to keep editing after a handled failure. */
+  onSave?: (
+    value: ResourceTypeMap[T]
+  ) => boolean | void | Promise<boolean | void>
   /** Callback when cancel is clicked */
   onCancel?: () => void
   /** Whether save operation is in progress */
@@ -49,14 +52,17 @@ export function YamlEditor<T extends ResourceType>({
   isSaving = false,
   className,
 }: YamlEditorProps<T>) {
-  const [isEditing, setIsEditing] = useState(true)
+  const [isEditing, setIsEditing] = useState(false)
   const [editorValue, setEditorValue] = useState(value)
   const [isValidYaml, setIsValidYaml] = useState(true)
   const [validationError, setValidationError] = useState<string>('')
+  const [isDiffOpen, setIsDiffOpen] = useState(false)
+  const [isConfirmingSave, setIsConfirmingSave] = useState(false)
   const { actualTheme, colorTheme } = useAppearance()
   const { t } = useTranslation()
   const resolvedTitle = title || t('yamlEditor.title')
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
+  const editStartValueRef = useRef(value)
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const themeMode = actualTheme === 'dark' ? 'dark' : 'light'
   const backgroundColor = useMonacoBackgroundColor(
@@ -68,7 +74,10 @@ export function YamlEditor<T extends ResourceType>({
   // Update editor value when value prop changes
   useEffect(() => {
     setEditorValue(value)
-  }, [value])
+    if (!isEditing) {
+      editStartValueRef.current = value
+    }
+  }, [isEditing, value])
 
   // Validate YAML on content change with debounce for error display
   useEffect(() => {
@@ -110,6 +119,7 @@ export function YamlEditor<T extends ResourceType>({
   }
 
   const handleEdit = () => {
+    editStartValueRef.current = editorValue
     setIsEditing(true)
     // Focus the editor after setting editing mode
     setTimeout(() => {
@@ -119,18 +129,55 @@ export function YamlEditor<T extends ResourceType>({
     }, 100)
   }
 
-  const handleSave = () => {
-    if (isValidYaml) {
-      onSave?.(yaml.load(editorValue) as ResourceTypeMap[T])
+  const completeSave = async () => {
+    if (!isValidYaml) {
+      return
+    }
+
+    setIsConfirmingSave(true)
+    try {
+      const saveResult = await onSave?.(
+        yaml.load(editorValue) as ResourceTypeMap[T]
+      )
+      if (saveResult === false) {
+        return
+      }
+      editStartValueRef.current = editorValue
+      setIsDiffOpen(false)
       if (!readOnly) {
         setIsEditing(false)
       }
+    } finally {
+      setIsConfirmingSave(false)
     }
   }
 
+  const handleSave = () => {
+    if (!isValidYaml) {
+      return
+    }
+
+    if (editorValue === editStartValueRef.current) {
+      setIsEditing(false)
+      return
+    }
+
+    setIsDiffOpen(true)
+  }
+
   const handleCancel = () => {
+    const originalValue = editStartValueRef.current
+    setEditorValue(originalValue)
+    onChange?.(originalValue)
     setIsEditing(false)
     onCancel?.()
+  }
+
+  const handleContinueEditing = () => {
+    setIsDiffOpen(false)
+    setTimeout(() => {
+      editorRef.current?.focus()
+    }, 100)
   }
 
   const handleEditorDidMount = (editor: monacoEditor.IStandaloneCodeEditor) => {
@@ -139,122 +186,135 @@ export function YamlEditor<T extends ResourceType>({
 
   const effectiveReadOnly = readOnly || !isEditing
 
+  const isSaveInProgress = isSaving || isConfirmingSave
+
   return (
-    <Card className={className}>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <div className="space-y-1">
-          <CardTitle>{resolvedTitle}</CardTitle>
-        </div>
-        <div className="flex items-center gap-4">
-          {showControls && (
-            <div className="flex gap-2">
-              {isEditing ? (
-                <>
-                  <Button
-                    size="sm"
-                    onClick={handleSave}
-                    disabled={!isValidYaml || isSaving}
-                  >
-                    {isSaving ? (
-                      <IconLoader className="w-4 h-4 mr-2 animate-spin" />
-                    ) : (
-                      <IconCheck className="w-4 h-4 mr-2" />
-                    )}
-                    {t('yamlEditor.save')}
-                  </Button>
+    <>
+      <Card className={className}>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div className="space-y-1">
+            <CardTitle>{resolvedTitle}</CardTitle>
+          </div>
+          <div className="flex items-center gap-4">
+            {showControls && (
+              <div className="flex gap-2">
+                {isEditing ? (
+                  <>
+                    <Button
+                      size="sm"
+                      onClick={handleSave}
+                      disabled={!isValidYaml || isSaveInProgress}
+                    >
+                      {isSaveInProgress ? (
+                        <IconLoader className="w-4 h-4 mr-2 animate-spin" />
+                      ) : (
+                        <IconCheck className="w-4 h-4 mr-2" />
+                      )}
+                      {t('yamlEditor.save')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleCancel}
+                      disabled={isSaveInProgress}
+                    >
+                      <IconX className="w-4 h-4 mr-2" />
+                      {t('yamlEditor.cancel')}
+                    </Button>
+                  </>
+                ) : (
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={handleCancel}
-                    disabled={isSaving}
+                    onClick={handleEdit}
+                    disabled={readOnly}
                   >
-                    <IconX className="w-4 h-4 mr-2" />
-                    {t('yamlEditor.cancel')}
+                    <IconEdit className="w-4 h-4 mr-2" />
+                    {t('yamlEditor.edit')}
                   </Button>
-                </>
-              ) : (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleEdit}
-                  disabled={readOnly}
-                >
-                  <IconEdit className="w-4 h-4 mr-2" />
-                  {t('yamlEditor.edit')}
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          {!isValidYaml && validationError && (
-            <div className="px-3 py-2 bg-destructive/10 border border-destructive/20 rounded-md">
-              <p className="text-sm text-destructive">{validationError}</p>
-            </div>
-          )}
-          <div className="overflow-hidden h-[calc(100dvh-300px)]">
-            <Suspense
-              fallback={
-                <div className="flex h-full items-center justify-center text-muted-foreground">
-                  {t('yamlEditor.loadingEditor')}
-                </div>
-              }
-            >
-              <MonacoEditor
-                key={`yaml-editor-${colorTheme}-${actualTheme}-${backgroundColor}`}
-                language="yaml"
-                theme={
-                  actualTheme === 'dark'
-                    ? `custom-dark-${colorTheme}`
-                    : `custom-vs-${colorTheme}`
-                }
-                value={editorValue}
-                beforeMount={(monaco) => {
-                  defineMonacoBackgroundThemes(monaco, {
-                    darkThemeName: `custom-dark-${colorTheme}`,
-                    lightThemeName: `custom-vs-${colorTheme}`,
-                    backgroundColor,
-                  })
-                }}
-                onChange={handleEditorChange}
-                onMount={handleEditorDidMount}
-                options={{
-                  readOnly: effectiveReadOnly,
-                  minimap: { enabled: false },
-                  scrollBeyondLastLine: false,
-                  automaticLayout: true,
-                  wordWrap: 'on',
-                  lineNumbers: 'on',
-                  folding: true,
-                  renderLineHighlight: effectiveReadOnly ? 'none' : 'line',
-                  tabSize: 2,
-                  insertSpaces: true,
-                  fontSize: 14,
-                  fontFamily:
-                    "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
-                  acceptSuggestionOnCommitCharacter: false,
-                  acceptSuggestionOnEnter: 'off',
-                  quickSuggestions: false,
-                  suggestOnTriggerCharacters: false,
-                  wordBasedSuggestions: 'off',
-                  parameterHints: { enabled: false },
-                  hover: { enabled: false },
-                  contextmenu: false,
-                  smoothScrolling: true,
-                  cursorSmoothCaretAnimation: 'on',
-                  multiCursorModifier: 'alt',
-                  accessibilitySupport: 'off',
-                  quickSuggestionsDelay: 500,
-                  links: false,
-                  colorDecorators: false,
-                }}
-              />
-            </Suspense>
+                )}
+              </div>
+            )}
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {!isValidYaml && validationError && (
+              <div className="px-3 py-2 bg-destructive/10 border border-destructive/20 rounded-md">
+                <p className="text-sm text-destructive">{validationError}</p>
+              </div>
+            )}
+            <div className="overflow-hidden h-[calc(100dvh-300px)]">
+              <Suspense
+                fallback={
+                  <div className="flex h-full items-center justify-center text-muted-foreground">
+                    {t('yamlEditor.loadingEditor')}
+                  </div>
+                }
+              >
+                <MonacoEditor
+                  key={`yaml-editor-${colorTheme}-${actualTheme}-${backgroundColor}`}
+                  language="yaml"
+                  theme={
+                    actualTheme === 'dark'
+                      ? `custom-dark-${colorTheme}`
+                      : `custom-vs-${colorTheme}`
+                  }
+                  value={editorValue}
+                  beforeMount={(monaco) => {
+                    defineMonacoBackgroundThemes(monaco, {
+                      darkThemeName: `custom-dark-${colorTheme}`,
+                      lightThemeName: `custom-vs-${colorTheme}`,
+                      backgroundColor,
+                    })
+                  }}
+                  onChange={handleEditorChange}
+                  onMount={handleEditorDidMount}
+                  options={{
+                    readOnly: effectiveReadOnly,
+                    minimap: { enabled: false },
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    wordWrap: 'on',
+                    lineNumbers: 'on',
+                    folding: true,
+                    renderLineHighlight: effectiveReadOnly ? 'none' : 'line',
+                    tabSize: 2,
+                    insertSpaces: true,
+                    fontSize: 14,
+                    fontFamily:
+                      "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
+                    acceptSuggestionOnCommitCharacter: false,
+                    acceptSuggestionOnEnter: 'off',
+                    quickSuggestions: false,
+                    suggestOnTriggerCharacters: false,
+                    wordBasedSuggestions: 'off',
+                    parameterHints: { enabled: false },
+                    hover: { enabled: false },
+                    contextmenu: false,
+                    smoothScrolling: true,
+                    cursorSmoothCaretAnimation: 'on',
+                    multiCursorModifier: 'alt',
+                    accessibilitySupport: 'off',
+                    quickSuggestionsDelay: 500,
+                    links: false,
+                    colorDecorators: false,
+                  }}
+                />
+              </Suspense>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <YamlDiffDialog
+        open={isDiffOpen}
+        original={editStartValueRef.current}
+        modified={editorValue}
+        isSaving={isSaveInProgress}
+        onOpenChange={setIsDiffOpen}
+        onConfirm={() => void completeSave()}
+        onContinueEditing={handleContinueEditing}
+      />
+    </>
   )
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1242,6 +1242,11 @@
     "save": "Save",
     "cancel": "Cancel",
     "edit": "Edit",
+    "saving": "Saving...",
+    "diffTitle": "Review YAML changes",
+    "diffDescription": "Review the differences between the current resource YAML and your edits before saving.",
+    "continueEditing": "Continue editing",
+    "confirmSave": "Confirm save",
     "invalidYaml": "Invalid YAML",
     "loadingEditor": "Loading editor..."
   },

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1721,6 +1721,11 @@
     "save": "保存",
     "cancel": "取消",
     "edit": "编辑",
+    "saving": "保存中...",
+    "diffTitle": "确认 YAML 变更",
+    "diffDescription": "保存前，请先确认当前资源 YAML 与本次编辑内容之间的差异。",
+    "continueEditing": "继续编辑",
+    "confirmSave": "确认保存",
     "invalidYaml": "YAML 格式无效",
     "loadingEditor": "正在加载编辑器..."
   },

--- a/ui/src/pages/configmap-detail.tsx
+++ b/ui/src/pages/configmap-detail.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import { updateResource, useResource } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource } from '@/lib/api'
 import { getOwnerInfo } from '@/lib/k8s'
 import { formatDate, translateError } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -16,11 +16,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { DescribeDialog } from '@/components/describe-dialog'
-import { RefreshButton } from '@/components/refresh-button'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { KeyValueDataViewer } from '@/components/key-value-data-viewer'
 import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -58,11 +58,13 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
       })
       toast.success(t('detail.status.yamlSaved'))
       await handleRefresh()
+      return true
     } catch (error) {
       trackResourceAction('configmaps', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -113,7 +115,11 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
           </p>
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/cronjob-detail.tsx
+++ b/ui/src/pages/cronjob-detail.tsx
@@ -12,25 +12,25 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { trackResourceAction } from '@/lib/analytics'
 import {
   createResource,
   updateResource,
   useResource,
   useResources,
 } from '@/lib/api'
-import { trackResourceAction } from '@/lib/analytics'
 import { formatDate, translateError } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
-import { RefreshButton } from '@/components/refresh-button'
 import { ContainerTable } from '@/components/container-table'
 import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -230,11 +230,13 @@ export function CronJobDetail(props: { namespace: string; name: string }) {
       })
       toast.success('CronJob YAML saved successfully')
       await refetchCronJob()
+      return true
     } catch (error) {
       trackResourceAction('cronjobs', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -378,7 +380,11 @@ export function CronJobDetail(props: { namespace: string; name: string }) {
           </p>
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/daemonset-detail.tsx
+++ b/ui/src/pages/daemonset-detail.tsx
@@ -110,23 +110,24 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
     [daemonset, watchedPods]
   )
 
-  const handleSaveYaml = async () => {
+  const handleSaveYaml = async (content: DaemonSet) => {
     setIsSavingYaml(true)
     try {
-      const parsedYaml = yaml.load(yamlContent) as DaemonSet
-      await updateResource('daemonsets', name, namespace, parsedYaml)
+      await updateResource('daemonsets', name, namespace, content)
       trackResourceAction('daemonsets', 'yaml_save', {
         result: 'success',
       })
       toast.success('DaemonSet YAML saved successfully')
       setRefreshInterval(1000) // Set a short refresh interval to see changes
       await refetchDaemonSet()
+      return true
     } catch (error) {
       console.error('Failed to save YAML:', error)
       trackResourceAction('daemonsets', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -438,7 +439,7 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
             label: t('detail.tabs.yaml'),
             content: (
               <div className="space-y-4">
-                <YamlEditor
+                <YamlEditor<'daemonsets'>
                   key={refreshKey}
                   value={yamlContent}
                   title={t('yamlEditor.daemonSetTitle')}

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -208,12 +208,14 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
       })
       toast.success('YAML saved successfully')
       setRefreshInterval(1000)
+      return true
     } catch (error) {
       console.error('Failed to save YAML:', error)
       trackResourceAction('deployments', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }

--- a/ui/src/pages/job-detail.tsx
+++ b/ui/src/pages/job-detail.tsx
@@ -7,8 +7,8 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import { updateResource, useResource, useResources } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource, useResources } from '@/lib/api'
 import { getOwnerInfo } from '@/lib/k8s'
 import { formatDate, translateError } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -16,7 +16,6 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
-import { RefreshButton } from '@/components/refresh-button'
 import { ContainerTable } from '@/components/container-table'
 import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
@@ -25,6 +24,7 @@ import { LabelsAnno } from '@/components/lables-anno'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -122,11 +122,13 @@ export function JobDetail(props: { namespace: string; name: string }) {
       })
       toast.success('Job YAML saved successfully')
       await refetchJob()
+      return true
     } catch (error) {
       trackResourceAction('jobs', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -181,7 +183,11 @@ export function JobDetail(props: { namespace: string; name: string }) {
           </p>
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/node-detail.tsx
+++ b/ui/src/pages/node-detail.tsx
@@ -206,12 +206,14 @@ export function NodeDetail(props: { name: string }) {
         result: 'success',
       })
       toast.success('YAML saved successfully')
+      return true
     } catch (error) {
       console.error('Failed to save YAML:', error)
       trackResourceAction('nodes', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }

--- a/ui/src/pages/pod-detail.tsx
+++ b/ui/src/pages/pod-detail.tsx
@@ -11,8 +11,8 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import { resizePod, updateResource, useResource } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { resizePod, updateResource, useResource } from '@/lib/api'
 import { getOwnerInfo, getPodErrorMessage, getPodStatus } from '@/lib/k8s'
 import { withSubPath } from '@/lib/subpath'
 import { formatDate, translateError, translatePodStatus } from '@/lib/utils'
@@ -37,11 +37,11 @@ import { ResourceEditor } from '@/components/editors/resource-editor'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
-import { RefreshButton } from '@/components/refresh-button'
 import { LogViewer } from '@/components/log-viewer'
 import { PodFileBrowser } from '@/components/pod-file-browser'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodStatusIcon } from '@/components/pod-status-icon'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ContainerSelector } from '@/components/selector/container-selector'
@@ -109,11 +109,13 @@ export function PodDetail(props: { namespace: string; name: string }) {
       toast.success(t('detail.status.yamlSaved'))
       // Refresh data after successful save
       await handleRefresh()
+      return true
     } catch (error) {
       trackResourceAction('pods', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -218,7 +220,11 @@ export function PodDetail(props: { namespace: string; name: string }) {
           </p>
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/secret-detail.tsx
+++ b/ui/src/pages/secret-detail.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import { updateResource, useResource } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource } from '@/lib/api'
 import { getOwnerInfo } from '@/lib/k8s'
 import { formatDate, translateError } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -16,10 +16,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { ErrorMessage } from '@/components/error-message'
-import { RefreshButton } from '@/components/refresh-button'
 import { EventTable } from '@/components/event-table'
 import { KeyValueDataViewer } from '@/components/key-value-data-viewer'
 import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -58,11 +58,13 @@ export function SecretDetail(props: { namespace: string; name: string }) {
       })
       toast.success(t('detail.status.yamlSaved'))
       await handleRefresh()
+      return true
     } catch (error) {
       trackResourceAction('secrets', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -142,7 +144,11 @@ export function SecretDetail(props: { namespace: string; name: string }) {
           </p>
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <Button

--- a/ui/src/pages/service-detail.tsx
+++ b/ui/src/pages/service-detail.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-  IconExternalLink,
-  IconLoader,
-  IconTrash,
-} from '@tabler/icons-react'
+import { IconExternalLink, IconLoader, IconTrash } from '@tabler/icons-react'
 import * as yaml from 'js-yaml'
 import { Service } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
@@ -11,8 +7,8 @@ import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { ResourceType } from '@/types/api'
-import { updateResource, useResource } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource } from '@/lib/api'
 import { getOwnerInfo } from '@/lib/k8s'
 import { withSubPath } from '@/lib/subpath'
 import { formatDate, translateError } from '@/lib/utils'
@@ -21,10 +17,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { DescribeDialog } from '@/components/describe-dialog'
-import { RefreshButton } from '@/components/refresh-button'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -63,11 +59,13 @@ export function ServiceDetail(props: { name: string; namespace?: string }) {
       toast.success(t('detail.status.yamlSaved'))
       // Refresh data after successful save
       await handleRefresh()
+      return true
     } catch (error) {
       trackResourceAction('services', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -127,7 +125,11 @@ export function ServiceDetail(props: { name: string; namespace?: string }) {
           )}
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/simple-resource-detail.tsx
+++ b/ui/src/pages/simple-resource-detail.tsx
@@ -6,8 +6,8 @@ import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { ResourceType, ResourceTypeMap } from '@/types/api'
-import { updateResource, useResource } from '@/lib/api'
 import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource } from '@/lib/api'
 import { getOwnerInfo } from '@/lib/k8s'
 import { formatDate, translateError } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -15,10 +15,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { DescribeDialog } from '@/components/describe-dialog'
-import { RefreshButton } from '@/components/refresh-button'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
@@ -64,11 +64,13 @@ export function SimpleResourceDetail<T extends ResourceType>(props: {
       toast.success('YAML saved successfully')
       // Refresh data after successful save
       await handleRefresh()
+      return true
     } catch (error) {
       trackResourceAction(resourceType, 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -126,7 +128,11 @@ export function SimpleResourceDetail<T extends ResourceType>(props: {
           )}
         </div>
         <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
-          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+          <RefreshButton
+            variant="outline"
+            size="sm"
+            onClick={handleManualRefresh}
+          >
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog

--- a/ui/src/pages/statefulset-detail.tsx
+++ b/ui/src/pages/statefulset-detail.tsx
@@ -125,22 +125,23 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
     refetchStatefulSet()
   }
 
-  const handleSaveYaml = async () => {
+  const handleSaveYaml = async (content: StatefulSet) => {
     setIsSavingYaml(true)
     try {
-      const parsedYaml = yaml.load(yamlContent) as StatefulSet
-      await updateResource('statefulsets', name, namespace, parsedYaml)
+      await updateResource('statefulsets', name, namespace, content)
       trackResourceAction('statefulsets', 'yaml_save', {
         result: 'success',
       })
       toast.success('StatefulSet YAML saved successfully')
       setRefreshInterval(1000)
+      return true
     } catch (error) {
       console.error('Failed to save YAML:', error)
       trackResourceAction('statefulsets', 'yaml_save', {
         result: 'error',
       })
       toast.error(translateError(error, t))
+      return false
     } finally {
       setIsSavingYaml(false)
     }
@@ -538,7 +539,7 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
             label: t('detail.tabs.yaml'),
             content: (
               <div className="space-y-4">
-                <YamlEditor
+                <YamlEditor<'statefulsets'>
                   key={refreshKey}
                   value={yamlContent}
                   title={t('yamlEditor.statefulSetTitle')}


### PR DESCRIPTION
- Implemented YamlDiffDialog component to show differences between original and modified YAML.
- Integrated YamlDiffDialog into YamlEditor for confirming saves.
- Updated YamlEditor to handle editing state and save confirmation logic.
- Enhanced tests for YamlEditor to cover diff dialog interactions and save scenarios.
- Added new translations for diff dialog titles and messages in English and Chinese.
- Refactored save logic in various resource detail pages to return success/failure status.

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #102 

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * YAML editor now displays a confirmation dialog with a side-by-side diff view before saving changes, allowing you to review and confirm modifications before they're applied.

* **Tests**
  * Added comprehensive test coverage for YAML editor save flows, diff confirmation dialogs, and keyboard shortcuts in focused states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/104)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->