### PR TITLE
feat(ai-chat): 添加代码块复制功能及相关国际化文本

### DIFF
--- a/ui/src/components/ai-chat/ai-chatbox.test.tsx
+++ b/ui/src/components/ai-chat/ai-chatbox.test.tsx
@@ -1,6 +1,6 @@
 import '@/i18n'
 
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +14,10 @@ const { useAIChatContext } = vi.hoisted(() => ({
 
 const { useAIChat } = vi.hoisted(() => ({
   useAIChat: vi.fn(),
+}))
+
+const { copyTextToClipboard } = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
 }))
 
 vi.mock('@/contexts/ai-chat-context', () => ({
@@ -30,6 +34,7 @@ vi.mock('@/hooks/use-mobile', () => ({
 
 vi.mock('@/lib/desktop', () => ({
   openURL: vi.fn(),
+  copyTextToClipboard,
 }))
 
 describe('AIChatbox', () => {
@@ -122,5 +127,84 @@ describe('AIChatbox', () => {
     })
 
     expect(screen.getByPlaceholderText('询问当前集群...')).toBeInTheDocument()
+  })
+
+  it('keeps the composer editable while a reply is loading but blocks sending', () => {
+    const sendMessage = vi.fn()
+    useAIChat.mockReturnValue({
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Working on it...',
+        },
+      ],
+      isLoading: true,
+      history: [],
+      currentSessionId: null,
+      sendMessage,
+      executeAction: vi.fn(),
+      submitInput: vi.fn(),
+      denyAction: vi.fn(),
+      stopGeneration: vi.fn(),
+      loadSession: vi.fn(),
+      deleteSession: vi.fn(),
+      newSession: vi.fn(),
+      ensureSessionId: vi.fn(() => 'session-1'),
+      saveCurrentSession: vi.fn(() => 'session-1'),
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/ai-chat-box']}>
+        <AIChatbox standalone />
+      </MemoryRouter>
+    )
+
+    const composer = screen.getByPlaceholderText('Ask about your cluster...')
+    expect(composer).not.toBeDisabled()
+
+    fireEvent.change(composer, { target: { value: 'next question' } })
+    fireEvent.keyDown(composer, { key: 'Enter' })
+
+    expect(composer).toHaveValue('next question')
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('copies markdown code blocks from assistant messages', async () => {
+    copyTextToClipboard.mockResolvedValue(undefined)
+    useAIChat.mockReturnValue({
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Try this:\n\n```bash\nkubectl get pods\n```',
+        },
+      ],
+      isLoading: false,
+      history: [],
+      currentSessionId: null,
+      sendMessage: vi.fn(),
+      executeAction: vi.fn(),
+      submitInput: vi.fn(),
+      denyAction: vi.fn(),
+      stopGeneration: vi.fn(),
+      loadSession: vi.fn(),
+      deleteSession: vi.fn(),
+      newSession: vi.fn(),
+      ensureSessionId: vi.fn(() => 'session-1'),
+      saveCurrentSession: vi.fn(() => 'session-1'),
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/ai-chat-box']}>
+        <AIChatbox standalone />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code' }))
+
+    await waitFor(() => {
+      expect(copyTextToClipboard).toHaveBeenCalledWith('kubectl get pods')
+    })
   })
 })

--- a/ui/src/components/ai-chat/ai-chatbox.tsx
+++ b/ui/src/components/ai-chat/ai-chatbox.tsx
@@ -6,6 +6,8 @@ import {
   CheckCircle2,
   ChevronRight,
   Clock,
+  Clipboard,
+  ClipboardCheck,
   ExternalLink,
   Loader2,
   MessageSquarePlus,
@@ -21,7 +23,7 @@ import ReactMarkdown from 'react-markdown'
 import { useLocation, useSearchParams } from 'react-router-dom'
 import remarkGfm from 'remark-gfm'
 
-import { openURL } from '@/lib/desktop'
+import { copyTextToClipboard, openURL } from '@/lib/desktop'
 import { withSubPath } from '@/lib/subpath'
 import { ChatMessage, ChatSession, useAIChat } from '@/hooks/use-ai-chat'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -225,6 +227,72 @@ function buildInputDefaults(
     values[field.name] = field.defaultValue || ''
   }
   return values
+}
+
+function getPlainTextFromNode(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(getPlainTextFromNode).join('')
+  }
+  if (node && typeof node === 'object' && 'props' in node) {
+    return getPlainTextFromNode(
+      (node as React.ReactElement<{ children?: React.ReactNode }>).props
+        .children
+    )
+  }
+  return ''
+}
+
+function MarkdownCodeBlock({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'code'>) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+  const code = getPlainTextFromNode(children).replace(/\n$/, '')
+
+  const handleCopy = async () => {
+    if (!code) return
+    await copyTextToClipboard(code)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1200)
+  }
+
+  return (
+    <div className="group relative my-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-1.5 top-1.5 z-10 h-7 w-7 bg-background/80 text-muted-foreground opacity-80 shadow-sm hover:bg-background hover:text-foreground group-hover:opacity-100"
+        aria-label={
+          copied
+            ? t('aiChat.code.copied', { defaultValue: 'Copied' })
+            : t('aiChat.code.copy', { defaultValue: 'Copy code' })
+        }
+        title={
+          copied
+            ? t('aiChat.code.copied', { defaultValue: 'Copied' })
+            : t('aiChat.code.copy', { defaultValue: 'Copy code' })
+        }
+        onClick={handleCopy}
+      >
+        {copied ? (
+          <ClipboardCheck className="h-3.5 w-3.5" />
+        ) : (
+          <Clipboard className="h-3.5 w-3.5" />
+        )}
+      </Button>
+      <pre className="overflow-x-auto rounded-md bg-background p-3 pr-10 text-xs">
+        <code className={className} {...props}>
+          {children}
+        </code>
+      </pre>
+    </div>
+  )
 }
 
 function ToolCallMessage({
@@ -604,7 +672,27 @@ function MessageBubble({
             )}
             {hasContent && (
               <div className="ai-markdown">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    pre: ({ children }) => <>{children}</>,
+                    code: ({ children, className, ...props }) => {
+                      const isBlock = /language-/.test(className || '')
+                      if (!isBlock) {
+                        return (
+                          <code className={className} {...props}>
+                            {children}
+                          </code>
+                        )
+                      }
+                      return (
+                        <MarkdownCodeBlock className={className} {...props}>
+                          {children}
+                        </MarkdownCodeBlock>
+                      )
+                    },
+                  }}
+                >
                   {formatMarkdownWithSoftBreaks(message.content)}
                 </ReactMarkdown>
               </div>
@@ -1408,7 +1496,6 @@ export function AIChatbox({
               autoComplete="off"
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              disabled={isLoading}
             />
             {isLoading ? (
               <Button

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1375,6 +1375,10 @@
     "composer": {
       "placeholder": "Ask about your cluster..."
     },
+    "code": {
+      "copy": "Copy code",
+      "copied": "Copied"
+    },
     "message": {
       "thinking": "Thinking"
     },

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1330,6 +1330,10 @@
     "composer": {
       "placeholder": "询问当前集群..."
     },
+    "code": {
+      "copy": "复制代码",
+      "copied": "已复制"
+    },
     "message": {
       "thinking": "思考中"
     },


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code blocks in AI chat now include a copy-to-clipboard button for quick sharing
  * Message composer input remains editable while waiting for assistant responses
  * Added language support for copy button labels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->