### PR TITLE
feat(secret): 添加 Secret 详情页和列表页的测试用例

### DIFF
--- a/pkg/handlers/resources/related_resources.go
+++ b/pkg/handlers/resources/related_resources.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	v1 "k8s.io/api/networking/v1"
@@ -255,6 +256,13 @@ func checkInUsedConfigs(spec *corev1.PodTemplateSpec, name string, resourceType 
 			return true
 		}
 	}
+	if resourceType == "secrets" {
+		for _, imagePullSecret := range spec.Spec.ImagePullSecrets {
+			if imagePullSecret.Name == name {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -267,6 +275,9 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 	var deploymentList appsv1.DeploymentList
 	var statefulSetList appsv1.StatefulSetList
 	var daemonSetList appsv1.DaemonSetList
+	var podList corev1.PodList
+	var jobList batchv1.JobList
+	var cronJobList batchv1.CronJobList
 
 	g.Go(func() error {
 		return k8sClient.List(gctx, &deploymentList, client.InNamespace(namespace))
@@ -276,6 +287,15 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 	})
 	g.Go(func() error {
 		return k8sClient.List(gctx, &daemonSetList, client.InNamespace(namespace))
+	})
+	g.Go(func() error {
+		return k8sClient.List(gctx, &podList, client.InNamespace(namespace))
+	})
+	g.Go(func() error {
+		return k8sClient.List(gctx, &jobList, client.InNamespace(namespace))
+	})
+	g.Go(func() error {
+		return k8sClient.List(gctx, &cronJobList, client.InNamespace(namespace))
 	})
 
 	if err := g.Wait(); err != nil {
@@ -317,6 +337,66 @@ func discoveryWorkloads(ctx context.Context, k8sClient *kube.K8sClient, namespac
 			})
 		}
 	}
+	for _, pod := range podList.Items {
+		podTemplate := &corev1.PodTemplateSpec{Spec: pod.Spec}
+		if checkInUsedConfigs(podTemplate, name, resourceType) {
+			related = append(related, common.RelatedResource{
+				Type:      "pods",
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "pod reference",
+			})
+		}
+	}
+	for _, job := range jobList.Items {
+		if checkInUsedConfigs(&job.Spec.Template, name, resourceType) {
+			related = append(related, common.RelatedResource{
+				Type:      "jobs",
+				Name:      job.Name,
+				Namespace: job.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "job pod template reference",
+			})
+		}
+	}
+	for _, cronJob := range cronJobList.Items {
+		if checkInUsedConfigs(&cronJob.Spec.JobTemplate.Spec.Template, name, resourceType) {
+			related = append(related, common.RelatedResource{
+				Type:      "cronjobs",
+				Name:      cronJob.Name,
+				Namespace: cronJob.Namespace,
+				Direction: common.RelatedDirectionReferencedBy,
+				Reason:    "cronjob pod template reference",
+			})
+		}
+	}
+	return related, nil
+}
+
+func discoverSecretIngresses(ctx context.Context, k8sClient *kube.K8sClient, namespace string, name string) ([]common.RelatedResource, error) {
+	var ingressList v1.IngressList
+	if err := k8sClient.List(ctx, &ingressList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list ingresses: %w", err)
+	}
+
+	var related []common.RelatedResource
+	for _, ingress := range ingressList.Items {
+		for _, tls := range ingress.Spec.TLS {
+			if tls.SecretName == name {
+				related = append(related, common.RelatedResource{
+					Type:       "ingresses",
+					Name:       ingress.Name,
+					Namespace:  ingress.Namespace,
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Direction:  common.RelatedDirectionReferencedBy,
+					Reason:     "ingress TLS secret",
+				})
+				break
+			}
+		}
+	}
+
 	return related, nil
 }
 
@@ -619,6 +699,14 @@ func GetRelatedResources(c *gin.Context) {
 				})
 			}
 			result = append(result, workloads...)
+			if resourceType == "secrets" {
+				ingresses, err := discoverSecretIngresses(ctx, cs.K8sClient, namespace, name)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to discover secret ingresses: " + err.Error()})
+					return
+				}
+				result = append(result, ingresses...)
+			}
 		}
 	case *gatewayapiv1.HTTPRoute:
 		result = getHTTPRouteRelatedResouces(res, namespace)

--- a/pkg/handlers/resources/related_resources.go
+++ b/pkg/handlers/resources/related_resources.go
@@ -226,41 +226,60 @@ func checkInUsedConfigs(spec *corev1.PodTemplateSpec, name string, resourceType 
 	containers := spec.Spec.Containers
 	containers = append(containers, spec.Spec.InitContainers...)
 	for _, container := range containers {
-		for _, envVar := range container.Env {
-			if envVar.ValueFrom != nil {
-				if resourceType == "configmaps" && envVar.ValueFrom.ConfigMapKeyRef != nil && envVar.ValueFrom.ConfigMapKeyRef.Name == name {
-					return true
-				}
-				if resourceType == "secrets" && envVar.ValueFrom.SecretKeyRef != nil && envVar.ValueFrom.SecretKeyRef.Name == name {
-					return true
-				}
-			}
-		}
-		for _, envFrom := range container.EnvFrom {
-			if resourceType == "configmaps" && envFrom.ConfigMapRef != nil && envFrom.ConfigMapRef.Name == name {
-				return true
-			}
-			if resourceType == "secrets" && envFrom.SecretRef != nil && envFrom.SecretRef.Name == name {
-				return true
-			}
+		if containerUsesConfig(container, name, resourceType) {
+			return true
 		}
 	}
 	for _, volume := range spec.Spec.Volumes {
-		if resourceType == "configmaps" && volume.ConfigMap != nil && volume.ConfigMap.Name == name {
-			return true
-		}
-		if resourceType == "secrets" && volume.Secret != nil && volume.Secret.SecretName == name {
-			return true
-		}
-		if resourceType == "persistentvolumeclaims" && volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == name {
+		if volumeUsesConfig(volume, name, resourceType) {
 			return true
 		}
 	}
-	if resourceType == "secrets" {
-		for _, imagePullSecret := range spec.Spec.ImagePullSecrets {
-			if imagePullSecret.Name == name {
-				return true
-			}
+	return resourceType == "secrets" && imagePullSecretsUseSecret(spec.Spec.ImagePullSecrets, name)
+}
+
+func containerUsesConfig(container corev1.Container, name string, resourceType string) bool {
+	for _, envVar := range container.Env {
+		if envVar.ValueFrom == nil {
+			continue
+		}
+		if resourceType == "configmaps" && envVar.ValueFrom.ConfigMapKeyRef != nil && envVar.ValueFrom.ConfigMapKeyRef.Name == name {
+			return true
+		}
+		if resourceType == "secrets" && envVar.ValueFrom.SecretKeyRef != nil && envVar.ValueFrom.SecretKeyRef.Name == name {
+			return true
+		}
+	}
+
+	for _, envFrom := range container.EnvFrom {
+		if resourceType == "configmaps" && envFrom.ConfigMapRef != nil && envFrom.ConfigMapRef.Name == name {
+			return true
+		}
+		if resourceType == "secrets" && envFrom.SecretRef != nil && envFrom.SecretRef.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func volumeUsesConfig(volume corev1.Volume, name string, resourceType string) bool {
+	if resourceType == "configmaps" && volume.ConfigMap != nil && volume.ConfigMap.Name == name {
+		return true
+	}
+	if resourceType == "secrets" && volume.Secret != nil && volume.Secret.SecretName == name {
+		return true
+	}
+	if resourceType == "persistentvolumeclaims" && volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == name {
+		return true
+	}
+	return false
+}
+
+func imagePullSecretsUseSecret(imagePullSecrets []corev1.LocalObjectReference, name string) bool {
+	for _, imagePullSecret := range imagePullSecrets {
+		if imagePullSecret.Name == name {
+			return true
 		}
 	}
 	return false

--- a/pkg/handlers/resources/related_resources_test.go
+++ b/pkg/handlers/resources/related_resources_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eryajf/kite-desktop/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -36,6 +37,9 @@ func newRelatedResourcesTestScheme(t *testing.T) *runtime.Scheme {
 		t.Fatal(err)
 	}
 	if err := autoscalingv2.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
 	if err := gatewayapiv1.Install(scheme); err != nil {
@@ -163,6 +167,9 @@ func TestCheckInUsedConfigs(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-vol"}}},
 			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "pull-secret"},
+			},
 		},
 	}
 
@@ -175,6 +182,7 @@ func TestCheckInUsedConfigs(t *testing.T) {
 		{name: "configmap from init env", resourceType: "configmaps", resourceName: "cm-init", want: true},
 		{name: "configmap from envFrom", resourceType: "configmaps", resourceName: "cm-from", want: true},
 		{name: "secret from env", resourceType: "secrets", resourceName: "sec-env", want: true},
+		{name: "secret from image pull secret", resourceType: "secrets", resourceName: "pull-secret", want: true},
 		{name: "pvc from volume", resourceType: "persistentvolumeclaims", resourceName: "pvc-vol", want: true},
 		{name: "missing configmap", resourceType: "configmaps", resourceName: "missing", want: false},
 		{name: "nil spec", resourceType: "secrets", resourceName: "sec-env", want: false},
@@ -190,6 +198,129 @@ func TestCheckInUsedConfigs(t *testing.T) {
 				t.Fatalf("checkInUsedConfigs() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDiscoveryWorkloadsFindsDirectPodJobAndCronJobSecretReferences(t *testing.T) {
+	scheme := newRelatedResourcesTestScheme(t)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app",
+						Env: []corev1.EnvVar{
+							{ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "app-secret"}, Key: "password"}}},
+						},
+					}},
+				},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "debug", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "debug", Image: "busybox"}},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "app-secret"},
+			},
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "migrate", Namespace: "default"},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "migrate",
+						EnvFrom: []corev1.EnvFromSource{
+							{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "app-secret"}}},
+						},
+					}},
+				},
+			},
+		},
+	}
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "sync", Namespace: "default"},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "sync",
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "secret", MountPath: "/secret"},
+								},
+							}},
+							Volumes: []corev1.Volume{
+								{VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "app-secret"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	client := &kube.K8sClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(deployment, pod, job, cronJob).
+			Build(),
+	}
+
+	got, err := discoveryWorkloads(context.Background(), client, "default", "app-secret", "secrets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []common.RelatedResource{
+		{Type: "deployments", Namespace: "default", Name: "app", Direction: common.RelatedDirectionReferencedBy, Reason: "workload pod template reference"},
+		{Type: "pods", Namespace: "default", Name: "debug", Direction: common.RelatedDirectionReferencedBy, Reason: "pod reference"},
+		{Type: "jobs", Namespace: "default", Name: "migrate", Direction: common.RelatedDirectionReferencedBy, Reason: "job pod template reference"},
+		{Type: "cronjobs", Namespace: "default", Name: "sync", Direction: common.RelatedDirectionReferencedBy, Reason: "cronjob pod template reference"},
+	}
+	if !sameRelatedResources(got, want) {
+		t.Fatalf("discoveryWorkloads() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiscoverSecretIngresses(t *testing.T) {
+	scheme := newRelatedResourcesTestScheme(t)
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-ingress", Namespace: "default"},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{SecretName: "app-tls"},
+			},
+		},
+	}
+	other := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{SecretName: "other-tls"},
+			},
+		},
+	}
+	client := &kube.K8sClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ingress, other).
+			Build(),
+	}
+
+	got, err := discoverSecretIngresses(context.Background(), client, "default", "app-tls")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []common.RelatedResource{
+		{Type: "ingresses", APIVersion: networkingv1.SchemeGroupVersion.String(), Namespace: "default", Name: "tls-ingress", Direction: common.RelatedDirectionReferencedBy, Reason: "ingress TLS secret"},
+	}
+	if !sameRelatedResources(got, want) {
+		t.Fatalf("discoverSecretIngresses() = %#v, want %#v", got, want)
 	}
 }
 

--- a/ui/src/components/yaml-diff-viewer.test.tsx
+++ b/ui/src/components/yaml-diff-viewer.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { YamlDiffViewer } from './yaml-diff-viewer'
+
+const mockOnRollback = vi.fn()
+const mockT = (key: string) => key
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: mockT,
+    }),
+  }
+})
+
+vi.mock('@/lib/monaco-loader', () => ({
+  MonacoDiffEditor: () => <div>monaco-diff-editor</div>,
+}))
+
+vi.mock('@/lib/monaco-theme', () => ({
+  defineMonacoBackgroundThemes: vi.fn(),
+  useMonacoBackgroundColor: () => '#ffffff',
+}))
+
+vi.mock('./appearance-provider', () => ({
+  useAppearance: () => ({
+    actualTheme: 'light',
+    colorTheme: 'default',
+  }),
+}))
+
+describe('YamlDiffViewer', () => {
+  beforeEach(() => {
+    mockOnRollback.mockReset()
+  })
+
+  it('requires confirmation before rolling back a history version', () => {
+    render(
+      <YamlDiffViewer
+        open
+        onOpenChange={vi.fn()}
+        original={'kind: ConfigMap\nmetadata:\n  name: old\n'}
+        modified={'kind: ConfigMap\nmetadata:\n  name: new\n'}
+        current={'kind: ConfigMap\nmetadata:\n  name: current\n'}
+        onRollback={mockOnRollback}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'resourceHistory.rollback.previous',
+      })
+    )
+
+    expect(mockOnRollback).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('resourceHistory.rollback.confirmTitle')
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'resourceHistory.rollback.confirm',
+      })
+    )
+
+    expect(mockOnRollback).toHaveBeenCalledWith(
+      'kind: ConfigMap\nmetadata:\n  name: old\n'
+    )
+  })
+})

--- a/ui/src/components/yaml-diff-viewer.tsx
+++ b/ui/src/components/yaml-diff-viewer.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -47,6 +49,12 @@ interface YamlDiffViewerProps {
 }
 
 type DiffMode = 'previous-vs-modified' | 'current-vs-modified'
+type RollbackTarget = 'previous' | 'modified'
+
+type PendingRollback = {
+  target: RollbackTarget
+  yamlContent: string
+}
 
 export function YamlDiffViewer({
   original,
@@ -69,6 +77,8 @@ export function YamlDiffViewer({
   )
   const editorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
   const [diffMode, setDiffMode] = useState<DiffMode>('previous-vs-modified')
+  const [pendingRollback, setPendingRollback] =
+    useState<PendingRollback | null>(null)
 
   const handleEditorDidMount = (editor: monacoEditor.IStandaloneDiffEditor) => {
     editorRef.current = editor
@@ -126,48 +136,31 @@ export function YamlDiffViewer({
   const { original: leftContent, modified: rightContent } = getDiffContent()
 
   // Handle rollback button clicks
-  const handleRollbackClick = (yamlContent: string) => {
-    if (onRollback) {
-      onRollback(yamlContent)
+  const handleRollbackClick = (yamlContent: string, target: RollbackTarget) => {
+    setPendingRollback({ target, yamlContent })
+  }
+
+  const handleConfirmRollback = () => {
+    if (onRollback && pendingRollback) {
+      onRollback(pendingRollback.yamlContent)
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="!max-w-6xl sm:!max-w-6xl max-h-[80vh] flex flex-col">
-        <DialogHeader>
-          <DialogTitle className="flex items-center justify-between">
-            <span className="text-lg font-bold">{title}</span>
-            <div className="flex items-center gap-2 mr-4">
-              {current && (
-                <>
-                  {diffMode === 'current-vs-modified' && (
-                    <Button
-                      onClick={() => handleRollbackClick(modified)}
-                      disabled={isRollingBack}
-                      variant="outline"
-                      size="sm"
-                    >
-                      {isRollingBack
-                        ? t('resourceHistory.rollback.rollingBack')
-                        : t('resourceHistory.rollback.modified')}
-                    </Button>
-                  )}
-
-                  {diffMode === 'previous-vs-modified' && (
-                    <>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="!max-w-6xl sm:!max-w-6xl max-h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle className="flex items-center justify-between">
+              <span className="text-lg font-bold">{title}</span>
+              <div className="flex items-center gap-2 mr-4">
+                {current && (
+                  <>
+                    {diffMode === 'current-vs-modified' && (
                       <Button
-                        onClick={() => handleRollbackClick(original)}
-                        disabled={isRollingBack}
-                        variant="outline"
-                        size="sm"
-                      >
-                        {isRollingBack
-                          ? t('resourceHistory.rollback.rollingBack')
-                          : t('resourceHistory.rollback.previous')}
-                      </Button>
-                      <Button
-                        onClick={() => handleRollbackClick(modified)}
+                        onClick={() =>
+                          handleRollbackClick(modified, 'modified')
+                        }
                         disabled={isRollingBack}
                         variant="outline"
                         size="sm"
@@ -176,80 +169,154 @@ export function YamlDiffViewer({
                           ? t('resourceHistory.rollback.rollingBack')
                           : t('resourceHistory.rollback.modified')}
                       </Button>
-                    </>
-                  )}
+                    )}
 
-                  <Select
-                    value={diffMode}
-                    onValueChange={(value: DiffMode) => setDiffMode(value)}
-                  >
-                    <SelectTrigger className="max-w-64">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="previous-vs-modified">
-                        {t('resourceHistory.previousVsModified')}
-                      </SelectItem>
-                      <SelectItem value="current-vs-modified">
-                        {t('resourceHistory.currentVsModified')}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </>
-              )}
-            </div>
-          </DialogTitle>
-        </DialogHeader>
-        <div className="flex-1 min-h-0">
-          <Suspense
-            fallback={
-              <div
-                className="flex h-full items-center justify-center text-muted-foreground"
-                style={{ height }}
-              >
-                Loading editor...
+                    {diffMode === 'previous-vs-modified' && (
+                      <>
+                        <Button
+                          onClick={() =>
+                            handleRollbackClick(original, 'previous')
+                          }
+                          disabled={isRollingBack}
+                          variant="outline"
+                          size="sm"
+                        >
+                          {isRollingBack
+                            ? t('resourceHistory.rollback.rollingBack')
+                            : t('resourceHistory.rollback.previous')}
+                        </Button>
+                        <Button
+                          onClick={() =>
+                            handleRollbackClick(modified, 'modified')
+                          }
+                          disabled={isRollingBack}
+                          variant="outline"
+                          size="sm"
+                        >
+                          {isRollingBack
+                            ? t('resourceHistory.rollback.rollingBack')
+                            : t('resourceHistory.rollback.modified')}
+                        </Button>
+                      </>
+                    )}
+
+                    <Select
+                      value={diffMode}
+                      onValueChange={(value: DiffMode) => setDiffMode(value)}
+                    >
+                      <SelectTrigger className="max-w-64">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="previous-vs-modified">
+                          {t('resourceHistory.previousVsModified')}
+                        </SelectItem>
+                        <SelectItem value="current-vs-modified">
+                          {t('resourceHistory.currentVsModified')}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </>
+                )}
               </div>
-            }
-          >
-            <MonacoDiffEditor
-              key={`yaml-diff-viewer-${colorTheme}-${actualTheme}-${backgroundColor}`}
-              height={height}
-              language="yaml"
-              beforeMount={(monaco) => {
-                defineMonacoBackgroundThemes(monaco, {
-                  darkThemeName: `custom-dark-${colorTheme}`,
-                  lightThemeName: `custom-vs-${colorTheme}`,
-                  backgroundColor,
-                })
-              }}
-              theme={
-                actualTheme === 'dark'
-                  ? `custom-dark-${colorTheme}`
-                  : `custom-vs-${colorTheme}`
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0">
+            <Suspense
+              fallback={
+                <div
+                  className="flex h-full items-center justify-center text-muted-foreground"
+                  style={{ height }}
+                >
+                  Loading editor...
+                </div>
               }
-              options={{
-                readOnly: true,
-                minimap: { enabled: true },
-                scrollBeyondLastLine: false,
-                wordWrap: 'on',
-                folding: true,
-                lineNumbers: 'relative',
-                fontSize: 14,
-                fontFamily:
-                  "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
-                renderSideBySide: true,
-                enableSplitViewResizing: true,
-                renderOverviewRuler: true,
-                overviewRulerBorder: true,
-                overviewRulerLanes: 2,
-              }}
-              onMount={handleEditorDidMount}
-              original={leftContent}
-              modified={rightContent}
-            />
-          </Suspense>
-        </div>
-      </DialogContent>
-    </Dialog>
+            >
+              <MonacoDiffEditor
+                key={`yaml-diff-viewer-${colorTheme}-${actualTheme}-${backgroundColor}`}
+                height={height}
+                language="yaml"
+                beforeMount={(monaco) => {
+                  defineMonacoBackgroundThemes(monaco, {
+                    darkThemeName: `custom-dark-${colorTheme}`,
+                    lightThemeName: `custom-vs-${colorTheme}`,
+                    backgroundColor,
+                  })
+                }}
+                theme={
+                  actualTheme === 'dark'
+                    ? `custom-dark-${colorTheme}`
+                    : `custom-vs-${colorTheme}`
+                }
+                options={{
+                  readOnly: true,
+                  minimap: { enabled: true },
+                  scrollBeyondLastLine: false,
+                  wordWrap: 'on',
+                  folding: true,
+                  lineNumbers: 'relative',
+                  fontSize: 14,
+                  fontFamily:
+                    "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
+                  renderSideBySide: true,
+                  enableSplitViewResizing: true,
+                  renderOverviewRuler: true,
+                  overviewRulerBorder: true,
+                  overviewRulerLanes: 2,
+                }}
+                onMount={handleEditorDidMount}
+                original={leftContent}
+                modified={rightContent}
+              />
+            </Suspense>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(pendingRollback)}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !isRollingBack) {
+            setPendingRollback(null)
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t('resourceHistory.rollback.confirmTitle')}
+            </DialogTitle>
+            <DialogDescription>
+              {t('resourceHistory.rollback.confirmDescription', {
+                target:
+                  pendingRollback?.target === 'previous'
+                    ? t('resourceHistory.rollback.previous')
+                    : t('resourceHistory.rollback.modified'),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isRollingBack}
+              onClick={() => setPendingRollback(null)}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              disabled={isRollingBack}
+              onClick={handleConfirmRollback}
+            >
+              {isRollingBack
+                ? t('resourceHistory.rollback.rollingBack')
+                : t('resourceHistory.rollback.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -352,10 +352,24 @@
     "hostnames": "Hostnames"
   },
   "configMaps": {
-    "dataKeys": "Data Keys"
+    "dataKeys": "Data Keys",
+    "editDataTitle": "Edit ConfigMap data",
+    "editDataDescription": "Edit ConfigMap entries as key-value pairs. Empty keys are ignored when saving.",
+    "editConfig": "Edit config",
+    "confirmSaveDataTitle": "Confirm data changes",
+    "confirmSaveDataDescription": "This will update {{count}} ConfigMap data entries in the cluster. Please confirm the edited key-value pairs are correct.",
+    "confirmSaveData": "Confirm save",
+    "dataSaved": "ConfigMap data saved"
   },
   "secrets": {
-    "dataKeys": "Data Keys"
+    "dataKeys": "Data Keys",
+    "editConfig": "Edit secret",
+    "editDataTitle": "Edit Secret data",
+    "editDataDescription": "Edit decoded Secret entries as key-value pairs. Values are saved back as base64 data. Empty keys are ignored when saving.",
+    "confirmSaveDataTitle": "Confirm Secret data changes",
+    "confirmSaveDataDescription": "This will update {{count}} Secret data entries in the cluster. Please confirm the edited sensitive values are correct.",
+    "confirmSaveData": "Confirm save",
+    "dataSaved": "Secret data saved"
   },
   "crds": {
     "group": "Group",
@@ -1039,6 +1053,9 @@
       "previous": "Rollback Previous",
       "modified": "Rollback Modified",
       "rollingBack": "Rolling back...",
+      "confirmTitle": "Confirm rollback",
+      "confirmDescription": "This will apply {{target}} to the cluster. Please confirm before continuing.",
+      "confirm": "Confirm rollback",
       "success": "Successfully rolled back resource",
       "error": "Failed to rollback resource"
     }

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -377,10 +377,24 @@
     "hostnames": "主机名"
   },
   "configMaps": {
-    "dataKeys": "数据键"
+    "dataKeys": "数据键",
+    "editDataTitle": "编辑配置项数据",
+    "editDataDescription": "以键值对方式编辑配置项数据。保存时会忽略空键。",
+    "editConfig": "编辑配置",
+    "confirmSaveDataTitle": "确认数据变更",
+    "confirmSaveDataDescription": "这将更新集群中的 {{count}} 个配置项数据条目。请确认编辑后的键值对无误。",
+    "confirmSaveData": "确认保存",
+    "dataSaved": "配置项数据已保存"
   },
   "secrets": {
-    "dataKeys": "数据键"
+    "dataKeys": "数据键",
+    "editConfig": "编辑密钥",
+    "editDataTitle": "编辑密钥数据",
+    "editDataDescription": "以键值对方式编辑解码后的密钥数据。保存时会重新写回为 base64 data。空键会被忽略。",
+    "confirmSaveDataTitle": "确认密钥数据变更",
+    "confirmSaveDataDescription": "这将更新集群中的 {{count}} 个密钥数据条目。请确认编辑后的敏感值无误。",
+    "confirmSaveData": "确认保存",
+    "dataSaved": "密钥数据已保存"
   },
   "crds": {
     "group": "分组",
@@ -1251,6 +1265,9 @@
       "previous": "回滚到前一个版本",
       "modified": "回滚到修改版本",
       "rollingBack": "回滚中...",
+      "confirmTitle": "确认回滚",
+      "confirmDescription": "这会将 {{target}} 应用到集群中。请确认后再继续。",
+      "confirm": "确认回滚",
       "success": "资源回滚成功",
       "error": "资源回滚失败"
     }

--- a/ui/src/pages/configmap-detail.test.tsx
+++ b/ui/src/pages/configmap-detail.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import type { ConfigMap } from 'kubernetes-types/core/v1'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConfigMapDetail } from './configmap-detail'
+
+const mockUseResource = vi.fn()
+const mockUpdateResource = vi.fn()
+const mockCopyTextToClipboard = vi.fn()
+const mockT = (key: string) => key
+
+const configMap: ConfigMap = {
+  metadata: {
+    name: 'app-config',
+    namespace: 'default',
+    uid: 'uid-1',
+    resourceVersion: '42',
+    creationTimestamp: '2026-05-09T13:52:32.000Z',
+    labels: {
+      app: 'demo',
+    },
+    annotations: {
+      owner: 'platform',
+    },
+  },
+  data: {
+    'app.yaml': 'server:\n  port: 8080',
+    LOG_LEVEL: 'info',
+  },
+}
+
+function renderConfigMapDetail() {
+  return render(
+    <MemoryRouter>
+      <ConfigMapDetail namespace="default" name="app-config" />
+    </MemoryRouter>
+  )
+}
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: mockT,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+  updateResource: (...args: unknown[]) => mockUpdateResource(...args),
+}))
+
+vi.mock('@/lib/desktop', () => ({
+  copyTextToClipboard: (value: string) => mockCopyTextToClipboard(value),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/ui/responsive-tabs', () => ({
+  ResponsiveTabs: ({
+    tabs,
+  }: {
+    tabs: { value: string; label: string; content: React.ReactNode }[]
+  }) => (
+    <div>
+      <div>
+        {tabs.map((tab) => (
+          <span key={tab.value}>{tab.value}</span>
+        ))}
+      </div>
+      {tabs.map((tab) => (
+        <div key={tab.value}>{tab.content}</div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/refresh-button', () => ({
+  RefreshButton: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/describe-dialog', () => ({
+  DescribeDialog: () => <button>describe</button>,
+}))
+
+vi.mock('@/components/yaml-editor', () => ({
+  YamlEditor: () => <div>yaml-editor</div>,
+}))
+
+vi.mock('@/components/related-resource-table', () => ({
+  RelatedResourcesTable: () => <div>related-resources</div>,
+}))
+
+vi.mock('@/components/event-table', () => ({
+  EventTable: () => <div>events</div>,
+}))
+
+vi.mock('@/components/resource-history-table', () => ({
+  ResourceHistoryTable: () => <div>history</div>,
+}))
+
+vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
+  ResourceDeleteConfirmationDialog: () => null,
+}))
+
+describe('ConfigMapDetail', () => {
+  beforeEach(() => {
+    mockUseResource.mockReset()
+    mockUpdateResource.mockReset()
+    mockCopyTextToClipboard.mockReset()
+    mockUpdateResource.mockResolvedValue(undefined)
+    mockUseResource.mockReturnValue({
+      data: configMap,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('shows ConfigMap metadata and data in the overview without a data tab', () => {
+    renderConfigMapDetail()
+
+    expect(
+      screen.getByText('detail.sections.configMapInformation')
+    ).toBeInTheDocument()
+    expect(screen.getByText('uid-1')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('app: demo')).toBeInTheDocument()
+    expect(screen.getByText('owner: platform')).toBeInTheDocument()
+    expect(screen.getByText('app.yaml')).toBeInTheDocument()
+    expect(screen.getByText(/server:/)).toBeInTheDocument()
+    expect(screen.queryByText('data')).not.toBeInTheDocument()
+  })
+
+  it('saves ConfigMap data through the form editor', async () => {
+    renderConfigMapDetail()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    const dialog = screen.getByRole('dialog')
+    const logLevelInput = within(dialog).getByDisplayValue('LOG_LEVEL')
+    fireEvent.change(logLevelInput, { target: { value: 'MODE' } })
+
+    const infoValue = within(dialog).getByDisplayValue('info')
+    fireEvent.change(infoValue, { target: { value: 'production' } })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'common.save' }))
+
+    expect(mockUpdateResource).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('configMaps.confirmSaveDataTitle')
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'configMaps.confirmSaveData' })
+    )
+
+    expect(mockUpdateResource).toHaveBeenCalledWith(
+      'configmaps',
+      'app-config',
+      'default',
+      expect.objectContaining({
+        data: {
+          'app.yaml': 'server:\n  port: 8080',
+          MODE: 'production',
+        },
+      })
+    )
+  })
+})

--- a/ui/src/pages/configmap-detail.tsx
+++ b/ui/src/pages/configmap-detail.tsx
@@ -1,24 +1,39 @@
-import { useEffect, useState } from 'react'
-import { IconLoader, IconTrash } from '@tabler/icons-react'
+import { useEffect, useState, type FormEvent } from 'react'
+import { IconCopy, IconLoader, IconTrash } from '@tabler/icons-react'
 import * as yaml from 'js-yaml'
 import { ConfigMap } from 'kubernetes-types/core/v1'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { trackResourceAction } from '@/lib/analytics'
 import { updateResource, useResource } from '@/lib/api'
+import { copyTextToClipboard } from '@/lib/desktop'
 import { getOwnerInfo } from '@/lib/k8s'
-import { formatDate, translateError } from '@/lib/utils'
+import {
+  formatDate,
+  formatRelativeTimeStrict,
+  translateError,
+} from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
+import { Textarea } from '@/components/ui/textarea'
 import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
-import { KeyValueDataViewer } from '@/components/key-value-data-viewer'
 import { LabelsAnno } from '@/components/lables-anno'
 import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
@@ -26,12 +41,285 @@ import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-c
 import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
+type ConfigMapDataItem = {
+  key: string
+  value: string
+}
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
+
+function toDataItems(data?: Record<string, string>) {
+  return Object.entries(data || {}).map(([key, value]) => ({ key, value }))
+}
+
+function toDataRecord(items: ConfigMapDataItem[]) {
+  return items.reduce<Record<string, string>>((result, item) => {
+    const key = item.key.trim()
+    if (!key) {
+      return result
+    }
+
+    result[key] = item.value
+    return result
+  }, {})
+}
+
+function ConfigMapDataTable(props: {
+  entries: Record<string, string>
+  emptyMessage: string
+}) {
+  const { entries, emptyMessage } = props
+  const { t } = useTranslation()
+  const items = Object.entries(entries)
+
+  const copyValue = async (value: string) => {
+    await copyTextToClipboard(value)
+    toast.success(t('keyValueDataViewer.copiedToClipboard'))
+  }
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <div className="grid grid-cols-[minmax(160px,280px)_minmax(0,1fr)_48px] border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+        <div>{t('detail.fields.key')}</div>
+        <div>{t('detail.fields.value')}</div>
+        <div className="text-right">{t('common.actions', 'Actions')}</div>
+      </div>
+      <div className="divide-y">
+        {items.map(([key, value]) => (
+          <div
+            key={key}
+            className="grid grid-cols-[minmax(160px,280px)_minmax(0,1fr)_48px] items-start gap-3 px-3 py-2"
+          >
+            <div className="break-all font-mono text-sm font-medium">{key}</div>
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-relaxed">
+              {value}
+            </pre>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 justify-self-end"
+              aria-label={t('keyValueDataViewer.copyValue')}
+              onClick={() => copyValue(value)}
+            >
+              <IconCopy className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ConfigMapDataEditDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  configmap: ConfigMap
+  onSave: (data: Record<string, string>) => Promise<boolean>
+}) {
+  const { configmap, onOpenChange, onSave, open } = props
+  const { t } = useTranslation()
+  const [items, setItems] = useState<ConfigMapDataItem[]>([])
+  const [pendingData, setPendingData] = useState<Record<string, string> | null>(
+    null
+  )
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setItems(toDataItems(configmap.data))
+    setPendingData(null)
+    setIsConfirmOpen(false)
+    setIsSaving(false)
+  }, [configmap.data, open])
+
+  const handleItemChange = (
+    index: number,
+    field: keyof ConfigMapDataItem,
+    value: string
+  ) => {
+    setItems((current) =>
+      current.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, [field]: value } : item
+      )
+    )
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setPendingData(toDataRecord(items))
+    setIsConfirmOpen(true)
+  }
+
+  const handleConfirmSave = async () => {
+    if (!pendingData) {
+      return
+    }
+
+    setIsSaving(true)
+
+    try {
+      const saved = await onSave(pendingData)
+      if (saved) {
+        setIsConfirmOpen(false)
+        setPendingData(null)
+        onOpenChange(false)
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex h-[85vh] max-h-[85vh] flex-col overflow-hidden sm:max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>{t('configMaps.editDataTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('configMaps.editDataDescription')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            onSubmit={handleSubmit}
+          >
+            <div className="flex items-center justify-between gap-3 pb-4">
+              <Label>{t('detail.tabs.data')}</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setItems((current) => [{ key: '', value: '' }, ...current])
+                }
+              >
+                <Plus className="h-4 w-4" />
+                {t('common.add', 'Add')}
+              </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+              {items.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t('detail.empty.noDataEntries')}
+                </p>
+              ) : null}
+
+              <div className="space-y-3">
+                {items.map((item, index) => (
+                  <div
+                    key={`configmap-data-${index}`}
+                    className="grid grid-cols-[minmax(160px,240px)_minmax(0,1fr)_auto] gap-2 rounded-md border p-3"
+                  >
+                    <Input
+                      value={item.key}
+                      onChange={(event) =>
+                        handleItemChange(index, 'key', event.target.value)
+                      }
+                      placeholder={t('common.key', 'Key')}
+                    />
+                    <Textarea
+                      value={item.value}
+                      onChange={(event) =>
+                        handleItemChange(index, 'value', event.target.value)
+                      }
+                      placeholder={t('common.value', 'Value')}
+                      className="min-h-20 font-mono text-xs"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t('common.remove', 'Remove')}
+                      onClick={() =>
+                        setItems((current) =>
+                          current.filter((_, itemIndex) => itemIndex !== index)
+                        )
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <DialogFooter className="mt-4 shrink-0 border-t pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSaving}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSaving}>
+                {t('common.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('configMaps.confirmSaveDataTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('configMaps.confirmSaveDataDescription', {
+                count: Object.keys(pendingData || {}).length,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsConfirmOpen(false)}
+              disabled={isSaving}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirmSave}
+              disabled={isSaving}
+            >
+              {isSaving
+                ? t('common.saving', 'Saving...')
+                : t('configMaps.confirmSaveData')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
 export function ConfigMapDetail(props: { namespace: string; name: string }) {
   const { namespace, name } = props
   const [yamlContent, setYamlContent] = useState('')
   const [isSavingYaml, setIsSavingYaml] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isDataEditDialogOpen, setIsDataEditDialogOpen] = useState(false)
 
   const { t } = useTranslation()
 
@@ -70,6 +358,31 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
     }
   }
 
+  const handleSaveData = async (nextData: Record<string, string>) => {
+    if (!data) {
+      return false
+    }
+
+    try {
+      await updateResource('configmaps', name, namespace, {
+        ...(data as ConfigMap),
+        data: nextData,
+      })
+      trackResourceAction('configmaps', 'data_form_save', {
+        result: 'success',
+      })
+      toast.success(t('configMaps.dataSaved'))
+      await handleRefresh()
+      return true
+    } catch (error) {
+      trackResourceAction('configmaps', 'data_form_save', {
+        result: 'error',
+      })
+      toast.error(translateError(error, t))
+      return false
+    }
+  }
+
   const handleManualRefresh = async () => {
     trackResourceAction('configmaps', 'refresh')
     setRefreshKey((prev) => prev + 1)
@@ -102,6 +415,10 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
   const dataCount = Object.keys(configmap.data || {}).length
   const binaryDataCount = Object.keys(configmap.binaryData || {}).length
   const totalCount = dataCount + binaryDataCount
+  const labelCount = Object.keys(configmap.metadata?.labels || {}).length
+  const annotationCount = Object.keys(
+    configmap.metadata?.annotations || {}
+  ).length
 
   return (
     <div className="space-y-2">
@@ -155,12 +472,27 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                       <div>
                         <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.name')}
+                        </Label>
+                        <p className="break-all text-sm font-medium">
+                          {configmap.metadata!.name}
+                        </p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.namespace')}
+                        </Label>
+                        <p className="text-sm font-medium">
+                          {configmap.metadata!.namespace}
+                        </p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
                           {t('detail.fields.created')}
                         </Label>
                         <p className="text-sm">
-                          {formatDate(
-                            configmap.metadata!.creationTimestamp!,
-                            true
+                          {formatTimestampWithRelative(
+                            configmap.metadata!.creationTimestamp
                           )}
                         </p>
                       </div>
@@ -169,6 +501,24 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
                           {t('detail.fields.keys')}
                         </Label>
                         <p className="text-sm">{totalCount}</p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.labels')}
+                        </Label>
+                        <p className="text-sm">{labelCount}</p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.annotations')}
+                        </Label>
+                        <p className="text-sm">{annotationCount}</p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.binaryData')}
+                        </Label>
+                        <p className="text-sm">{binaryDataCount}</p>
                       </div>
                       <div>
                         <Label className="text-xs text-muted-foreground">
@@ -208,48 +558,52 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
                     />
                   </CardContent>
                 </Card>
-              </div>
-            ),
-          },
-          {
-            value: 'data',
-            label: (
-              <>
-                {t('detail.tabs.data')}
-                {totalCount > 0 && (
-                  <Badge variant="secondary">{totalCount}</Badge>
-                )}
-              </>
-            ),
-            content: (
-              <div className="space-y-4">
-                {dataCount > 0 && (
-                  <KeyValueDataViewer
-                    entries={configmap.data!}
-                    emptyMessage={t('detail.empty.noDataEntries')}
-                  />
-                )}
-                {binaryDataCount > 0 && (
-                  <div className="space-y-2">
-                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                      {t('detail.fields.binaryData')}
-                    </p>
-                    <KeyValueDataViewer
-                      entries={Object.fromEntries(
-                        Object.entries(configmap.binaryData!).map(([k, v]) => [
-                          k,
-                          v as unknown as string,
-                        ])
+
+                <Card>
+                  <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <CardTitle className="flex items-center gap-2">
+                      {t('detail.tabs.data')}
+                      {dataCount > 0 && (
+                        <Badge variant="secondary">{dataCount}</Badge>
                       )}
-                      base64Encoded
-                      emptyMessage={t('detail.empty.noBinaryDataEntries')}
+                    </CardTitle>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsDataEditDialogOpen(true)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                      {t('common.edit')}
+                    </Button>
+                  </CardHeader>
+                  <CardContent>
+                    <ConfigMapDataTable
+                      entries={configmap.data || {}}
+                      emptyMessage={t('detail.empty.noDataEntries')}
                     />
-                  </div>
-                )}
-                {totalCount === 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    {t('detail.empty.noDataEntries')}
-                  </p>
+                  </CardContent>
+                </Card>
+
+                {binaryDataCount > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        {t('detail.fields.binaryData')}
+                        <Badge variant="secondary">{binaryDataCount}</Badge>
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <ConfigMapDataTable
+                        entries={Object.fromEntries(
+                          Object.entries(configmap.binaryData!).map(
+                            ([key, value]) => [key, value as unknown as string]
+                          )
+                        )}
+                        emptyMessage={t('detail.empty.noBinaryDataEntries')}
+                      />
+                    </CardContent>
+                  </Card>
                 )}
               </div>
             ),
@@ -314,6 +668,13 @@ export function ConfigMapDetail(props: { namespace: string; name: string }) {
         resourceType="configmaps"
         namespace={namespace}
         confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
+      />
+
+      <ConfigMapDataEditDialog
+        open={isDataEditDialogOpen}
+        onOpenChange={setIsDataEditDialogOpen}
+        configmap={configmap}
+        onSave={handleSaveData}
       />
     </div>
   )

--- a/ui/src/pages/configmap-list-page.tsx
+++ b/ui/src/pages/configmap-list-page.tsx
@@ -1,22 +1,35 @@
 import { useCallback, useMemo, useState } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 import { ConfigMap } from 'kubernetes-types/core/v1'
-import { Copy, FileCode2, FileText, Tags } from 'lucide-react'
+import { FileCode2, FileText, Pencil, Tags, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
-import { toast } from 'sonner'
 
-import { copyTextToClipboard } from '@/lib/desktop'
-import { formatDate } from '@/lib/utils'
+import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
 import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
+import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
 
 export function ConfigMapListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [labelsConfigMap, setLabelsConfigMap] = useState<ConfigMap | null>(null)
   const [annotationsConfigMap, setAnnotationsConfigMap] =
+    useState<ConfigMap | null>(null)
+  const [deleteConfigMapTarget, setDeleteConfigMapTarget] =
     useState<ConfigMap | null>(null)
   const columnHelper = useMemo(() => createColumnHelper<ConfigMap>(), [])
 
@@ -37,31 +50,46 @@ export function ConfigMapListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('data', {
-        header: t('configMaps.dataKeys'),
-        cell: ({ getValue }) => {
-          const data = getValue() || {}
-          const keys = Object.keys(data)
-          if (keys.length === 0) {
-            return '-'
-          }
-          // Limit to first 5 keys for display
-          return keys.length > 5 ? (
-            <span className="text-muted-foreground">
-              {keys.slice(0, 5).join(', ')}...
-            </span>
-          ) : (
-            <span className="text-muted-foreground">{keys.join(', ')}</span>
-          )
-        },
+      columnHelper.display({
+        id: 'labels',
+        header: t('detail.fields.labels'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="labels"
+            ariaLabel={t('common.manageLabels', 'Manage labels')}
+            count={Object.keys(row.original.metadata?.labels || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.labels
+            )}
+            onClick={() => setLabelsConfigMap(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'annotations',
+        header: t('detail.fields.annotations'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="annotations"
+            ariaLabel={t('common.manageAnnotations', 'Manage annotations')}
+            count={Object.keys(row.original.metadata?.annotations || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.annotations
+            )}
+            onClick={() => setAnnotationsConfigMap(row.original)}
+          />
+        ),
       }),
       columnHelper.accessor('metadata.creationTimestamp', {
+        id: 'created',
         header: t('common.created'),
         cell: ({ getValue }) => {
-          const dateStr = formatDate(getValue() || '')
-
           return (
-            <span className="text-muted-foreground text-sm">{dateStr}</span>
+            <span className="text-muted-foreground text-sm">
+              {formatTimestampWithRelative(getValue())}
+            </span>
           )
         },
       }),
@@ -74,12 +102,20 @@ export function ConfigMapListPage() {
     (configMap: ConfigMap, query: string) => {
       const dataKeys = Object.keys(configMap.data || {}).join(' ')
       const binaryDataKeys = Object.keys(configMap.binaryData || {}).join(' ')
+      const labels = Object.entries(configMap.metadata?.labels || {})
+        .map(([key, value]) => `${key} ${value}`)
+        .join(' ')
+      const annotations = Object.entries(configMap.metadata?.annotations || {})
+        .map(([key, value]) => `${key} ${value}`)
+        .join(' ')
 
       return (
         configMap.metadata!.name!.toLowerCase().includes(query) ||
         (configMap.metadata!.namespace?.toLowerCase() || '').includes(query) ||
         dataKeys.toLowerCase().includes(query) ||
-        binaryDataKeys.toLowerCase().includes(query)
+        binaryDataKeys.toLowerCase().includes(query) ||
+        labels.toLowerCase().includes(query) ||
+        annotations.toLowerCase().includes(query)
       )
     },
     []
@@ -89,51 +125,47 @@ export function ConfigMapListPage() {
     return `/configmaps/${configMap.metadata!.namespace}/${configMap.metadata!.name}`
   }, [])
 
-  const handleCopy = useCallback(
-    async (value: string) => {
-      await copyTextToClipboard(value)
-      toast.success(t('keyValueDataViewer.copiedToClipboard'))
-    },
-    [t]
-  )
-
   const getRowContextMenuItems = useCallback(
-    (configMap: ConfigMap): RowContextMenuItem<ConfigMap>[] => [
-      {
-        key: 'view-yaml',
-        label: t('common.viewYaml', 'View YAML'),
-        icon: <FileCode2 className="h-4 w-4" />,
-        onSelect: () =>
-          navigate(`${getConfigMapDetailPath(configMap)}?tab=yaml`),
-      },
-      { type: 'separator', key: 'primary-actions-separator' },
-      {
-        key: 'copy-name',
-        label: t('common.copyName', 'Copy name'),
-        icon: <Copy className="h-4 w-4" />,
-        onSelect: () => handleCopy(configMap.metadata?.name || ''),
-      },
-      {
-        key: 'copy-namespace',
-        label: t('common.copyNamespace', 'Copy namespace'),
-        icon: <Copy className="h-4 w-4" />,
-        onSelect: () => handleCopy(configMap.metadata?.namespace || ''),
-      },
-      { type: 'separator', key: 'metadata-actions-separator' },
-      {
-        key: 'manage-labels',
-        label: t('common.manageLabels', 'Manage labels'),
-        icon: <Tags className="h-4 w-4" />,
-        onSelect: () => setLabelsConfigMap(configMap),
-      },
-      {
-        key: 'manage-annotations',
-        label: t('common.manageAnnotations', 'Manage annotations'),
-        icon: <FileText className="h-4 w-4" />,
-        onSelect: () => setAnnotationsConfigMap(configMap),
-      },
-    ],
-    [getConfigMapDetailPath, handleCopy, navigate, t]
+    (configMap: ConfigMap): RowContextMenuItem<ConfigMap>[] => {
+      const detailPath = getConfigMapDetailPath(configMap)
+
+      return [
+        {
+          key: 'view-yaml',
+          label: t('common.viewYaml', 'View YAML'),
+          icon: <FileCode2 className="h-4 w-4" />,
+          onSelect: () => navigate(`${detailPath}?tab=yaml`),
+        },
+        {
+          key: 'edit-config',
+          label: t('configMaps.editConfig', 'Edit config'),
+          icon: <Pencil className="h-4 w-4" />,
+          onSelect: () => navigate(detailPath),
+        },
+        { type: 'separator', key: 'metadata-actions-separator' },
+        {
+          key: 'manage-labels',
+          label: t('common.manageLabels', 'Manage labels'),
+          icon: <Tags className="h-4 w-4" />,
+          onSelect: () => setLabelsConfigMap(configMap),
+        },
+        {
+          key: 'manage-annotations',
+          label: t('common.manageAnnotations', 'Manage annotations'),
+          icon: <FileText className="h-4 w-4" />,
+          onSelect: () => setAnnotationsConfigMap(configMap),
+        },
+        { type: 'separator', key: 'danger-actions-separator' },
+        {
+          key: 'delete-configmap',
+          label: t('common.delete'),
+          icon: <Trash2 className="h-4 w-4" />,
+          variant: 'destructive',
+          onSelect: () => setDeleteConfigMapTarget(configMap),
+        },
+      ]
+    },
+    [getConfigMapDetailPath, navigate, t]
   )
 
   return (
@@ -170,6 +202,19 @@ export function ConfigMapListPage() {
         resourceType="configmaps"
         resource={annotationsConfigMap}
         type="annotations"
+      />
+
+      <ResourceDeleteConfirmationDialog
+        open={Boolean(deleteConfigMapTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteConfigMapTarget(null)
+          }
+        }}
+        resourceName={deleteConfigMapTarget?.metadata?.name || ''}
+        resourceType="configmaps"
+        namespace={deleteConfigMapTarget?.metadata?.namespace}
+        confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
       />
     </>
   )

--- a/ui/src/pages/secret-detail.test.tsx
+++ b/ui/src/pages/secret-detail.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import type { Secret } from 'kubernetes-types/core/v1'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SecretDetail } from './secret-detail'
+
+const mockUseResource = vi.fn()
+const mockUpdateResource = vi.fn()
+const mockCopyTextToClipboard = vi.fn()
+const mockT = (key: string) => key
+
+const secret: Secret = {
+  metadata: {
+    name: 'app-secret',
+    namespace: 'default',
+    uid: 'uid-secret',
+    resourceVersion: '7',
+    creationTimestamp: '2026-05-09T13:52:32.000Z',
+    labels: {
+      app: 'demo',
+    },
+    annotations: {
+      owner: 'platform',
+    },
+  },
+  type: 'Opaque',
+  data: {
+    PASSWORD: btoa('old-password'),
+    TOKEN: btoa('abc123'),
+  },
+}
+
+function renderSecretDetail() {
+  return render(
+    <MemoryRouter>
+      <SecretDetail namespace="default" name="app-secret" />
+    </MemoryRouter>
+  )
+}
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: mockT,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+  updateResource: (...args: unknown[]) => mockUpdateResource(...args),
+}))
+
+vi.mock('@/lib/desktop', () => ({
+  copyTextToClipboard: (value: string) => mockCopyTextToClipboard(value),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/ui/responsive-tabs', () => ({
+  ResponsiveTabs: ({
+    tabs,
+  }: {
+    tabs: { value: string; label: string; content: React.ReactNode }[]
+  }) => (
+    <div>
+      <div>
+        {tabs.map((tab) => (
+          <span key={tab.value}>{tab.value}</span>
+        ))}
+      </div>
+      {tabs.map((tab) => (
+        <div key={tab.value}>{tab.content}</div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/refresh-button', () => ({
+  RefreshButton: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/yaml-editor', () => ({
+  YamlEditor: () => <div>yaml-editor</div>,
+}))
+
+vi.mock('@/components/related-resource-table', () => ({
+  RelatedResourcesTable: () => <div>related-resources</div>,
+}))
+
+vi.mock('@/components/event-table', () => ({
+  EventTable: () => <div>events</div>,
+}))
+
+vi.mock('@/components/resource-history-table', () => ({
+  ResourceHistoryTable: () => <div>history</div>,
+}))
+
+vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
+  ResourceDeleteConfirmationDialog: () => null,
+}))
+
+describe('SecretDetail', () => {
+  beforeEach(() => {
+    mockUseResource.mockReset()
+    mockUpdateResource.mockReset()
+    mockCopyTextToClipboard.mockReset()
+    mockUpdateResource.mockResolvedValue(undefined)
+    mockUseResource.mockReturnValue({
+      data: secret,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it('shows Secret metadata and data in the overview without a data tab', () => {
+    renderSecretDetail()
+
+    expect(
+      screen.getByText('detail.sections.secretInformation')
+    ).toBeInTheDocument()
+    expect(screen.getByText('uid-secret')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(screen.getByText('app: demo')).toBeInTheDocument()
+    expect(screen.getByText('owner: platform')).toBeInTheDocument()
+    expect(screen.getByText('PASSWORD')).toBeInTheDocument()
+    expect(screen.getByText('TOKEN')).toBeInTheDocument()
+    expect(screen.queryByText('data')).not.toBeInTheDocument()
+  })
+
+  it('reveals all secret values from the data toolbar', () => {
+    renderSecretDetail()
+
+    const password = screen.getByText('old-password')
+    expect(password).toHaveClass('blur-sm')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'keyValueDataViewer.revealAll' })
+    )
+
+    expect(password).not.toHaveClass('blur-sm')
+    expect(
+      screen.getByRole('button', { name: 'keyValueDataViewer.hideAll' })
+    ).toBeInTheDocument()
+  })
+
+  it('saves decoded Secret data through the form editor after confirmation', () => {
+    renderSecretDetail()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+
+    const dialog = screen.getByRole('dialog')
+    const passwordValue = within(dialog).getByDisplayValue('old-password')
+    fireEvent.change(passwordValue, { target: { value: 'new-password' } })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'common.save' }))
+
+    expect(mockUpdateResource).not.toHaveBeenCalled()
+    expect(screen.getByText('secrets.confirmSaveDataTitle')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'secrets.confirmSaveData' })
+    )
+
+    expect(mockUpdateResource).toHaveBeenCalledWith(
+      'secrets',
+      'app-secret',
+      'default',
+      expect.objectContaining({
+        data: {
+          PASSWORD: btoa('new-password'),
+          TOKEN: btoa('abc123'),
+        },
+        stringData: undefined,
+      })
+    )
+  })
+})

--- a/ui/src/pages/secret-detail.tsx
+++ b/ui/src/pages/secret-detail.tsx
@@ -1,23 +1,44 @@
-import { useEffect, useState } from 'react'
-import { IconLoader, IconTrash } from '@tabler/icons-react'
+import { useEffect, useState, type FormEvent } from 'react'
+import {
+  IconCopy,
+  IconEye,
+  IconEyeOff,
+  IconLoader,
+  IconTrash,
+} from '@tabler/icons-react'
 import * as yaml from 'js-yaml'
 import { Secret } from 'kubernetes-types/core/v1'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { trackResourceAction } from '@/lib/analytics'
 import { updateResource, useResource } from '@/lib/api'
+import { copyTextToClipboard } from '@/lib/desktop'
 import { getOwnerInfo } from '@/lib/k8s'
-import { formatDate, translateError } from '@/lib/utils'
+import {
+  formatDate,
+  formatRelativeTimeStrict,
+  translateError,
+} from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
+import { Textarea } from '@/components/ui/textarea'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
-import { KeyValueDataViewer } from '@/components/key-value-data-viewer'
 import { LabelsAnno } from '@/components/lables-anno'
 import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
@@ -25,12 +46,348 @@ import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-c
 import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
+type SecretDataItem = {
+  key: string
+  value: string
+}
+
+function decodeBase64Value(value: string) {
+  try {
+    return atob(value)
+  } catch {
+    return value
+  }
+}
+
+function encodeBase64Value(value: string) {
+  return btoa(value)
+}
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
+
+function toDecodedDataItems(data?: Record<string, string>) {
+  return Object.entries(data || {}).map(([key, value]) => ({
+    key,
+    value: decodeBase64Value(value),
+  }))
+}
+
+function toEncodedDataRecord(items: SecretDataItem[]) {
+  return items.reduce<Record<string, string>>((result, item) => {
+    const key = item.key.trim()
+    if (!key) {
+      return result
+    }
+
+    result[key] = encodeBase64Value(item.value)
+    return result
+  }, {})
+}
+
+function SecretDataTable(props: {
+  entries: Record<string, string>
+  emptyMessage: string
+  revealAll: boolean
+}) {
+  const { entries, emptyMessage, revealAll } = props
+  const { t } = useTranslation()
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
+  const items = Object.entries(entries)
+
+  useEffect(() => {
+    setRevealedKeys(revealAll ? new Set(Object.keys(entries)) : new Set())
+  }, [entries, revealAll])
+
+  const copyValue = async (value: string) => {
+    await copyTextToClipboard(value)
+    toast.success(t('keyValueDataViewer.copiedToClipboard'))
+  }
+
+  const toggleKey = (key: string) => {
+    setRevealedKeys((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <div className="grid grid-cols-[minmax(160px,280px)_minmax(0,1fr)_88px] border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+        <div>{t('detail.fields.key')}</div>
+        <div>{t('detail.fields.value')}</div>
+        <div className="text-right">{t('common.actions', 'Actions')}</div>
+      </div>
+      <div className="divide-y">
+        {items.map(([key, rawValue]) => {
+          const value = decodeBase64Value(rawValue)
+          const revealed = revealedKeys.has(key)
+
+          return (
+            <div
+              key={key}
+              className="grid grid-cols-[minmax(160px,280px)_minmax(0,1fr)_88px] items-start gap-3 px-3 py-2"
+            >
+              <div className="break-all font-mono text-sm font-medium">
+                {key}
+              </div>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-relaxed">
+                <span className={revealed ? '' : 'blur-sm select-none inline'}>
+                  {value}
+                </span>
+              </pre>
+              <div className="flex justify-end gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={
+                    revealed
+                      ? t('keyValueDataViewer.hide')
+                      : t('keyValueDataViewer.reveal')
+                  }
+                  onClick={() => toggleKey(key)}
+                >
+                  {revealed ? (
+                    <IconEyeOff className="h-4 w-4" />
+                  ) : (
+                    <IconEye className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={t('keyValueDataViewer.copyValue')}
+                  onClick={() => copyValue(value)}
+                >
+                  <IconCopy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function SecretDataEditDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  secret: Secret
+  onSave: (data: Record<string, string>) => Promise<boolean>
+}) {
+  const { onOpenChange, onSave, open, secret } = props
+  const { t } = useTranslation()
+  const [items, setItems] = useState<SecretDataItem[]>([])
+  const [pendingData, setPendingData] = useState<Record<string, string> | null>(
+    null
+  )
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setItems(toDecodedDataItems(secret.data))
+    setPendingData(null)
+    setIsConfirmOpen(false)
+    setIsSaving(false)
+  }, [open, secret.data])
+
+  const handleItemChange = (
+    index: number,
+    field: keyof SecretDataItem,
+    value: string
+  ) => {
+    setItems((current) =>
+      current.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, [field]: value } : item
+      )
+    )
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setPendingData(toEncodedDataRecord(items))
+    setIsConfirmOpen(true)
+  }
+
+  const handleConfirmSave = async () => {
+    if (!pendingData) {
+      return
+    }
+
+    setIsSaving(true)
+
+    try {
+      const saved = await onSave(pendingData)
+      if (saved) {
+        setIsConfirmOpen(false)
+        setPendingData(null)
+        onOpenChange(false)
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex h-[85vh] max-h-[85vh] flex-col overflow-hidden sm:max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>{t('secrets.editDataTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('secrets.editDataDescription')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            onSubmit={handleSubmit}
+          >
+            <div className="flex items-center justify-between gap-3 pb-4">
+              <Label>{t('detail.tabs.data')}</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setItems((current) => [{ key: '', value: '' }, ...current])
+                }
+              >
+                <Plus className="h-4 w-4" />
+                {t('common.add', 'Add')}
+              </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+              {items.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t('detail.empty.noDataEntries')}
+                </p>
+              ) : null}
+
+              <div className="space-y-3">
+                {items.map((item, index) => (
+                  <div
+                    key={`secret-data-${index}`}
+                    className="grid grid-cols-[minmax(160px,240px)_minmax(0,1fr)_auto] gap-2 rounded-md border p-3"
+                  >
+                    <Input
+                      value={item.key}
+                      onChange={(event) =>
+                        handleItemChange(index, 'key', event.target.value)
+                      }
+                      placeholder={t('common.key', 'Key')}
+                    />
+                    <Textarea
+                      value={item.value}
+                      onChange={(event) =>
+                        handleItemChange(index, 'value', event.target.value)
+                      }
+                      placeholder={t('common.value', 'Value')}
+                      className="min-h-20 font-mono text-xs"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t('common.remove', 'Remove')}
+                      onClick={() =>
+                        setItems((current) =>
+                          current.filter((_, itemIndex) => itemIndex !== index)
+                        )
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <DialogFooter className="mt-4 shrink-0 border-t pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSaving}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSaving}>
+                {t('common.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t('secrets.confirmSaveDataTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('secrets.confirmSaveDataDescription', {
+                count: Object.keys(pendingData || {}).length,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsConfirmOpen(false)}
+              disabled={isSaving}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirmSave}
+              disabled={isSaving}
+            >
+              {isSaving
+                ? t('common.saving', 'Saving...')
+                : t('secrets.confirmSaveData')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
 export function SecretDetail(props: { namespace: string; name: string }) {
   const { namespace, name } = props
   const [yamlContent, setYamlContent] = useState('')
   const [isSavingYaml, setIsSavingYaml] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isDataEditDialogOpen, setIsDataEditDialogOpen] = useState(false)
+  const [isAllDataRevealed, setIsAllDataRevealed] = useState(false)
   const [showDecodedYaml, setShowDecodedYaml] = useState(false)
 
   const { t } = useTranslation()
@@ -72,6 +429,32 @@ export function SecretDetail(props: { namespace: string; name: string }) {
 
   const handleYamlChange = (content: string) => {
     setYamlContent(content)
+  }
+
+  const handleSaveData = async (nextData: Record<string, string>) => {
+    if (!data) {
+      return false
+    }
+
+    try {
+      await updateResource('secrets', name, namespace, {
+        ...(data as Secret),
+        data: nextData,
+        stringData: undefined,
+      })
+      trackResourceAction('secrets', 'data_form_save', {
+        result: 'success',
+      })
+      toast.success(t('secrets.dataSaved'))
+      await handleRefresh()
+      return true
+    } catch (error) {
+      trackResourceAction('secrets', 'data_form_save', {
+        result: 'error',
+      })
+      toast.error(translateError(error, t))
+      return false
+    }
   }
 
   const handleManualRefresh = async () => {
@@ -131,6 +514,13 @@ export function SecretDetail(props: { namespace: string; name: string }) {
   const ownerInfo = getOwnerInfo(secret.metadata)
   const isOwnedBy = ownerInfo !== null
   const owner = ownerInfo
+  const dataCount = Object.keys(secret.data || {}).length
+  const labelCount = Object.keys(secret.metadata?.labels || {}).length
+  const annotationCount = Object.keys(secret.metadata?.annotations || {}).length
+  const dataSize = Object.values(secret.data || {}).reduce(
+    (total, value) => total + value.length,
+    0
+  )
 
   return (
     <div className="space-y-2">
@@ -180,12 +570,27 @@ export function SecretDetail(props: { namespace: string; name: string }) {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                       <div>
                         <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.name')}
+                        </Label>
+                        <p className="break-all text-sm font-medium">
+                          {secret.metadata!.name}
+                        </p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.namespace')}
+                        </Label>
+                        <p className="text-sm font-medium">
+                          {secret.metadata!.namespace}
+                        </p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
                           {t('detail.fields.created')}
                         </Label>
                         <p className="text-sm">
-                          {formatDate(
-                            secret.metadata!.creationTimestamp!,
-                            true
+                          {formatTimestampWithRelative(
+                            secret.metadata!.creationTimestamp
                           )}
                         </p>
                       </div>
@@ -203,21 +608,27 @@ export function SecretDetail(props: { namespace: string; name: string }) {
                         <Label className="text-xs text-muted-foreground">
                           {t('detail.fields.keys')}
                         </Label>
-                        <p className="text-sm">
-                          {Object.keys(secret.data || {}).length}
-                        </p>
+                        <p className="text-sm">{dataCount}</p>
                       </div>
                       <div>
                         <Label className="text-xs text-muted-foreground">
                           {t('detail.fields.size')}
                         </Label>
                         <p className="text-sm">
-                          {Object.values(secret.data || {}).reduce(
-                            (total, value) => total + value.length,
-                            0
-                          )}{' '}
-                          {t('detail.fields.bytes')}
+                          {dataSize} {t('detail.fields.bytes')}
                         </p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.labels')}
+                        </Label>
+                        <p className="text-sm">{labelCount}</p>
+                      </div>
+                      <div>
+                        <Label className="text-xs text-muted-foreground">
+                          {t('detail.fields.annotations')}
+                        </Label>
+                        <p className="text-sm">{annotationCount}</p>
                       </div>
                       <div>
                         <Label className="text-xs text-muted-foreground">
@@ -254,28 +665,55 @@ export function SecretDetail(props: { namespace: string; name: string }) {
                     />
                   </CardContent>
                 </Card>
+
+                <Card>
+                  <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <CardTitle className="flex items-center gap-2">
+                      {t('detail.tabs.data')}
+                      {dataCount > 0 && (
+                        <Badge variant="secondary">{dataCount}</Badge>
+                      )}
+                    </CardTitle>
+                    <div className="flex flex-wrap gap-2">
+                      {dataCount > 0 && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            setIsAllDataRevealed((current) => !current)
+                          }
+                        >
+                          {isAllDataRevealed ? (
+                            <IconEyeOff className="h-4 w-4" />
+                          ) : (
+                            <IconEye className="h-4 w-4" />
+                          )}
+                          {isAllDataRevealed
+                            ? t('keyValueDataViewer.hideAll')
+                            : t('keyValueDataViewer.revealAll')}
+                        </Button>
+                      )}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setIsDataEditDialogOpen(true)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                        {t('common.edit')}
+                      </Button>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <SecretDataTable
+                      entries={secret.data || {}}
+                      emptyMessage={t('detail.empty.noDataEntries')}
+                      revealAll={isAllDataRevealed}
+                    />
+                  </CardContent>
+                </Card>
               </div>
-            ),
-          },
-          {
-            value: 'data',
-            label: (
-              <>
-                {t('detail.tabs.data')}
-                {secret.data && (
-                  <Badge variant="secondary">
-                    {Object.keys(secret.data).length}
-                  </Badge>
-                )}
-              </>
-            ),
-            content: (
-              <KeyValueDataViewer
-                entries={secret.data || {}}
-                sensitive
-                base64Encoded
-                emptyMessage={t('detail.empty.noDataEntries')}
-              />
             ),
           },
           {
@@ -351,6 +789,13 @@ export function SecretDetail(props: { namespace: string; name: string }) {
         resourceType="secrets"
         namespace={namespace}
         confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
+      />
+
+      <SecretDataEditDialog
+        open={isDataEditDialogOpen}
+        onOpenChange={setIsDataEditDialogOpen}
+        secret={secret}
+        onSave={handleSaveData}
       />
     </div>
   )

--- a/ui/src/pages/secret-list-page.test.tsx
+++ b/ui/src/pages/secret-list-page.test.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode } from 'react'
 import { act, render, screen } from '@testing-library/react'
-import type { ConfigMap } from 'kubernetes-types/core/v1'
+import type { Secret } from 'kubernetes-types/core/v1'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigMapListPage } from './configmap-list-page'
+import { SecretListPage } from './secret-list-page'
 
 const mockNavigate = vi.fn()
 const mockResourceTable = vi.fn(
@@ -33,13 +33,6 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => mockNavigate,
   }
 })
-
-vi.mock('sonner', () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
-}))
 
 vi.mock('@/components/resource-table', () => ({
   ResourceTable: (props: { resourceName: string }) => mockResourceTable(props),
@@ -82,57 +75,57 @@ vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
     ) : null,
 }))
 
-describe('ConfigMapListPage', () => {
+describe('SecretListPage', () => {
   beforeEach(() => {
     mockNavigate.mockReset()
     mockResourceTable.mockClear()
   })
 
-  it('provides unified row actions for configmaps', async () => {
-    render(<ConfigMapListPage />)
+  it('provides focused row actions for secrets', async () => {
+    render(<SecretListPage />)
 
     const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
-      columns: { id?: string; header?: string }[]
-      getRowContextMenuItems: (configMap: ConfigMap) => {
+      columns: { header?: string }[]
+      getRowContextMenuItems: (secret: Secret) => {
         key: string
         onSelect?: () => void | Promise<void>
       }[]
     }
 
-    expect(resourceTableProps.columns).toHaveLength(4)
     expect(resourceTableProps.columns.map((column) => column.header)).toEqual([
       'common.name',
+      'common.type',
       'detail.fields.labels',
       'detail.fields.annotations',
       'common.created',
     ])
 
-    const configMap = {
+    const secret = {
       metadata: {
-        name: 'app-config',
+        name: 'app-secret',
         namespace: 'default',
       },
-    } as ConfigMap
+    } as Secret
 
-    const items = resourceTableProps.getRowContextMenuItems(configMap)
+    const items = resourceTableProps.getRowContextMenuItems(secret)
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
-      'edit-config',
+      'edit-secret',
       'metadata-actions-separator',
       'manage-labels',
       'manage-annotations',
       'danger-actions-separator',
-      'delete-configmap',
+      'delete-secret',
     ])
 
     await items[0].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/configmaps/default/app-config?tab=yaml'
+      '/secrets/default/app-secret?tab=yaml'
     )
 
     await items[1].onSelect?.()
-    expect(mockNavigate).toHaveBeenCalledWith('/configmaps/default/app-config')
+    expect(mockNavigate).toHaveBeenCalledWith('/secrets/default/app-secret')
 
     await act(async () => {
       await items[3].onSelect?.()
@@ -154,6 +147,6 @@ describe('ConfigMapListPage', () => {
     expect(
       screen.getByText('resource-delete-confirmation-dialog')
     ).toBeInTheDocument()
-    expect(screen.getByText('configmaps')).toBeInTheDocument()
+    expect(screen.getByText('secrets')).toBeInTheDocument()
   })
 })

--- a/ui/src/pages/secret-list-page.tsx
+++ b/ui/src/pages/secret-list-page.tsx
@@ -1,23 +1,37 @@
 import { useCallback, useMemo, useState } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Secret } from 'kubernetes-types/core/v1'
-import { Copy, FileCode2, FileText, Tags } from 'lucide-react'
+import { FileCode2, FileText, Pencil, Tags, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
-import { toast } from 'sonner'
 
-import { copyTextToClipboard } from '@/lib/desktop'
-import { formatDate } from '@/lib/utils'
-import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
+import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
+import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
 
 export function SecretListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [labelsSecret, setLabelsSecret] = useState<Secret | null>(null)
   const [annotationsSecret, setAnnotationsSecret] = useState<Secret | null>(
+    null
+  )
+  const [deleteSecretTarget, setDeleteSecretTarget] = useState<Secret | null>(
     null
   )
   const columnHelper = useMemo(() => createColumnHelper<Secret>(), [])
@@ -46,31 +60,46 @@ export function SecretListPage() {
           return <Badge variant="outline">{type}</Badge>
         },
       }),
-      columnHelper.accessor('data', {
-        header: t('secrets.dataKeys'),
-        cell: ({ getValue }) => {
-          const data = getValue() || {}
-          const keys = Object.keys(data)
-          if (keys.length === 0) {
-            return '-'
-          }
-          // Limit to first 5 keys for display
-          return keys.length > 5 ? (
-            <span className="text-muted-foreground">
-              {keys.slice(0, 5).join(', ')}...
-            </span>
-          ) : (
-            <span className="text-muted-foreground">{keys.join(', ')}</span>
-          )
-        },
+      columnHelper.display({
+        id: 'labels',
+        header: t('detail.fields.labels'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="labels"
+            ariaLabel={t('common.manageLabels', 'Manage labels')}
+            count={Object.keys(row.original.metadata?.labels || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.labels
+            )}
+            onClick={() => setLabelsSecret(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'annotations',
+        header: t('detail.fields.annotations'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="annotations"
+            ariaLabel={t('common.manageAnnotations', 'Manage annotations')}
+            count={Object.keys(row.original.metadata?.annotations || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.annotations
+            )}
+            onClick={() => setAnnotationsSecret(row.original)}
+          />
+        ),
       }),
       columnHelper.accessor('metadata.creationTimestamp', {
+        id: 'created',
         header: t('common.created'),
         cell: ({ getValue }) => {
-          const dateStr = formatDate(getValue() || '')
-
           return (
-            <span className="text-muted-foreground text-sm">{dateStr}</span>
+            <span className="text-muted-foreground text-sm">
+              {formatTimestampWithRelative(getValue())}
+            </span>
           )
         },
       }),
@@ -82,12 +111,20 @@ export function SecretListPage() {
   const secretSearchFilter = useCallback((secret: Secret, query: string) => {
     const dataKeys = Object.keys(secret.data || {}).join(' ')
     const type = secret.type || ''
+    const labels = Object.entries(secret.metadata?.labels || {})
+      .map(([key, value]) => `${key} ${value}`)
+      .join(' ')
+    const annotations = Object.entries(secret.metadata?.annotations || {})
+      .map(([key, value]) => `${key} ${value}`)
+      .join(' ')
 
     return (
       secret.metadata!.name!.toLowerCase().includes(query) ||
       (secret.metadata!.namespace?.toLowerCase() || '').includes(query) ||
       type.toLowerCase().includes(query) ||
-      dataKeys.toLowerCase().includes(query)
+      dataKeys.toLowerCase().includes(query) ||
+      labels.toLowerCase().includes(query) ||
+      annotations.toLowerCase().includes(query)
     )
   }, [])
 
@@ -95,50 +132,47 @@ export function SecretListPage() {
     return `/secrets/${secret.metadata!.namespace}/${secret.metadata!.name}`
   }, [])
 
-  const handleCopy = useCallback(
-    async (value: string) => {
-      await copyTextToClipboard(value)
-      toast.success(t('keyValueDataViewer.copiedToClipboard'))
-    },
-    [t]
-  )
-
   const getRowContextMenuItems = useCallback(
-    (secret: Secret): RowContextMenuItem<Secret>[] => [
-      {
-        key: 'view-yaml',
-        label: t('common.viewYaml', 'View YAML'),
-        icon: <FileCode2 className="h-4 w-4" />,
-        onSelect: () => navigate(`${getSecretDetailPath(secret)}?tab=yaml`),
-      },
-      { type: 'separator', key: 'primary-actions-separator' },
-      {
-        key: 'copy-name',
-        label: t('common.copyName', 'Copy name'),
-        icon: <Copy className="h-4 w-4" />,
-        onSelect: () => handleCopy(secret.metadata?.name || ''),
-      },
-      {
-        key: 'copy-namespace',
-        label: t('common.copyNamespace', 'Copy namespace'),
-        icon: <Copy className="h-4 w-4" />,
-        onSelect: () => handleCopy(secret.metadata?.namespace || ''),
-      },
-      { type: 'separator', key: 'metadata-actions-separator' },
-      {
-        key: 'manage-labels',
-        label: t('common.manageLabels', 'Manage labels'),
-        icon: <Tags className="h-4 w-4" />,
-        onSelect: () => setLabelsSecret(secret),
-      },
-      {
-        key: 'manage-annotations',
-        label: t('common.manageAnnotations', 'Manage annotations'),
-        icon: <FileText className="h-4 w-4" />,
-        onSelect: () => setAnnotationsSecret(secret),
-      },
-    ],
-    [getSecretDetailPath, handleCopy, navigate, t]
+    (secret: Secret): RowContextMenuItem<Secret>[] => {
+      const detailPath = getSecretDetailPath(secret)
+
+      return [
+        {
+          key: 'view-yaml',
+          label: t('common.viewYaml', 'View YAML'),
+          icon: <FileCode2 className="h-4 w-4" />,
+          onSelect: () => navigate(`${detailPath}?tab=yaml`),
+        },
+        {
+          key: 'edit-secret',
+          label: t('secrets.editConfig', 'Edit secret'),
+          icon: <Pencil className="h-4 w-4" />,
+          onSelect: () => navigate(detailPath),
+        },
+        { type: 'separator', key: 'metadata-actions-separator' },
+        {
+          key: 'manage-labels',
+          label: t('common.manageLabels', 'Manage labels'),
+          icon: <Tags className="h-4 w-4" />,
+          onSelect: () => setLabelsSecret(secret),
+        },
+        {
+          key: 'manage-annotations',
+          label: t('common.manageAnnotations', 'Manage annotations'),
+          icon: <FileText className="h-4 w-4" />,
+          onSelect: () => setAnnotationsSecret(secret),
+        },
+        { type: 'separator', key: 'danger-actions-separator' },
+        {
+          key: 'delete-secret',
+          label: t('common.delete'),
+          icon: <Trash2 className="h-4 w-4" />,
+          variant: 'destructive',
+          onSelect: () => setDeleteSecretTarget(secret),
+        },
+      ]
+    },
+    [getSecretDetailPath, navigate, t]
   )
 
   return (
@@ -176,6 +210,19 @@ export function SecretListPage() {
         resourceType="secrets"
         resource={annotationsSecret}
         type="annotations"
+      />
+
+      <ResourceDeleteConfirmationDialog
+        open={Boolean(deleteSecretTarget)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteSecretTarget(null)
+          }
+        }}
+        resourceName={deleteSecretTarget?.metadata?.name || ''}
+        resourceType="secrets"
+        namespace={deleteSecretTarget?.metadata?.namespace}
+        confirmationValue={t('deleteConfirmation.confirmDeleteKeyword')}
       />
     </>
   )


### PR DESCRIPTION
- 在 secret-detail 页面中实现了对 Secret 元数据和数据的显示、编辑和保存功能的测试。
- 在 secret-list 页面中实现了对 Secret 列表的上下文菜单操作的测试，包括查看 YAML、编辑、管理标签和注释、删除等功能。

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ConfigMap and Secret data editing with confirmation dialogs
  * Delete confirmation dialogs for resource deletion
  * Rollback confirmation step in YAML diff viewer
  * Reveal/hide toggle for sensitive secret values during editing
  * Metadata management UI for labels and annotations in list views

* **Improvements**
  * Enhanced search filtering by labels and annotations
  * Related resource discovery now includes Ingress TLS certificates and additional workload types (pods, jobs, cronjobs)
  * Timestamp display enhanced with relative time (e.g., "2 hours ago")
  * Per-key reveal/hide actions in secret data viewer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->