### PR TITLE
feat(storage): 添加存储类详情页面及相关测试用例

### DIFF
--- a/ui/src/components/editors/storage-create-dialogs.test.tsx
+++ b/ui/src/components/editors/storage-create-dialogs.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import type { StorageClass } from 'kubernetes-types/storage/v1'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StorageClassCreateDialog } from './storage-create-dialogs'
+
+const mockCreateResource = vi.fn()
+const mockOnOpenChange = vi.fn()
+const mockOnSuccess = vi.fn()
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  createResource: (...args: unknown[]) => mockCreateResource(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function selectStorageClassTemplate(label: string) {
+  fireEvent.click(
+    screen.getByRole('combobox', { name: 'storageCreate.templateLabel' })
+  )
+  const listbox = screen.getByRole('listbox')
+  fireEvent.click(within(listbox).getByText(label))
+}
+
+describe('StorageClassCreateDialog', () => {
+  beforeEach(() => {
+    mockCreateResource.mockReset()
+    mockOnOpenChange.mockReset()
+    mockOnSuccess.mockReset()
+    mockCreateResource.mockImplementation(
+      async (_resource: string, _namespace: string | undefined, body: StorageClass) =>
+        body
+    )
+  })
+
+  it('prefills AWS EBS template and submits expected StorageClass', async () => {
+    render(
+      <StorageClassCreateDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onSuccess={mockOnSuccess}
+      />
+    )
+
+    selectStorageClassTemplate('storageCreate.template.awsEbs')
+
+    expect(screen.getByDisplayValue('aws-ebs-gp3')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('ebs.csi.aws.com')).toBeInTheDocument()
+    expect(screen.getByDisplayValue(/type=gp3/)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(/encrypted=true/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
+
+    await waitFor(() => {
+      expect(mockCreateResource).toHaveBeenCalledWith(
+        'storageclasses',
+        undefined,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'aws-ebs-gp3',
+          }),
+          provisioner: 'ebs.csi.aws.com',
+          reclaimPolicy: 'Delete',
+          volumeBindingMode: 'WaitForFirstConsumer',
+          allowVolumeExpansion: true,
+          parameters: expect.objectContaining({
+            type: 'gp3',
+            encrypted: 'true',
+            'csi.storage.k8s.io/fstype': 'ext4',
+          }),
+        })
+      )
+    })
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+    expect(mockOnSuccess).toHaveBeenCalled()
+  })
+
+  it('adds EKS Auto Mode topology parameter for the auto EBS template', async () => {
+    render(
+      <StorageClassCreateDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onSuccess={mockOnSuccess}
+      />
+    )
+
+    selectStorageClassTemplate('storageCreate.template.awsEksAutoEbs')
+    fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
+
+    await waitFor(() => {
+      expect(mockCreateResource).toHaveBeenCalledWith(
+        'storageclasses',
+        undefined,
+        expect.objectContaining({
+          provisioner: 'ebs.csi.eks.amazonaws.com',
+          parameters: expect.objectContaining({
+            allowedTopologies: 'eks.amazonaws.com/compute-type=auto',
+          }),
+        })
+      )
+    })
+  })
+})

--- a/ui/src/components/editors/storage-create-dialogs.tsx
+++ b/ui/src/components/editors/storage-create-dialogs.tsx
@@ -1,0 +1,847 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import type {
+  PersistentVolume,
+  PersistentVolumeClaim,
+} from 'kubernetes-types/core/v1'
+import type { StorageClass } from 'kubernetes-types/storage/v1'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { createResource } from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+
+type KeyValueMap = Record<string, string>
+type PersistentVolumeAccessMode =
+  | 'ReadWriteOnce'
+  | 'ReadOnlyMany'
+  | 'ReadWriteMany'
+type StorageVolumeBindingMode = 'Immediate' | 'WaitForFirstConsumer'
+type StorageClassTemplateId =
+  | 'generic'
+  | 'alibaba-disk'
+  | 'tencent-cbs'
+  | 'aws-ebs'
+  | 'aws-eks-auto-ebs'
+  | 'aws-efs'
+
+type StorageClassTemplate = {
+  id: StorageClassTemplateId
+  labelKey: string
+  name: string
+  provisioner: string
+  reclaimPolicy: 'Delete' | 'Retain'
+  bindingMode: StorageVolumeBindingMode
+  allowExpansion: boolean
+  parameters: KeyValueMap
+  mountOptions?: string[]
+  autoModeTopology?: boolean
+}
+
+const storageClassTemplates: StorageClassTemplate[] = [
+  {
+    id: 'generic',
+    labelKey: 'storageCreate.template.generic',
+    name: 'local-static',
+    provisioner: 'kubernetes.io/no-provisioner',
+    reclaimPolicy: 'Retain',
+    bindingMode: 'WaitForFirstConsumer',
+    allowExpansion: false,
+    parameters: {},
+  },
+  {
+    id: 'alibaba-disk',
+    labelKey: 'storageCreate.template.alibabaDisk',
+    name: 'alibaba-cloud-disk',
+    provisioner: 'diskplugin.csi.alibabacloud.com',
+    reclaimPolicy: 'Delete',
+    bindingMode: 'Immediate',
+    allowExpansion: true,
+    parameters: {
+      type: 'cloud_essd,cloud_ssd,cloud_efficiency',
+      encrypted: 'false',
+    },
+  },
+  {
+    id: 'tencent-cbs',
+    labelKey: 'storageCreate.template.tencentCbs',
+    name: 'tencent-cbs',
+    provisioner: 'com.tencent.cloud.csi.cbs',
+    reclaimPolicy: 'Delete',
+    bindingMode: 'WaitForFirstConsumer',
+    allowExpansion: true,
+    parameters: {
+      type: 'CLOUD_PREMIUM',
+      paymode: 'POSTPAID_BY_HOUR',
+      renewflag: 'NOTIFY_AND_MANUAL_RENEW',
+    },
+  },
+  {
+    id: 'aws-ebs',
+    labelKey: 'storageCreate.template.awsEbs',
+    name: 'aws-ebs-gp3',
+    provisioner: 'ebs.csi.aws.com',
+    reclaimPolicy: 'Delete',
+    bindingMode: 'WaitForFirstConsumer',
+    allowExpansion: true,
+    parameters: {
+      type: 'gp3',
+      encrypted: 'true',
+      'csi.storage.k8s.io/fstype': 'ext4',
+    },
+  },
+  {
+    id: 'aws-eks-auto-ebs',
+    labelKey: 'storageCreate.template.awsEksAutoEbs',
+    name: 'aws-auto-ebs-gp3',
+    provisioner: 'ebs.csi.eks.amazonaws.com',
+    reclaimPolicy: 'Delete',
+    bindingMode: 'WaitForFirstConsumer',
+    allowExpansion: true,
+    parameters: {
+      type: 'gp3',
+      encrypted: 'true',
+      'csi.storage.k8s.io/fstype': 'ext4',
+    },
+    autoModeTopology: true,
+  },
+  {
+    id: 'aws-efs',
+    labelKey: 'storageCreate.template.awsEfs',
+    name: 'aws-efs',
+    provisioner: 'efs.csi.aws.com',
+    reclaimPolicy: 'Retain',
+    bindingMode: 'Immediate',
+    allowExpansion: false,
+    parameters: {
+      provisioningMode: 'efs-ap',
+      fileSystemId: 'fs-xxxxxxxx',
+      directoryPerms: '700',
+    },
+  },
+]
+
+function parseKeyValueLines(value: string): KeyValueMap {
+  return Object.fromEntries(
+    value
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const separatorIndex = line.indexOf('=')
+        if (separatorIndex === -1) {
+          return [line, '']
+        }
+        return [
+          line.slice(0, separatorIndex).trim(),
+          line.slice(separatorIndex + 1).trim(),
+        ]
+      })
+      .filter(([key]) => Boolean(key))
+  )
+}
+
+function parseListLines(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function formatKeyValueLines(values: KeyValueMap) {
+  return Object.entries(values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
+}
+
+function AccessModeSelect({
+  value,
+  onChange,
+}: {
+  value: PersistentVolumeAccessMode
+  onChange: (value: PersistentVolumeAccessMode) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as PersistentVolumeAccessMode)}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="ReadWriteOnce">{t('storageCreate.accessMode.rwo')}</SelectItem>
+        <SelectItem value="ReadOnlyMany">{t('storageCreate.accessMode.rom')}</SelectItem>
+        <SelectItem value="ReadWriteMany">{t('storageCreate.accessMode.rwm')}</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function StorageClassCreateDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: (storageClass: StorageClass) => void
+}) {
+  const { t } = useTranslation()
+  const [templateId, setTemplateId] =
+    useState<StorageClassTemplateId>('generic')
+  const [name, setName] = useState('')
+  const [provisioner, setProvisioner] = useState('kubernetes.io/no-provisioner')
+  const [reclaimPolicy, setReclaimPolicy] = useState<'Delete' | 'Retain'>('Delete')
+  const [bindingMode, setBindingMode] =
+    useState<StorageVolumeBindingMode>('Immediate')
+  const [allowExpansion, setAllowExpansion] = useState(true)
+  const [isDefault, setIsDefault] = useState(false)
+  const [parameters, setParameters] = useState('')
+  const [mountOptions, setMountOptions] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+  const selectedTemplate = useMemo(
+    () =>
+      storageClassTemplates.find((template) => template.id === templateId) ||
+      storageClassTemplates[0],
+    [templateId]
+  )
+
+  useEffect(() => {
+    if (!open) {
+      setTemplateId('generic')
+      setName('')
+      setProvisioner('kubernetes.io/no-provisioner')
+      setReclaimPolicy('Delete')
+      setBindingMode('Immediate')
+      setAllowExpansion(true)
+      setIsDefault(false)
+      setParameters('')
+      setMountOptions('')
+      setIsCreating(false)
+    }
+  }, [open])
+
+  const applyTemplate = (nextTemplateId: StorageClassTemplateId) => {
+    const template =
+      storageClassTemplates.find((item) => item.id === nextTemplateId) ||
+      storageClassTemplates[0]
+
+    setTemplateId(template.id)
+    setName(template.name)
+    setProvisioner(template.provisioner)
+    setReclaimPolicy(template.reclaimPolicy)
+    setBindingMode(template.bindingMode)
+    setAllowExpansion(template.allowExpansion)
+    setParameters(formatKeyValueLines(template.parameters))
+    setMountOptions((template.mountOptions || []).join('\n'))
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    const trimmedProvisioner = provisioner.trim()
+    if (!trimmedName || !trimmedProvisioner) return
+
+    setIsCreating(true)
+    try {
+      const parsedParameters = parseKeyValueLines(parameters)
+      const finalParameters = { ...parsedParameters }
+      if (
+        selectedTemplate.autoModeTopology &&
+        !finalParameters.allowedTopologies
+      ) {
+        finalParameters.allowedTopologies =
+          'eks.amazonaws.com/compute-type=auto'
+      }
+      const parsedMountOptions = parseListLines(mountOptions)
+      const storageClass: StorageClass = {
+        apiVersion: 'storage.k8s.io/v1',
+        kind: 'StorageClass',
+        metadata: {
+          name: trimmedName,
+          annotations: isDefault
+            ? {
+                'storageclass.kubernetes.io/is-default-class': 'true',
+              }
+            : undefined,
+        },
+        provisioner: trimmedProvisioner,
+        reclaimPolicy,
+        volumeBindingMode: bindingMode,
+        allowVolumeExpansion: allowExpansion || undefined,
+        parameters:
+          Object.keys(finalParameters).length > 0 ? finalParameters : undefined,
+        mountOptions: parsedMountOptions.length > 0 ? parsedMountOptions : undefined,
+      }
+
+      const created = await createResource('storageclasses', undefined, storageClass)
+      toast.success(t('storageCreate.storageClassSuccess', { name: trimmedName }))
+      onOpenChange(false)
+      onSuccess(created)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('storageCreate.storageClassTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('storageCreate.storageClassDescription')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label>{t('storageCreate.templateLabel')}</Label>
+            <Select value={templateId} onValueChange={(value) => applyTemplate(value as StorageClassTemplateId)}>
+              <SelectTrigger aria-label={t('storageCreate.templateLabel')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {storageClassTemplates.map((template) => (
+                  <SelectItem key={template.id} value={template.id}>
+                    {t(template.labelKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-muted-foreground text-xs">
+              {t('storageCreate.templateHint')}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="storage-class-name">{t('common.name')}</Label>
+              <Input
+                id="storage-class-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="fast-ssd"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="storage-class-provisioner">
+                {t('storageClasses.provisioner')}
+              </Label>
+              <Input
+                id="storage-class-provisioner"
+                value={provisioner}
+                onChange={(event) => setProvisioner(event.target.value)}
+                placeholder="ebs.csi.aws.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('pvs.reclaimPolicy')}</Label>
+              <Select
+                value={reclaimPolicy}
+                onValueChange={(value) => setReclaimPolicy(value as 'Delete' | 'Retain')}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Delete">Delete</SelectItem>
+                  <SelectItem value="Retain">Retain</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{t('storageClasses.volumeBindingMode')}</Label>
+              <Select
+                value={bindingMode}
+                onValueChange={(value) =>
+                  setBindingMode(value as StorageVolumeBindingMode)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Immediate">Immediate</SelectItem>
+                  <SelectItem value="WaitForFirstConsumer">WaitForFirstConsumer</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="flex items-center gap-3 rounded-md border p-3">
+              <Switch checked={allowExpansion} onCheckedChange={setAllowExpansion} />
+              <span className="text-sm">{t('storageClasses.allowExpansion')}</span>
+            </label>
+            <label className="flex items-center gap-3 rounded-md border p-3">
+              <Switch checked={isDefault} onCheckedChange={setIsDefault} />
+              <span className="text-sm">{t('storageClasses.defaultClass')}</span>
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="storage-class-parameters">
+                {t('storageClasses.parameters')}
+              </Label>
+              <Textarea
+                id="storage-class-parameters"
+                value={parameters}
+                onChange={(event) => setParameters(event.target.value)}
+                placeholder={'type=gp3\nencrypted=true'}
+                className="min-h-24 font-mono"
+              />
+              {selectedTemplate.autoModeTopology ? (
+                <p className="text-muted-foreground text-xs">
+                  {t('storageCreate.awsAutoModeHint')}
+                </p>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="storage-class-mount-options">
+                {t('storageClasses.mountOptions')}
+              </Label>
+              <Textarea
+                id="storage-class-mount-options"
+                value={mountOptions}
+                onChange={(event) => setMountOptions(event.target.value)}
+                placeholder="discard"
+                className="min-h-24 font-mono"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isCreating}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isCreating || !name.trim() || !provisioner.trim()}>
+              {isCreating ? t('common.creating') : t('common.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function PVCCreateDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: (pvc: PersistentVolumeClaim, namespace: string) => void
+}) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [namespace, setNamespace] = useState('default')
+  const [storageClassName, setStorageClassName] = useState('')
+  const [storage, setStorage] = useState('10Gi')
+  const [accessMode, setAccessMode] =
+    useState<PersistentVolumeAccessMode>('ReadWriteOnce')
+  const [volumeMode, setVolumeMode] = useState<'Filesystem' | 'Block'>('Filesystem')
+  const [volumeName, setVolumeName] = useState('')
+  const [labels, setLabels] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setNamespace('default')
+      setStorageClassName('')
+      setStorage('10Gi')
+      setAccessMode('ReadWriteOnce')
+      setVolumeMode('Filesystem')
+      setVolumeName('')
+      setLabels('')
+      setIsCreating(false)
+    }
+  }, [open])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    const trimmedNamespace = namespace.trim()
+    const trimmedStorage = storage.trim()
+    if (!trimmedName || !trimmedNamespace || !trimmedStorage) return
+
+    setIsCreating(true)
+    try {
+      const parsedLabels = parseKeyValueLines(labels)
+      const pvc: PersistentVolumeClaim = {
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: {
+          name: trimmedName,
+          namespace: trimmedNamespace,
+          labels: Object.keys(parsedLabels).length > 0 ? parsedLabels : undefined,
+        },
+        spec: {
+          accessModes: [accessMode],
+          volumeMode,
+          storageClassName: storageClassName.trim() || undefined,
+          volumeName: volumeName.trim() || undefined,
+          resources: {
+            requests: {
+              storage: trimmedStorage,
+            },
+          },
+        },
+      }
+
+      const created = await createResource(
+        'persistentvolumeclaims',
+        trimmedNamespace,
+        pvc
+      )
+      toast.success(t('storageCreate.pvcSuccess', { name: trimmedName }))
+      onOpenChange(false)
+      onSuccess(created, trimmedNamespace)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('storageCreate.pvcTitle')}</DialogTitle>
+          <DialogDescription>{t('storageCreate.pvcDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="pvc-name">{t('common.name')}</Label>
+              <Input id="pvc-name" value={name} onChange={(event) => setName(event.target.value)} placeholder="data-web-0" autoFocus />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pvc-namespace">{t('detail.fields.namespace')}</Label>
+              <Input id="pvc-namespace" value={namespace} onChange={(event) => setNamespace(event.target.value)} placeholder="default" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pvc-storage">{t('storageCreate.requestStorage')}</Label>
+              <Input id="pvc-storage" value={storage} onChange={(event) => setStorage(event.target.value)} placeholder="10Gi" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pvc-storage-class">{t('pvcs.storageClass')}</Label>
+              <Input id="pvc-storage-class" value={storageClassName} onChange={(event) => setStorageClassName(event.target.value)} placeholder={t('storageCreate.storageClassOptional')} />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('pvcs.accessModes')}</Label>
+              <AccessModeSelect value={accessMode} onChange={setAccessMode} />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('storageDetails.volumeMode')}</Label>
+              <Select value={volumeMode} onValueChange={(value) => setVolumeMode(value as 'Filesystem' | 'Block')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Filesystem">Filesystem</SelectItem>
+                  <SelectItem value="Block">Block</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="pvc-volume-name">{t('storageCreate.boundVolumeOptional')}</Label>
+              <Input id="pvc-volume-name" value={volumeName} onChange={(event) => setVolumeName(event.target.value)} placeholder="pv-data-web-0" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pvc-labels">{t('detail.fields.labels')}</Label>
+              <Textarea id="pvc-labels" value={labels} onChange={(event) => setLabels(event.target.value)} placeholder="app=web" className="min-h-20 font-mono" />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isCreating}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isCreating || !name.trim() || !namespace.trim() || !storage.trim()}>
+              {isCreating ? t('common.creating') : t('common.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function PVCreateDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: (pv: PersistentVolume) => void
+}) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [capacity, setCapacity] = useState('10Gi')
+  const [storageClassName, setStorageClassName] = useState('')
+  const [accessMode, setAccessMode] =
+    useState<PersistentVolumeAccessMode>('ReadWriteOnce')
+  const [volumeMode, setVolumeMode] = useState<'Filesystem' | 'Block'>('Filesystem')
+  const [reclaimPolicy, setReclaimPolicy] = useState<'Retain' | 'Delete' | 'Recycle'>('Retain')
+  const [sourceType, setSourceType] = useState<'hostPath' | 'nfs' | 'local'>('hostPath')
+  const [path, setPath] = useState('/data')
+  const [nfsServer, setNfsServer] = useState('')
+  const [readOnly, setReadOnly] = useState(false)
+  const [nodeHostname, setNodeHostname] = useState('')
+  const [labels, setLabels] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setName('')
+      setCapacity('10Gi')
+      setStorageClassName('')
+      setAccessMode('ReadWriteOnce')
+      setVolumeMode('Filesystem')
+      setReclaimPolicy('Retain')
+      setSourceType('hostPath')
+      setPath('/data')
+      setNfsServer('')
+      setReadOnly(false)
+      setNodeHostname('')
+      setLabels('')
+      setIsCreating(false)
+    }
+  }, [open])
+
+  const sourceSpec = useMemo(() => {
+    if (sourceType === 'nfs') {
+      return {
+        nfs: {
+          server: nfsServer.trim(),
+          path: path.trim(),
+          readOnly,
+        },
+      }
+    }
+    if (sourceType === 'local') {
+      return {
+        local: {
+          path: path.trim(),
+        },
+      }
+    }
+    return {
+      hostPath: {
+        path: path.trim(),
+        type: 'DirectoryOrCreate',
+      },
+    }
+  }, [nfsServer, path, readOnly, sourceType])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    const trimmedCapacity = capacity.trim()
+    const trimmedPath = path.trim()
+    if (!trimmedName || !trimmedCapacity || !trimmedPath) return
+    if (sourceType === 'nfs' && !nfsServer.trim()) return
+
+    setIsCreating(true)
+    try {
+      const parsedLabels = parseKeyValueLines(labels)
+      const pv: PersistentVolume = {
+        apiVersion: 'v1',
+        kind: 'PersistentVolume',
+        metadata: {
+          name: trimmedName,
+          labels: Object.keys(parsedLabels).length > 0 ? parsedLabels : undefined,
+        },
+        spec: {
+          capacity: {
+            storage: trimmedCapacity,
+          },
+          accessModes: [accessMode],
+          volumeMode,
+          persistentVolumeReclaimPolicy: reclaimPolicy,
+          storageClassName: storageClassName.trim() || undefined,
+          ...sourceSpec,
+          nodeAffinity:
+            sourceType === 'local' && nodeHostname.trim()
+              ? {
+                  required: {
+                    nodeSelectorTerms: [
+                      {
+                        matchExpressions: [
+                          {
+                            key: 'kubernetes.io/hostname',
+                            operator: 'In',
+                            values: [nodeHostname.trim()],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                }
+              : undefined,
+        },
+      }
+
+      const created = await createResource('persistentvolumes', undefined, pv)
+      toast.success(t('storageCreate.pvSuccess', { name: trimmedName }))
+      onOpenChange(false)
+      onSuccess(created)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('storageCreate.pvTitle')}</DialogTitle>
+          <DialogDescription>{t('storageCreate.pvDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="pv-name">{t('common.name')}</Label>
+              <Input id="pv-name" value={name} onChange={(event) => setName(event.target.value)} placeholder="pv-data-web-0" autoFocus />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pv-capacity">{t('pvs.capacity')}</Label>
+              <Input id="pv-capacity" value={capacity} onChange={(event) => setCapacity(event.target.value)} placeholder="10Gi" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pv-storage-class">{t('pvs.storageClass')}</Label>
+              <Input id="pv-storage-class" value={storageClassName} onChange={(event) => setStorageClassName(event.target.value)} placeholder={t('storageCreate.storageClassOptional')} />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('pvs.reclaimPolicy')}</Label>
+              <Select value={reclaimPolicy} onValueChange={(value) => setReclaimPolicy(value as 'Retain' | 'Delete' | 'Recycle')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Retain">Retain</SelectItem>
+                  <SelectItem value="Delete">Delete</SelectItem>
+                  <SelectItem value="Recycle">Recycle</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{t('pvs.accessModes')}</Label>
+              <AccessModeSelect value={accessMode} onChange={setAccessMode} />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('storageDetails.volumeMode')}</Label>
+              <Select value={volumeMode} onValueChange={(value) => setVolumeMode(value as 'Filesystem' | 'Block')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Filesystem">Filesystem</SelectItem>
+                  <SelectItem value="Block">Block</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-4 rounded-md border p-4">
+            <div className="space-y-2">
+              <Label>{t('storageDetails.volumeSource')}</Label>
+              <Select value={sourceType} onValueChange={(value) => setSourceType(value as 'hostPath' | 'nfs' | 'local')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="hostPath">HostPath</SelectItem>
+                  <SelectItem value="nfs">NFS</SelectItem>
+                  <SelectItem value="local">Local</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {sourceType === 'nfs' ? (
+                <div className="space-y-2">
+                  <Label htmlFor="pv-nfs-server">{t('storageCreate.nfsServer')}</Label>
+                  <Input id="pv-nfs-server" value={nfsServer} onChange={(event) => setNfsServer(event.target.value)} placeholder="10.0.0.10" />
+                </div>
+              ) : null}
+              <div className="space-y-2">
+                <Label htmlFor="pv-source-path">{t('storageCreate.sourcePath')}</Label>
+                <Input id="pv-source-path" value={path} onChange={(event) => setPath(event.target.value)} placeholder="/data" />
+              </div>
+              {sourceType === 'local' ? (
+                <div className="space-y-2">
+                  <Label htmlFor="pv-node-hostname">{t('storageCreate.nodeHostnameOptional')}</Label>
+                  <Input id="pv-node-hostname" value={nodeHostname} onChange={(event) => setNodeHostname(event.target.value)} placeholder="worker-1" />
+                </div>
+              ) : null}
+            </div>
+            {sourceType === 'nfs' ? (
+              <label className="flex items-center gap-3 text-sm">
+                <Checkbox checked={readOnly} onCheckedChange={(value) => setReadOnly(value === true)} />
+                {t('storageCreate.readOnly')}
+              </label>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="pv-labels">{t('detail.fields.labels')}</Label>
+            <Textarea id="pv-labels" value={labels} onChange={(event) => setLabels(event.target.value)} placeholder="tier=storage" className="min-h-20 font-mono" />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isCreating}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                isCreating ||
+                !name.trim() ||
+                !capacity.trim() ||
+                !path.trim() ||
+                (sourceType === 'nfs' && !nfsServer.trim())
+              }
+            >
+              {isCreating ? t('common.creating') : t('common.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/editors/storage-edit-dialogs.tsx
+++ b/ui/src/components/editors/storage-edit-dialogs.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import type {
+  PersistentVolume,
+  PersistentVolumeClaim,
+} from 'kubernetes-types/core/v1'
+import type { StorageClass } from 'kubernetes-types/storage/v1'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { patchResource } from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+type ReclaimPolicy = 'Retain' | 'Delete' | 'Recycle'
+
+const DEFAULT_STORAGE_CLASS_ANNOTATION =
+  'storageclass.kubernetes.io/is-default-class'
+const BETA_DEFAULT_STORAGE_CLASS_ANNOTATION =
+  'storageclass.beta.kubernetes.io/is-default-class'
+
+export function isDefaultStorageClass(storageClass: StorageClass) {
+  const annotations = storageClass.metadata?.annotations || {}
+  return (
+    annotations[DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true' ||
+    annotations[BETA_DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true'
+  )
+}
+
+export async function setStorageClassDefault(
+  storageClass: StorageClass,
+  nextDefault: boolean
+) {
+  const name = storageClass.metadata?.name
+  if (!name) return
+
+  await patchResource('storageclasses', name, undefined, {
+    metadata: {
+      annotations: {
+        ...(storageClass.metadata?.annotations || {}),
+        [DEFAULT_STORAGE_CLASS_ANNOTATION]: nextDefault ? 'true' : 'false',
+        [BETA_DEFAULT_STORAGE_CLASS_ANNOTATION]: 'false',
+      },
+    },
+  })
+}
+
+export function PVCResizeDialog({
+  open,
+  onOpenChange,
+  pvc,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  pvc: PersistentVolumeClaim | null
+  onSuccess?: () => void | Promise<void>
+}) {
+  const { t } = useTranslation()
+  const [storage, setStorage] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open || !pvc) {
+      setStorage('')
+      setIsSaving(false)
+      return
+    }
+
+    setStorage(
+      pvc.spec?.resources?.requests?.storage ||
+        pvc.status?.capacity?.storage ||
+        ''
+    )
+    setIsSaving(false)
+  }, [open, pvc])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const name = pvc?.metadata?.name
+    const namespace = pvc?.metadata?.namespace
+    const nextStorage = storage.trim()
+    if (!name || !namespace || !nextStorage) return
+
+    setIsSaving(true)
+    try {
+      await patchResource('persistentvolumeclaims', name, namespace, {
+        spec: {
+          resources: {
+            requests: {
+              storage: nextStorage,
+            },
+          },
+        },
+      })
+      toast.success(t('storageEdit.resizePVCSuccess', { name }))
+      onOpenChange(false)
+      await onSuccess?.()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('storageEdit.resizePVCTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('storageEdit.resizePVCDescription')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="pvc-resize-storage">
+              {t('storageEdit.newStorageSize')}
+            </Label>
+            <Input
+              id="pvc-resize-storage"
+              value={storage}
+              onChange={(event) => setStorage(event.target.value)}
+              placeholder="20Gi"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('storageEdit.resizePVCHint')}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isSaving || !storage.trim()}>
+              {isSaving ? t('common.applying') : t('common.apply')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function PVReclaimPolicyDialog({
+  open,
+  onOpenChange,
+  pv,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  pv: PersistentVolume | null
+  onSuccess?: () => void | Promise<void>
+}) {
+  const { t } = useTranslation()
+  const [policy, setPolicy] = useState<ReclaimPolicy>('Retain')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open || !pv) {
+      setPolicy('Retain')
+      setIsSaving(false)
+      return
+    }
+
+    setPolicy((pv.spec?.persistentVolumeReclaimPolicy || 'Retain') as ReclaimPolicy)
+    setIsSaving(false)
+  }, [open, pv])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const name = pv?.metadata?.name
+    if (!name) return
+
+    setIsSaving(true)
+    try {
+      await patchResource('persistentvolumes', name, undefined, {
+        spec: {
+          persistentVolumeReclaimPolicy: policy,
+        },
+      })
+      toast.success(t('storageEdit.reclaimPolicySuccess', { name }))
+      onOpenChange(false)
+      await onSuccess?.()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('storageEdit.reclaimPolicyTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('storageEdit.reclaimPolicyDescription')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label>{t('pvs.reclaimPolicy')}</Label>
+            <Select
+              value={policy}
+              onValueChange={(value) => setPolicy(value as ReclaimPolicy)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Retain">Retain</SelectItem>
+                <SelectItem value="Delete">Delete</SelectItem>
+                <SelectItem value="Recycle">Recycle</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {t('storageEdit.reclaimPolicyHint')}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? t('common.applying') : t('common.apply')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1064,14 +1064,103 @@
     "volume": "Volume",
     "storageClass": "Storage Class",
     "capacity": "Capacity",
-    "accessModes": "Access Modes"
+    "accessModes": "Access Modes",
+    "copyVolume": "Copy Volume",
+    "copyStorageClass": "Copy Storage Class"
   },
   "pvs": {
     "storageClass": "Storage Class",
     "capacity": "Capacity",
     "accessModes": "Access Modes",
     "reclaimPolicy": "Reclaim Policy",
-    "claim": "Claim"
+    "claim": "Claim",
+    "copyStorageClass": "Copy Storage Class",
+    "copyClaim": "Copy Claim"
+  },
+  "pvcList": {
+    "manageLabels": "Manage PVC labels",
+    "manageAnnotations": "Manage PVC annotations"
+  },
+  "pvList": {
+    "manageLabels": "Manage PV labels",
+    "manageAnnotations": "Manage PV annotations"
+  },
+  "storageClasses": {
+    "provisioner": "Provisioner",
+    "defaultClass": "Default",
+    "volumeBindingMode": "Binding Mode",
+    "allowExpansion": "Allow Expansion",
+    "parameters": "Parameters",
+    "mountOptions": "Mount Options",
+    "viewParameters": "View Parameters",
+    "viewMountOptions": "View Mount Options",
+    "copyProvisioner": "Copy Provisioner"
+  },
+  "storageDetails": {
+    "pvcInformation": "PVC Information",
+    "pvInformation": "PV Information",
+    "storageClassInformation": "Storage Class Information",
+    "requestedStorage": "Requested Storage",
+    "volumeMode": "Volume Mode",
+    "volumeSource": "Volume Source",
+    "volumeSourceDetail": "Source Detail",
+    "nodeAffinity": "Node Affinity",
+    "releasedRetainWarning": "This volume is Released with Retain policy. The backing storage may require manual cleanup or rebinding.",
+    "associations": "Associations",
+    "consumingPods": "Consuming Pods",
+    "claims": "Claims",
+    "volumes": "Volumes"
+  },
+  "storageCreate": {
+    "storageClassTitle": "Create Storage Class",
+    "storageClassDescription": "Define a storage class for dynamic provisioning, including provisioner, policy, binding behavior, and optional driver parameters.",
+    "storageClassSuccess": "Storage class {{name}} created",
+    "templateLabel": "Template",
+    "templateHint": "Templates prefill common CSI provisioners and parameters. You can still adjust every field before creating.",
+    "awsAutoModeHint": "EKS Auto Mode uses a different EBS provisioner. Keep the auto compute topology parameter unless you know your cluster does not require it.",
+    "template": {
+      "generic": "Generic CSI / Local static",
+      "alibabaDisk": "Alibaba Cloud ACK Disk",
+      "tencentCbs": "Tencent Cloud TKE CBS",
+      "awsEbs": "AWS EBS CSI",
+      "awsEksAutoEbs": "AWS EKS Auto Mode EBS",
+      "awsEfs": "AWS EFS CSI"
+    },
+    "pvcTitle": "Create Persistent Volume Claim",
+    "pvcDescription": "Request storage for workloads. Use Storage Class for dynamic provisioning, or bind to a specific existing volume when needed.",
+    "pvcSuccess": "Persistent volume claim {{name}} created",
+    "pvTitle": "Create Persistent Volume",
+    "pvDescription": "Create a static persistent volume backed by HostPath, NFS, or Local storage.",
+    "pvSuccess": "Persistent volume {{name}} created",
+    "requestStorage": "Requested Storage",
+    "storageClassOptional": "Optional storage class",
+    "boundVolumeOptional": "Bind Volume (optional)",
+    "sourcePath": "Source Path",
+    "nfsServer": "NFS Server",
+    "nodeHostnameOptional": "Node Hostname (optional)",
+    "readOnly": "Read Only",
+    "accessMode": {
+      "rwo": "ReadWriteOnce",
+      "rom": "ReadOnlyMany",
+      "rwm": "ReadWriteMany"
+    }
+  },
+  "storageEdit": {
+    "resizePVCAction": "Resize",
+    "resizePVCTitle": "Resize Persistent Volume Claim",
+    "resizePVCDescription": "Update the PVC requested storage. Actual expansion depends on the StorageClass and CSI driver support.",
+    "newStorageSize": "New Size",
+    "resizePVCHint": "For example, 20Gi. Kubernetes generally supports expansion, not direct shrinking.",
+    "resizePVCSuccess": "Persistent volume claim {{name}} resized",
+    "reclaimPolicyAction": "Edit Reclaim Policy",
+    "reclaimPolicyTitle": "Edit Persistent Volume Reclaim Policy",
+    "reclaimPolicyDescription": "Change how the backing storage is handled after the PV is released.",
+    "reclaimPolicyHint": "Retain keeps data, Delete removes backing resources with the PV, and Recycle is deprecated.",
+    "reclaimPolicySuccess": "Persistent volume {{name}} reclaim policy updated",
+    "setDefaultAction": "Set as Default",
+    "unsetDefaultAction": "Unset Default",
+    "setDefaultSuccess": "Storage class {{name}} set as default",
+    "unsetDefaultSuccess": "Storage class {{name}} unset as default"
   },
   "resourceKind": {
     "pod": "Pod",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1546,14 +1546,103 @@
     "volume": "卷",
     "storageClass": "存储类",
     "capacity": "容量",
-    "accessModes": "访问模式"
+    "accessModes": "访问模式",
+    "copyVolume": "复制卷",
+    "copyStorageClass": "复制存储类"
   },
   "pvs": {
     "storageClass": "存储类",
     "capacity": "容量",
     "accessModes": "访问模式",
     "reclaimPolicy": "回收策略",
-    "claim": "声明"
+    "claim": "声明",
+    "copyStorageClass": "复制存储类",
+    "copyClaim": "复制声明"
+  },
+  "pvcList": {
+    "manageLabels": "管理 PVC 标签",
+    "manageAnnotations": "管理 PVC 注解"
+  },
+  "pvList": {
+    "manageLabels": "管理 PV 标签",
+    "manageAnnotations": "管理 PV 注解"
+  },
+  "storageClasses": {
+    "provisioner": "供应器",
+    "defaultClass": "默认",
+    "volumeBindingMode": "绑定模式",
+    "allowExpansion": "允许扩容",
+    "parameters": "参数",
+    "mountOptions": "挂载选项",
+    "viewParameters": "查看参数",
+    "viewMountOptions": "查看挂载选项",
+    "copyProvisioner": "复制供应器"
+  },
+  "storageDetails": {
+    "pvcInformation": "PVC 信息",
+    "pvInformation": "PV 信息",
+    "storageClassInformation": "存储类信息",
+    "requestedStorage": "请求容量",
+    "volumeMode": "卷模式",
+    "volumeSource": "卷来源",
+    "volumeSourceDetail": "来源详情",
+    "nodeAffinity": "节点亲和性",
+    "releasedRetainWarning": "该卷处于 Released 状态且回收策略为 Retain，底层存储可能需要手动清理或重新绑定。",
+    "associations": "关联",
+    "consumingPods": "消费该卷的 Pod",
+    "claims": "声明",
+    "volumes": "卷"
+  },
+  "storageCreate": {
+    "storageClassTitle": "创建存储类",
+    "storageClassDescription": "定义用于动态供给的存储类，包括供应器、回收策略、绑定模式和可选驱动参数。",
+    "storageClassSuccess": "存储类 {{name}} 已创建",
+    "templateLabel": "模板",
+    "templateHint": "模板会预填常见 CSI 供应器和参数，创建前仍可按集群实际情况调整所有字段。",
+    "awsAutoModeHint": "EKS Auto Mode 使用不同的 EBS 供应器。除非确认集群不需要，否则建议保留 auto compute 拓扑参数。",
+    "template": {
+      "generic": "通用 CSI / 本地静态卷",
+      "alibabaDisk": "阿里云 ACK 云盘",
+      "tencentCbs": "腾讯云 TKE CBS",
+      "awsEbs": "AWS EBS CSI",
+      "awsEksAutoEbs": "AWS EKS Auto Mode EBS",
+      "awsEfs": "AWS EFS CSI"
+    },
+    "pvcTitle": "创建存储声明",
+    "pvcDescription": "为工作负载申请存储。可通过存储类动态供给，也可按需绑定指定存储卷。",
+    "pvcSuccess": "存储声明 {{name}} 已创建",
+    "pvTitle": "创建存储卷",
+    "pvDescription": "创建由 HostPath、NFS 或 Local 存储提供的静态存储卷。",
+    "pvSuccess": "存储卷 {{name}} 已创建",
+    "requestStorage": "请求容量",
+    "storageClassOptional": "可选存储类",
+    "boundVolumeOptional": "绑定卷（可选）",
+    "sourcePath": "来源路径",
+    "nfsServer": "NFS 服务器",
+    "nodeHostnameOptional": "节点主机名（可选）",
+    "readOnly": "只读",
+    "accessMode": {
+      "rwo": "ReadWriteOnce",
+      "rom": "ReadOnlyMany",
+      "rwm": "ReadWriteMany"
+    }
+  },
+  "storageEdit": {
+    "resizePVCAction": "调整容量",
+    "resizePVCTitle": "调整存储声明容量",
+    "resizePVCDescription": "更新 PVC 的请求容量。实际扩容能力取决于存储类是否允许扩容以及底层 CSI 驱动支持情况。",
+    "newStorageSize": "新容量",
+    "resizePVCHint": "例如 20Gi。Kubernetes 通常只支持扩容，不支持直接缩容。",
+    "resizePVCSuccess": "存储声明 {{name}} 容量已更新",
+    "reclaimPolicyAction": "编辑回收策略",
+    "reclaimPolicyTitle": "编辑存储卷回收策略",
+    "reclaimPolicyDescription": "调整 PV 释放后的底层存储处理方式。",
+    "reclaimPolicyHint": "Retain 会保留底层数据，Delete 会随 PV 删除底层资源，Recycle 已不推荐使用。",
+    "reclaimPolicySuccess": "存储卷 {{name}} 回收策略已更新",
+    "setDefaultAction": "设为默认存储类",
+    "unsetDefaultAction": "取消默认存储类",
+    "setDefaultSuccess": "存储类 {{name}} 已设为默认",
+    "unsetDefaultSuccess": "存储类 {{name}} 已取消默认"
   },
   "resourceKind": {
     "pod": "容器组",

--- a/ui/src/pages/pv-detail.tsx
+++ b/ui/src/pages/pv-detail.tsx
@@ -1,0 +1,173 @@
+import type { PersistentVolume } from 'kubernetes-types/core/v1'
+import { useState } from 'react'
+import { RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { formatDate } from '@/lib/utils'
+import { PVReclaimPolicyDialog } from '@/components/editors/storage-edit-dialogs'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+import {
+  DetailField,
+  StatusBadge,
+  StorageResourceDetailShell,
+} from './storage-detail-shared'
+
+function getVolumeSource(pv: PersistentVolume) {
+  const spec = pv.spec
+
+  if (spec?.csi) {
+    return {
+      type: 'CSI',
+      detail: spec.csi.driver || spec.csi.volumeHandle || '-',
+    }
+  }
+  if (spec?.nfs) {
+    return {
+      type: 'NFS',
+      detail: `${spec.nfs.server}:${spec.nfs.path}`,
+    }
+  }
+  if (spec?.hostPath) {
+    return {
+      type: 'HostPath',
+      detail: spec.hostPath.path,
+    }
+  }
+  if (spec?.local) {
+    return {
+      type: 'Local',
+      detail: spec.local.path,
+    }
+  }
+  if (spec?.awsElasticBlockStore) {
+    return {
+      type: 'AWSElasticBlockStore',
+      detail: spec.awsElasticBlockStore.volumeID,
+    }
+  }
+  if (spec?.gcePersistentDisk) {
+    return {
+      type: 'GCEPersistentDisk',
+      detail: spec.gcePersistentDisk.pdName,
+    }
+  }
+
+  return {
+    type: '-',
+    detail: '-',
+  }
+}
+
+export function PVDetail(props: { name: string }) {
+  const { name } = props
+  const { t } = useTranslation()
+  const [reclaimPolicyPV, setReclaimPolicyPV] =
+    useState<PersistentVolume | null>(null)
+
+  return (
+    <StorageResourceDetailShell
+      resourceType="persistentvolumes"
+      name={name}
+      title="PV"
+      overviewTitle={t('storageDetails.pvInformation')}
+      renderHeaderActions={(pv, refresh) => (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setReclaimPolicyPV(pv)}
+          >
+            <RotateCcw className="h-4 w-4" />
+            {t('storageEdit.reclaimPolicyAction')}
+          </Button>
+          <PVReclaimPolicyDialog
+            open={Boolean(reclaimPolicyPV)}
+            onOpenChange={(open) => {
+              if (!open) {
+                setReclaimPolicyPV(null)
+              }
+            }}
+            pv={reclaimPolicyPV}
+            onSuccess={refresh}
+          />
+        </>
+      )}
+      renderOverview={(pv) => {
+        const source = getVolumeSource(pv)
+        const claimRef = pv.spec?.claimRef
+        const isReleasedRetain =
+          pv.status?.phase === 'Released' &&
+          pv.spec?.persistentVolumeReclaimPolicy === 'Retain'
+
+        return (
+          <div className="space-y-4">
+            {isReleasedRetain ? (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  {t('storageDetails.releasedRetainWarning')}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <DetailField label={t('common.status')}>
+                <StatusBadge phase={pv.status?.phase} />
+              </DetailField>
+              <DetailField label={t('pvs.capacity')} mono>
+                {pv.spec?.capacity?.storage || '-'}
+              </DetailField>
+              <DetailField label={t('pvs.accessModes')}>
+                {pv.spec?.accessModes?.join(', ') || '-'}
+              </DetailField>
+              <DetailField label={t('pvs.reclaimPolicy')}>
+                {pv.spec?.persistentVolumeReclaimPolicy || '-'}
+              </DetailField>
+              <DetailField label={t('storageDetails.volumeMode')}>
+                {pv.spec?.volumeMode || '-'}
+              </DetailField>
+              <DetailField label={t('pvs.storageClass')}>
+                {pv.spec?.storageClassName ? (
+                  <Link to={`/storageclasses/${pv.spec.storageClassName}`} className="app-link">
+                    {pv.spec.storageClassName}
+                  </Link>
+                ) : (
+                  '-'
+                )}
+              </DetailField>
+              <DetailField label={t('pvs.claim')}>
+                {claimRef?.namespace && claimRef.name ? (
+                  <Link
+                    to={`/persistentvolumeclaims/${claimRef.namespace}/${claimRef.name}`}
+                    className="app-link"
+                  >
+                    {claimRef.namespace}/{claimRef.name}
+                  </Link>
+                ) : (
+                  '-'
+                )}
+              </DetailField>
+              <DetailField label={t('storageDetails.volumeSource')}>
+                {source.type}
+              </DetailField>
+              <DetailField label={t('storageDetails.volumeSourceDetail')} mono>
+                {source.detail}
+              </DetailField>
+              <DetailField label={t('storageDetails.nodeAffinity')}>
+                {pv.spec?.nodeAffinity ? t('common.yes') : t('common.no')}
+              </DetailField>
+              <DetailField label={t('detail.fields.created')}>
+                {formatDate(pv.metadata?.creationTimestamp || '')}
+              </DetailField>
+              <DetailField label={t('detail.fields.uid')} mono>
+                {pv.metadata?.uid || '-'}
+              </DetailField>
+            </div>
+          </div>
+        )
+      }}
+    />
+  )
+}

--- a/ui/src/pages/pv-list-page.test.tsx
+++ b/ui/src/pages/pv-list-page.test.tsx
@@ -1,12 +1,12 @@
 import { type ReactNode } from 'react'
 import { createColumnHelper, flexRender } from '@tanstack/react-table'
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import type { PersistentVolumeClaim } from 'kubernetes-types/core/v1'
+import type { PersistentVolume } from 'kubernetes-types/core/v1'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
 
-import { PVCListPage } from './pvc-list-page'
+import { PVListPage } from './pv-list-page'
 
 const mockNavigate = vi.fn()
 const mockCopyTextToClipboard = vi.fn()
@@ -82,44 +82,27 @@ vi.mock('@/components/resource-table', () => ({
 }))
 
 vi.mock('@/components/editors/resource-metadata-dialog', () => ({
-  ResourceMetadataDialog: ({
-    open,
-    type,
-    resource,
-  }: {
-    open: boolean
-    type: 'labels' | 'annotations'
-    resource?: { metadata?: { name?: string } } | null
-  }) =>
-    open ? (
-      <div>
-        <span>{`resource-metadata-dialog-${type}`}</span>
-        <span>{resource?.metadata?.name}</span>
-      </div>
-    ) : null,
+  ResourceMetadataDialog: () => null,
 }))
 
 vi.mock('@/components/editors/storage-create-dialogs', () => ({
-  PVCCreateDialog: ({
+  PVCreateDialog: ({
     open,
     onSuccess,
   }: {
     open: boolean
-    onSuccess: (pvc: PersistentVolumeClaim, namespace: string) => void
+    onSuccess: (pv: PersistentVolume) => void
   }) =>
     open ? (
       <div>
-        <span>pvc-create-dialog</span>
+        <span>pv-create-dialog</span>
         <button
           onClick={() =>
-            onSuccess(
-              {
-                metadata: {
-                  name: 'data-web-0',
-                },
-              } as PersistentVolumeClaim,
-              'default'
-            )
+            onSuccess({
+              metadata: {
+                name: 'pv-data-web-0',
+              },
+            } as PersistentVolume)
           }
         >
           finish-create
@@ -129,11 +112,11 @@ vi.mock('@/components/editors/storage-create-dialogs', () => ({
 }))
 
 vi.mock('@/components/editors/storage-edit-dialogs', () => ({
-  PVCResizeDialog: ({ open }: { open: boolean }) =>
-    open ? <div>pvc-resize-dialog</div> : null,
+  PVReclaimPolicyDialog: ({ open }: { open: boolean }) =>
+    open ? <div>pv-reclaim-policy-dialog</div> : null,
 }))
 
-describe('PVCListPage', () => {
+describe('PVListPage', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-10T13:53:27.000Z'))
@@ -143,29 +126,27 @@ describe('PVCListPage', () => {
     mockResourceTable.mockClear()
   })
 
-  it('opens pvc create dialog and navigates to the created resource', async () => {
-    render(<PVCListPage />)
+  it('opens pv create dialog and navigates to the created resource', async () => {
+    render(<PVListPage />)
 
     expect(screen.getByText('create-enabled')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'open-create' }))
-    expect(screen.getByText('pvc-create-dialog')).toBeInTheDocument()
+    expect(screen.getByText('pv-create-dialog')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'finish-create' }))
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ['persistentvolumeclaims'],
+      queryKey: ['persistentvolumes'],
     })
     await Promise.resolve()
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/persistentvolumeclaims/default/data-web-0'
-    )
+    expect(mockNavigate).toHaveBeenCalledWith('/persistentvolumes/pv-data-web-0')
   })
 
-  it('renders pvc creation time with relative age', () => {
-    render(<PVCListPage />)
+  it('renders pv creation time with relative age', () => {
+    render(<PVListPage />)
 
     const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
-      columns: ReturnType<typeof createColumnHelper<PersistentVolumeClaim>>[]
+      columns: ReturnType<typeof createColumnHelper<PersistentVolume>>[]
     }
     const createdAt = '2026-05-09T13:53:27.000Z'
     const createdColumn = resourceTableProps.columns.at(-1)
@@ -183,37 +164,38 @@ describe('PVCListPage', () => {
     )
   })
 
-  it('provides unified row actions for pvc resources', async () => {
-    render(<PVCListPage />)
+  it('provides unified row actions for pv resources', async () => {
+    render(<PVListPage />)
 
     const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
-      getRowContextMenuItems: (pvc: PersistentVolumeClaim) => {
+      getRowContextMenuItems: (pv: PersistentVolume) => {
         key: string
         onSelect?: () => void | Promise<void>
       }[]
     }
 
-    const pvc = {
+    const pv = {
       metadata: {
-        name: 'data-web-0',
-        namespace: 'default',
+        name: 'pv-data-web-0',
       },
       spec: {
-        volumeName: 'pv-data-web-0',
         storageClassName: 'fast-ssd',
+        claimRef: {
+          namespace: 'default',
+          name: 'data-web-0',
+        },
       },
-    } as PersistentVolumeClaim
+    } as PersistentVolume
 
-    const items = resourceTableProps.getRowContextMenuItems(pvc)
+    const items = resourceTableProps.getRowContextMenuItems(pv)
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
-      'resize-pvc',
+      'edit-reclaim-policy',
       'primary-actions-separator',
       'copy-name',
-      'copy-namespace',
-      'copy-volume',
       'copy-storage-class',
+      'copy-claim',
       'metadata-actions-separator',
       'manage-labels',
       'manage-annotations',
@@ -221,38 +203,21 @@ describe('PVCListPage', () => {
 
     await items[0].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/persistentvolumeclaims/default/data-web-0?tab=yaml'
+      '/persistentvolumes/pv-data-web-0?tab=yaml'
     )
 
     await act(async () => {
       await items[1].onSelect?.()
     })
-    expect(screen.getByText('pvc-resize-dialog')).toBeInTheDocument()
+    expect(screen.getByText('pv-reclaim-policy-dialog')).toBeInTheDocument()
 
     await items[3].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('data-web-0')
-
-    await items[4].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('default')
-
-    await items[5].onSelect?.()
     expect(mockCopyTextToClipboard).toHaveBeenCalledWith('pv-data-web-0')
 
-    await items[6].onSelect?.()
+    await items[4].onSelect?.()
     expect(mockCopyTextToClipboard).toHaveBeenCalledWith('fast-ssd')
 
-    await act(async () => {
-      await items[8].onSelect?.()
-    })
-    expect(
-      screen.getByText('resource-metadata-dialog-labels')
-    ).toBeInTheDocument()
-
-    await act(async () => {
-      await items[9].onSelect?.()
-    })
-    expect(
-      screen.getByText('resource-metadata-dialog-annotations')
-    ).toBeInTheDocument()
+    await items[5].onSelect?.()
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('default/data-web-0')
   })
 })

--- a/ui/src/pages/pv-list-page.tsx
+++ b/ui/src/pages/pv-list-page.tsx
@@ -1,26 +1,56 @@
 import { useCallback, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { PersistentVolume } from 'kubernetes-types/core/v1'
-import { Copy, FileCode2, FileText, Tags } from 'lucide-react'
+import { Copy, FileCode2, FileText, RotateCcw, Tags } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { copyTextToClipboard } from '@/lib/desktop'
-import { formatDate, parseBytes } from '@/lib/utils'
+import { formatDate, formatRelativeTimeStrict, parseBytes } from '@/lib/utils'
 import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import { PVCreateDialog } from '@/components/editors/storage-create-dialogs'
+import { PVReclaimPolicyDialog } from '@/components/editors/storage-edit-dialogs'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
 import { Badge } from '@/components/ui/badge'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
 
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
+
 export function PVListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [reclaimPolicyPV, setReclaimPolicyPV] =
+    useState<PersistentVolume | null>(null)
   const [labelsPV, setLabelsPV] = useState<PersistentVolume | null>(null)
   const [annotationsPV, setAnnotationsPV] = useState<PersistentVolume | null>(
     null
   )
   const columnHelper = useMemo(() => createColumnHelper<PersistentVolume>(), [])
+
+  const getVolumeSourceType = useCallback((pv: PersistentVolume) => {
+    const spec = pv.spec
+    if (spec?.csi) return 'CSI'
+    if (spec?.nfs) return 'NFS'
+    if (spec?.hostPath) return 'HostPath'
+    if (spec?.local) return 'Local'
+    if (spec?.awsElasticBlockStore) return 'AWSElasticBlockStore'
+    if (spec?.gcePersistentDisk) return 'GCEPersistentDisk'
+    return '-'
+  }, [])
 
   // Define columns for the PV table
   const columns = useMemo(
@@ -87,6 +117,15 @@ export function PVListPage() {
           return modes.join(', ') || '-'
         },
       }),
+      columnHelper.accessor('spec.volumeMode', {
+        header: t('storageDetails.volumeMode'),
+        cell: ({ getValue }) => getValue() || '-',
+      }),
+      columnHelper.display({
+        id: 'volume-source',
+        header: t('storageDetails.volumeSource'),
+        cell: ({ row }) => getVolumeSourceType(row.original),
+      }),
       columnHelper.accessor('spec.persistentVolumeReclaimPolicy', {
         header: t('pvs.reclaimPolicy'),
         cell: ({ getValue }) => {
@@ -112,18 +151,50 @@ export function PVListPage() {
           return '-'
         },
       }),
+      columnHelper.display({
+        id: 'labels',
+        header: t('detail.fields.labels'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="labels"
+            ariaLabel={t('pvList.manageLabels')}
+            count={Object.keys(row.original.metadata?.labels || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.labels
+            )}
+            onClick={() => setLabelsPV(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'annotations',
+        header: t('detail.fields.annotations'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="annotations"
+            ariaLabel={t('pvList.manageAnnotations')}
+            count={Object.keys(row.original.metadata?.annotations || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.annotations
+            )}
+            onClick={() => setAnnotationsPV(row.original)}
+          />
+        ),
+      }),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.created'),
         cell: ({ getValue }) => {
-          const dateStr = formatDate(getValue() || '')
-
           return (
-            <span className="text-muted-foreground text-sm">{dateStr}</span>
+            <span className="text-muted-foreground text-sm">
+              {formatTimestampWithRelative(getValue())}
+            </span>
           )
         },
       }),
     ],
-    [columnHelper, t]
+    [columnHelper, getVolumeSourceType, t]
   )
 
   // Custom filter for PV search
@@ -132,10 +203,12 @@ export function PVListPage() {
       pv.metadata!.name!.toLowerCase().includes(query) ||
       (pv.spec!.storageClassName?.toLowerCase() || '').includes(query) ||
       (pv.status!.phase?.toLowerCase() || '').includes(query) ||
+      (pv.spec!.volumeMode?.toLowerCase() || '').includes(query) ||
+      getVolumeSourceType(pv).toLowerCase().includes(query) ||
       (pv.spec!.claimRef?.name?.toLowerCase() || '').includes(query) ||
       (pv.spec!.claimRef?.namespace?.toLowerCase() || '').includes(query)
     )
-  }, [])
+  }, [getVolumeSourceType])
 
   const getPVDetailPath = useCallback((pv: PersistentVolume) => {
     return `/persistentvolumes/${pv.metadata!.name}`
@@ -149,6 +222,22 @@ export function PVListPage() {
     [t]
   )
 
+  const handleCreateSuccess = useCallback(
+    async (pv: PersistentVolume) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['persistentvolumes'],
+      })
+      navigate(`/persistentvolumes/${pv.metadata?.name || ''}`)
+    },
+    [navigate, queryClient]
+  )
+
+  const handleEditSuccess = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ['persistentvolumes'],
+    })
+  }, [queryClient])
+
   const getRowContextMenuItems = useCallback(
     (pv: PersistentVolume): RowContextMenuItem<PersistentVolume>[] => [
       {
@@ -157,12 +246,37 @@ export function PVListPage() {
         icon: <FileCode2 className="h-4 w-4" />,
         onSelect: () => navigate(`${getPVDetailPath(pv)}?tab=yaml`),
       },
+      {
+        key: 'edit-reclaim-policy',
+        label: t('storageEdit.reclaimPolicyAction'),
+        icon: <RotateCcw className="h-4 w-4" />,
+        onSelect: () => setReclaimPolicyPV(pv),
+      },
       { type: 'separator', key: 'primary-actions-separator' },
       {
         key: 'copy-name',
         label: t('common.copyName', 'Copy name'),
         icon: <Copy className="h-4 w-4" />,
         onSelect: () => handleCopy(pv.metadata?.name || ''),
+      },
+      {
+        key: 'copy-storage-class',
+        label: t('pvs.copyStorageClass'),
+        icon: <Copy className="h-4 w-4" />,
+        disabled: !pv.spec?.storageClassName,
+        onSelect: () => handleCopy(pv.spec?.storageClassName || ''),
+      },
+      {
+        key: 'copy-claim',
+        label: t('pvs.copyClaim'),
+        icon: <Copy className="h-4 w-4" />,
+        disabled: !pv.spec?.claimRef?.name,
+        onSelect: () =>
+          handleCopy(
+            pv.spec?.claimRef?.namespace && pv.spec?.claimRef?.name
+              ? `${pv.spec.claimRef.namespace}/${pv.spec.claimRef.name}`
+              : ''
+          ),
       },
       { type: 'separator', key: 'metadata-actions-separator' },
       {
@@ -188,10 +302,29 @@ export function PVListPage() {
         columns={columns}
         clusterScope={true}
         searchQueryFilter={pvSearchFilter}
+        showCreateButton={true}
+        onCreateClick={() => setIsCreateDialogOpen(true)}
         batchDeleteConfirmationValue={t(
           'deleteConfirmation.confirmDeleteKeyword'
         )}
         getRowContextMenuItems={getRowContextMenuItems}
+      />
+
+      <PVCreateDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        onSuccess={handleCreateSuccess}
+      />
+
+      <PVReclaimPolicyDialog
+        open={Boolean(reclaimPolicyPV)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setReclaimPolicyPV(null)
+          }
+        }}
+        pv={reclaimPolicyPV}
+        onSuccess={handleEditSuccess}
       />
 
       <ResourceMetadataDialog

--- a/ui/src/pages/pvc-detail.tsx
+++ b/ui/src/pages/pvc-detail.tsx
@@ -1,0 +1,168 @@
+import type { PersistentVolumeClaim, Pod } from 'kubernetes-types/core/v1'
+import { useState } from 'react'
+import { Maximize2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { useResources } from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import { PVCResizeDialog } from '@/components/editors/storage-edit-dialogs'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import {
+  DetailField,
+  EmptyTableRow,
+  StatusBadge,
+  StorageResourceDetailShell,
+} from './storage-detail-shared'
+
+function podUsesPVC(pod: Pod, pvcName: string) {
+  return (pod.spec?.volumes || []).some(
+    (volume) => volume.persistentVolumeClaim?.claimName === pvcName
+  )
+}
+
+function PVCConsumers({
+  namespace,
+  pvc,
+}: {
+  namespace: string
+  pvc: PersistentVolumeClaim
+}) {
+  const { t } = useTranslation()
+  const { data: pods = [] } = useResources('pods', namespace)
+  const consumers = pods.filter((pod) => podUsesPVC(pod, pvc.metadata?.name || ''))
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold">{t('storageDetails.consumingPods')}</h3>
+      <Table containerClassName="border-b">
+        <TableHeader className="bg-muted">
+          <TableRow>
+            <TableHead>{t('common.name')}</TableHead>
+            <TableHead>{t('detail.fields.namespace')}</TableHead>
+            <TableHead>{t('detail.fields.created')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {consumers.length === 0 ? (
+            <EmptyTableRow colSpan={3} />
+          ) : (
+            consumers.map((pod) => (
+              <TableRow key={pod.metadata?.uid || pod.metadata?.name}>
+                <TableCell>
+                  <Link
+                    to={`/pods/${pod.metadata?.namespace}/${pod.metadata?.name}`}
+                    className="app-link"
+                  >
+                    {pod.metadata?.name}
+                  </Link>
+                </TableCell>
+                <TableCell>{pod.metadata?.namespace || '-'}</TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {pod.metadata?.creationTimestamp
+                    ? formatDate(pod.metadata.creationTimestamp)
+                    : '-'}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export function PVCDetail(props: { namespace: string; name: string }) {
+  const { name, namespace } = props
+  const { t } = useTranslation()
+  const [resizePVC, setResizePVC] = useState<PersistentVolumeClaim | null>(null)
+
+  return (
+    <>
+      <StorageResourceDetailShell
+        resourceType="persistentvolumeclaims"
+        namespace={namespace}
+        name={name}
+        title="PVC"
+        overviewTitle={t('storageDetails.pvcInformation')}
+        renderHeaderActions={(pvc, refresh) => (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setResizePVC(pvc)}
+            >
+              <Maximize2 className="h-4 w-4" />
+              {t('storageEdit.resizePVCAction')}
+            </Button>
+            <PVCResizeDialog
+              open={Boolean(resizePVC)}
+              onOpenChange={(open) => {
+                if (!open) {
+                  setResizePVC(null)
+                }
+              }}
+              pvc={resizePVC}
+              onSuccess={refresh}
+            />
+          </>
+        )}
+        renderOverview={(pvc) => (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <DetailField label={t('common.status')}>
+              <StatusBadge phase={pvc.status?.phase} />
+            </DetailField>
+            <DetailField label={t('pvcs.capacity')} mono>
+              {pvc.status?.capacity?.storage ||
+                pvc.spec?.resources?.requests?.storage ||
+                '-'}
+            </DetailField>
+            <DetailField label={t('storageDetails.requestedStorage')} mono>
+              {pvc.spec?.resources?.requests?.storage || '-'}
+            </DetailField>
+            <DetailField label={t('pvcs.accessModes')}>
+              {pvc.spec?.accessModes?.join(', ') || '-'}
+            </DetailField>
+            <DetailField label={t('storageDetails.volumeMode')}>
+              {pvc.spec?.volumeMode || '-'}
+            </DetailField>
+            <DetailField label={t('pvcs.volume')}>
+              {pvc.spec?.volumeName ? (
+                <Link to={`/persistentvolumes/${pvc.spec.volumeName}`} className="app-link">
+                  {pvc.spec.volumeName}
+                </Link>
+              ) : (
+                '-'
+              )}
+            </DetailField>
+            <DetailField label={t('pvcs.storageClass')}>
+              {pvc.spec?.storageClassName ? (
+                <Link to={`/storageclasses/${pvc.spec.storageClassName}`} className="app-link">
+                  {pvc.spec.storageClassName}
+                </Link>
+              ) : (
+                '-'
+              )}
+            </DetailField>
+            <DetailField label={t('detail.fields.created')}>
+              {formatDate(pvc.metadata?.creationTimestamp || '')}
+            </DetailField>
+            <DetailField label={t('detail.fields.uid')} mono>
+              {pvc.metadata?.uid || '-'}
+            </DetailField>
+          </div>
+        )}
+        renderAssociations={(pvc) => <PVCConsumers namespace={namespace} pvc={pvc} />}
+      />
+    </>
+  )
+}

--- a/ui/src/pages/pvc-list-page.tsx
+++ b/ui/src/pages/pvc-list-page.tsx
@@ -1,21 +1,39 @@
 import { useCallback, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { PersistentVolumeClaim } from 'kubernetes-types/core/v1'
-import { Copy, FileCode2, FileText, Tags } from 'lucide-react'
+import { Copy, FileCode2, FileText, Maximize2, Tags } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
 import { copyTextToClipboard } from '@/lib/desktop'
-import { formatDate, parseBytes } from '@/lib/utils'
+import { formatDate, formatRelativeTimeStrict, parseBytes } from '@/lib/utils'
 import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import { PVCCreateDialog } from '@/components/editors/storage-create-dialogs'
+import { PVCResizeDialog } from '@/components/editors/storage-edit-dialogs'
+import {
+  MetadataActionButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
 import { Badge } from '@/components/ui/badge'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
 
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
+
 export function PVCListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [resizePVC, setResizePVC] = useState<PersistentVolumeClaim | null>(null)
   const [labelsPVC, setLabelsPVC] = useState<PersistentVolumeClaim | null>(null)
   const [annotationsPVC, setAnnotationsPVC] =
     useState<PersistentVolumeClaim | null>(null)
@@ -108,13 +126,49 @@ export function PVCListPage() {
           return modes.join(', ') || '-'
         },
       }),
+      columnHelper.accessor('spec.volumeMode', {
+        header: t('storageDetails.volumeMode'),
+        cell: ({ getValue }) => getValue() || '-',
+      }),
+      columnHelper.display({
+        id: 'labels',
+        header: t('detail.fields.labels'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="labels"
+            ariaLabel={t('pvcList.manageLabels')}
+            count={Object.keys(row.original.metadata?.labels || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.labels
+            )}
+            onClick={() => setLabelsPVC(row.original)}
+          />
+        ),
+      }),
+      columnHelper.display({
+        id: 'annotations',
+        header: t('detail.fields.annotations'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataActionButton
+            icon="annotations"
+            ariaLabel={t('pvcList.manageAnnotations')}
+            count={Object.keys(row.original.metadata?.annotations || {}).length}
+            tooltipContent={renderMetadataTooltipContent(
+              row.original.metadata?.annotations
+            )}
+            onClick={() => setAnnotationsPVC(row.original)}
+          />
+        ),
+      }),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.created'),
         cell: ({ getValue }) => {
-          const dateStr = formatDate(getValue() || '')
-
           return (
-            <span className="text-muted-foreground text-sm">{dateStr}</span>
+            <span className="text-muted-foreground text-sm">
+              {formatTimestampWithRelative(getValue())}
+            </span>
           )
         },
       }),
@@ -130,6 +184,7 @@ export function PVCListPage() {
         (pvc.metadata!.namespace?.toLowerCase() || '').includes(query) ||
         (pvc.spec!.volumeName?.toLowerCase() || '').includes(query) ||
         (pvc.spec!.storageClassName?.toLowerCase() || '').includes(query) ||
+        (pvc.spec!.volumeMode?.toLowerCase() || '').includes(query) ||
         (pvc.status!.phase?.toLowerCase() || '').includes(query)
       )
     },
@@ -148,6 +203,24 @@ export function PVCListPage() {
     [t]
   )
 
+  const handleCreateSuccess = useCallback(
+    async (pvc: PersistentVolumeClaim, namespace: string) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['persistentvolumeclaims'],
+      })
+      navigate(
+        `/persistentvolumeclaims/${namespace}/${pvc.metadata?.name || ''}`
+      )
+    },
+    [navigate, queryClient]
+  )
+
+  const handleEditSuccess = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ['persistentvolumeclaims'],
+    })
+  }, [queryClient])
+
   const getRowContextMenuItems = useCallback(
     (pvc: PersistentVolumeClaim): RowContextMenuItem<PersistentVolumeClaim>[] => [
       {
@@ -155,6 +228,12 @@ export function PVCListPage() {
         label: t('common.viewYaml', 'View YAML'),
         icon: <FileCode2 className="h-4 w-4" />,
         onSelect: () => navigate(`${getPVCDetailPath(pvc)}?tab=yaml`),
+      },
+      {
+        key: 'resize-pvc',
+        label: t('storageEdit.resizePVCAction'),
+        icon: <Maximize2 className="h-4 w-4" />,
+        onSelect: () => setResizePVC(pvc),
       },
       { type: 'separator', key: 'primary-actions-separator' },
       {
@@ -168,6 +247,20 @@ export function PVCListPage() {
         label: t('common.copyNamespace', 'Copy namespace'),
         icon: <Copy className="h-4 w-4" />,
         onSelect: () => handleCopy(pvc.metadata?.namespace || ''),
+      },
+      {
+        key: 'copy-volume',
+        label: t('pvcs.copyVolume'),
+        icon: <Copy className="h-4 w-4" />,
+        disabled: !pvc.spec?.volumeName,
+        onSelect: () => handleCopy(pvc.spec?.volumeName || ''),
+      },
+      {
+        key: 'copy-storage-class',
+        label: t('pvcs.copyStorageClass'),
+        icon: <Copy className="h-4 w-4" />,
+        disabled: !pvc.spec?.storageClassName,
+        onSelect: () => handleCopy(pvc.spec?.storageClassName || ''),
       },
       { type: 'separator', key: 'metadata-actions-separator' },
       {
@@ -192,10 +285,29 @@ export function PVCListPage() {
         resourceName={'PersistentVolumeClaims'}
         columns={columns}
         searchQueryFilter={pvcSearchFilter}
+        showCreateButton={true}
+        onCreateClick={() => setIsCreateDialogOpen(true)}
         batchDeleteConfirmationValue={t(
           'deleteConfirmation.confirmDeleteKeyword'
         )}
         getRowContextMenuItems={getRowContextMenuItems}
+      />
+
+      <PVCCreateDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        onSuccess={handleCreateSuccess}
+      />
+
+      <PVCResizeDialog
+        open={Boolean(resizePVC)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setResizePVC(null)
+          }
+        }}
+        pvc={resizePVC}
+        onSuccess={handleEditSuccess}
       />
 
       <ResourceMetadataDialog

--- a/ui/src/pages/resource-detail.tsx
+++ b/ui/src/pages/resource-detail.tsx
@@ -12,10 +12,13 @@ import { IngressDetail } from './ingress-detail'
 import { JobDetail } from './job-detail'
 import { NodeDetail } from './node-detail'
 import { PodDetail } from './pod-detail'
+import { PVDetail } from './pv-detail'
+import { PVCDetail } from './pvc-detail'
 import { SecretDetail } from './secret-detail'
 import { ServiceDetail } from './service-detail'
 import { SimpleResourceDetail } from './simple-resource-detail'
 import { StatefulSetDetail } from './statefulset-detail'
+import { StorageClassDetail } from './storageclass-detail'
 
 function getResourceTypeName(resource: string): string {
   const resourceMap: Record<string, string> = {
@@ -78,6 +81,12 @@ export function ResourceDetail() {
       return <ServiceDetail namespace={namespace!} name={name} />
     case 'ingresses':
       return <IngressDetail namespace={namespace!} name={name} />
+    case 'persistentvolumeclaims':
+      return <PVCDetail namespace={namespace!} name={name} />
+    case 'persistentvolumes':
+      return <PVDetail name={name} />
+    case 'storageclasses':
+      return <StorageClassDetail name={name} />
     default:
       return (
         <SimpleResourceDetail

--- a/ui/src/pages/resource-list.tsx
+++ b/ui/src/pages/resource-list.tsx
@@ -23,6 +23,7 @@ import { SecretListPage } from './secret-list-page'
 import { ServiceListPage } from './service-list-page'
 import { SimpleListPage } from './simple-list-page'
 import { StatefulSetListPage } from './statefulset-list-page'
+import { StorageClassListPage } from './storageclass-list-page'
 
 export function ResourceList() {
   const { resource } = useParams()
@@ -62,6 +63,8 @@ export function ResourceList() {
       return <PVCListPage />
     case 'persistentvolumes':
       return <PVListPage />
+    case 'storageclasses':
+      return <StorageClassListPage />
     case 'crds':
       return <CRDListPage />
     case 'gateways':

--- a/ui/src/pages/storage-detail-shared.tsx
+++ b/ui/src/pages/storage-detail-shared.tsx
@@ -1,0 +1,290 @@
+import { ReactNode, useEffect, useState } from 'react'
+import { IconLoader, IconTrash } from '@tabler/icons-react'
+import * as yaml from 'js-yaml'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { ResourceType, ResourceTypeMap } from '@/types/api'
+import { trackResourceAction } from '@/lib/analytics'
+import { updateResource, useResource } from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
+import { DescribeDialog } from '@/components/describe-dialog'
+import { ErrorMessage } from '@/components/error-message'
+import { EventTable } from '@/components/event-table'
+import { LabelsAnno } from '@/components/lables-anno'
+import { RefreshButton } from '@/components/refresh-button'
+import { RelatedResourcesTable } from '@/components/related-resource-table'
+import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
+import { ResourceHistoryTable } from '@/components/resource-history-table'
+import { YamlEditor } from '@/components/yaml-editor'
+
+export function DetailField(props: {
+  label: ReactNode
+  children: ReactNode
+  mono?: boolean
+}) {
+  const { children, label, mono = false } = props
+
+  return (
+    <div className="min-w-0">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div className={mono ? 'mt-1 truncate font-mono text-sm' : 'mt-1 text-sm'}>
+        {children || '-'}
+      </div>
+    </div>
+  )
+}
+
+export function StatusBadge({ phase }: { phase?: string }) {
+  const value = phase || 'Unknown'
+  const variant =
+    value === 'Bound'
+      ? 'default'
+      : value === 'Lost' || value === 'Failed' || value === 'Released'
+        ? 'destructive'
+        : 'secondary'
+
+  return <Badge variant={variant}>{value}</Badge>
+}
+
+export function KeyValueList({ values }: { values?: Record<string, string> }) {
+  const entries = Object.entries(values || {})
+
+  if (entries.length === 0) {
+    return <span className="text-sm text-muted-foreground">-</span>
+  }
+
+  return (
+    <div className="space-y-1">
+      {entries.map(([key, value]) => (
+        <div key={key} className="break-all font-mono text-sm">
+          {key}={value}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function EmptyTableRow({ colSpan }: { colSpan: number }) {
+  const { t } = useTranslation()
+
+  return (
+    <tr className="border-b transition-colors">
+      <td colSpan={colSpan} className="h-16 p-2 text-center text-sm text-muted-foreground">
+        {t('common.noData', 'No data')}
+      </td>
+    </tr>
+  )
+}
+
+export function StorageResourceDetailShell<T extends ResourceType>(props: {
+  resourceType: T
+  name: string
+  namespace?: string
+  title: string
+  overviewTitle: string
+  renderOverview: (resource: ResourceTypeMap[T]) => ReactNode
+  renderAssociations?: (resource: ResourceTypeMap[T]) => ReactNode
+  renderHeaderActions?: (
+    resource: ResourceTypeMap[T],
+    refresh: () => Promise<void>
+  ) => ReactNode
+}) {
+  const {
+    name,
+    namespace,
+    overviewTitle,
+    renderAssociations,
+    renderHeaderActions,
+    renderOverview,
+    resourceType,
+    title,
+  } = props
+  const [yamlContent, setYamlContent] = useState('')
+  const [isSavingYaml, setIsSavingYaml] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const { t } = useTranslation()
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch: handleRefresh,
+  } = useResource(resourceType, name, namespace)
+
+  useEffect(() => {
+    if (data) {
+      setYamlContent(yaml.dump(data, { indent: 2 }))
+    }
+  }, [data])
+
+  const handleSaveYaml = async (content: ResourceTypeMap[T]) => {
+    setIsSavingYaml(true)
+    try {
+      await updateResource(resourceType, name, namespace, content)
+      trackResourceAction(resourceType, 'yaml_save', { result: 'success' })
+      toast.success('YAML saved successfully')
+      await handleRefresh()
+      return true
+    } catch (error) {
+      trackResourceAction(resourceType, 'yaml_save', { result: 'error' })
+      toast.error(translateError(error, t))
+      return false
+    } finally {
+      setIsSavingYaml(false)
+    }
+  }
+
+  const handleManualRefresh = async () => {
+    trackResourceAction(resourceType, 'refresh')
+    setRefreshKey((prev) => prev + 1)
+    await handleRefresh()
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-center gap-2">
+              <IconLoader className="animate-spin" />
+              <span>{t('detail.status.loading', { resource: title })}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <ErrorMessage
+        resourceName={title}
+        error={error}
+        refetch={handleManualRefresh}
+      />
+    )
+  }
+
+  const resource = data as ResourceTypeMap[T]
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-lg font-bold">{name}</h1>
+          {namespace && (
+            <p className="text-muted-foreground">
+              {t('detail.fields.namespace')}:{' '}
+              <span className="font-medium">{namespace}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex w-full flex-wrap gap-2 md:w-auto md:justify-end">
+          <RefreshButton variant="outline" size="sm" onClick={handleManualRefresh}>
+            {t('detail.buttons.refresh')}
+          </RefreshButton>
+          <DescribeDialog resourceType={resourceType} namespace={namespace} name={name} />
+          {renderHeaderActions ? renderHeaderActions(resource, handleManualRefresh) : null}
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            <IconTrash className="w-4 h-4" />
+            {t('detail.buttons.delete')}
+          </Button>
+        </div>
+      </div>
+
+      <ResponsiveTabs
+        tabs={[
+          {
+            value: 'overview',
+            label: t('detail.tabs.overview'),
+            content: (
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{overviewTitle}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    {renderOverview(resource)}
+                    {renderAssociations ? renderAssociations(resource) : null}
+                    <LabelsAnno
+                      labels={resource.metadata?.labels || {}}
+                      annotations={resource.metadata?.annotations || {}}
+                    />
+                  </CardContent>
+                </Card>
+              </div>
+            ),
+          },
+          {
+            value: 'yaml',
+            label: t('detail.tabs.yaml'),
+            content: (
+              <YamlEditor
+                key={refreshKey}
+                value={yamlContent}
+                title={t('yamlEditor.title')}
+                onSave={handleSaveYaml}
+                onChange={setYamlContent}
+                isSaving={isSavingYaml}
+              />
+            ),
+          },
+          {
+            value: 'Related',
+            label: t('detail.tabs.related'),
+            content: (
+              <RelatedResourcesTable
+                resource={resourceType}
+                name={name}
+                namespace={namespace}
+              />
+            ),
+          },
+          {
+            value: 'events',
+            label: t('detail.tabs.events'),
+            content: (
+              <EventTable
+                resource={resourceType}
+                namespace={namespace}
+                name={name}
+              />
+            ),
+          },
+          {
+            value: 'history',
+            label: t('detail.tabs.history'),
+            content: (
+              <ResourceHistoryTable
+                resourceType={resourceType}
+                name={name}
+                namespace={namespace}
+                currentResource={resource}
+              />
+            ),
+          },
+        ]}
+      />
+
+      <ResourceDeleteConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        resourceName={name}
+        resourceType={resourceType}
+        namespace={namespace}
+      />
+    </div>
+  )
+}

--- a/ui/src/pages/storage-resource-detail.test.tsx
+++ b/ui/src/pages/storage-resource-detail.test.tsx
@@ -1,0 +1,329 @@
+import { render, screen } from '@testing-library/react'
+import type {
+  PersistentVolume,
+  PersistentVolumeClaim,
+  Pod,
+} from 'kubernetes-types/core/v1'
+import type { StorageClass } from 'kubernetes-types/storage/v1'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PVDetail } from './pv-detail'
+import { PVCDetail } from './pvc-detail'
+import { StorageClassDetail } from './storageclass-detail'
+
+const mockUseResource = vi.fn()
+const mockUseResources = vi.fn()
+const mockUpdateResource = vi.fn()
+const mockT = (key: string) => key
+const mockResponsiveTabs = vi.fn()
+
+function renderPVCDetail() {
+  return render(
+    <MemoryRouter>
+      <PVCDetail namespace="default" name="data-web-0" />
+    </MemoryRouter>
+  )
+}
+
+function renderPVDetail() {
+  return render(
+    <MemoryRouter>
+      <PVDetail name="pv-data-web-0" />
+    </MemoryRouter>
+  )
+}
+
+function renderStorageClassDetail() {
+  return render(
+    <MemoryRouter>
+      <StorageClassDetail name="fast-ssd" />
+    </MemoryRouter>
+  )
+}
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: mockT,
+    }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+  useResources: (...args: unknown[]) => mockUseResources(...args),
+  updateResource: (...args: unknown[]) => mockUpdateResource(...args),
+}))
+
+vi.mock('@/components/ui/responsive-tabs', () => ({
+  ResponsiveTabs: ({
+    tabs,
+  }: {
+    tabs: { value: string; label: string; content: React.ReactNode }[]
+  }) => {
+    mockResponsiveTabs(tabs)
+    return (
+      <div>
+        {tabs.map((tab) => (
+          <section key={tab.value}>{tab.content}</section>
+        ))}
+      </div>
+    )
+  },
+}))
+
+vi.mock('@/components/refresh-button', () => ({
+  RefreshButton: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/describe-dialog', () => ({
+  DescribeDialog: () => <button>describe</button>,
+}))
+
+vi.mock('@/components/yaml-editor', () => ({
+  YamlEditor: () => <div>yaml-editor</div>,
+}))
+
+vi.mock('@/components/related-resource-table', () => ({
+  RelatedResourcesTable: () => <div>related-resources</div>,
+}))
+
+vi.mock('@/components/event-table', () => ({
+  EventTable: () => <div>events</div>,
+}))
+
+vi.mock('@/components/resource-history-table', () => ({
+  ResourceHistoryTable: () => <div>history</div>,
+}))
+
+vi.mock('@/components/resource-delete-confirmation-dialog', () => ({
+  ResourceDeleteConfirmationDialog: () => null,
+}))
+
+describe('storage resource details', () => {
+  beforeEach(() => {
+    mockUseResource.mockReset()
+    mockUseResources.mockReset()
+    mockUpdateResource.mockReset()
+    mockResponsiveTabs.mockReset()
+    mockUpdateResource.mockResolvedValue(undefined)
+    mockUseResources.mockReturnValue({
+      data: [],
+      isLoading: false,
+    })
+  })
+
+  it('shows pvc binding, capacity, and consuming pods', () => {
+    const pvc = {
+      metadata: {
+        name: 'data-web-0',
+        namespace: 'default',
+        creationTimestamp: '2026-05-09T13:52:32.000Z',
+      },
+      spec: {
+        storageClassName: 'fast-ssd',
+        volumeName: 'pv-data-web-0',
+        volumeMode: 'Filesystem',
+        accessModes: ['ReadWriteOnce'],
+        resources: {
+          requests: {
+            storage: '20Gi',
+          },
+        },
+      },
+      status: {
+        phase: 'Bound',
+        capacity: {
+          storage: '20Gi',
+        },
+      },
+    } as PersistentVolumeClaim
+    const pod = {
+      metadata: {
+        name: 'web-0',
+        namespace: 'default',
+      },
+      spec: {
+        volumes: [
+          {
+            name: 'data',
+            persistentVolumeClaim: {
+              claimName: 'data-web-0',
+            },
+          },
+        ],
+      },
+    } as Pod
+
+    mockUseResource.mockReturnValue({
+      data: pvc,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseResources.mockImplementation((resource: string) => ({
+      data: resource === 'pods' ? [pod] : [],
+      isLoading: false,
+    }))
+
+    renderPVCDetail()
+
+    expect(screen.getByText('storageDetails.pvcInformation')).toBeInTheDocument()
+    expect(screen.getByText('Bound')).toBeInTheDocument()
+    expect(screen.getAllByText('20Gi')).toHaveLength(2)
+    expect(screen.getByText('ReadWriteOnce')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'pv-data-web-0' })).toHaveAttribute(
+      'href',
+      '/persistentvolumes/pv-data-web-0'
+    )
+    expect(screen.getByRole('link', { name: 'fast-ssd' })).toHaveAttribute(
+      'href',
+      '/storageclasses/fast-ssd'
+    )
+    expect(screen.getByRole('link', { name: 'web-0' })).toHaveAttribute(
+      'href',
+      '/pods/default/web-0'
+    )
+    expect(mockResponsiveTabs.mock.calls[0][0].map((tab: { value: string }) => tab.value)).toEqual([
+      'overview',
+      'yaml',
+      'Related',
+      'events',
+      'history',
+    ])
+  })
+
+  it('shows pv binding, source type, and reclaim risk', () => {
+    const pv = {
+      metadata: {
+        name: 'pv-data-web-0',
+        creationTimestamp: '2026-05-09T13:52:32.000Z',
+      },
+      spec: {
+        storageClassName: 'fast-ssd',
+        persistentVolumeReclaimPolicy: 'Retain',
+        volumeMode: 'Filesystem',
+        accessModes: ['ReadWriteOnce'],
+        capacity: {
+          storage: '20Gi',
+        },
+        claimRef: {
+          namespace: 'default',
+          name: 'data-web-0',
+        },
+        csi: {
+          driver: 'ebs.csi.aws.com',
+          volumeHandle: 'vol-123',
+        },
+      },
+      status: {
+        phase: 'Released',
+      },
+    } as PersistentVolume
+
+    mockUseResource.mockReturnValue({
+      data: pv,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderPVDetail()
+
+    expect(screen.getByText('storageDetails.pvInformation')).toBeInTheDocument()
+    expect(screen.getByText('Released')).toBeInTheDocument()
+    expect(screen.getByText('Retain')).toBeInTheDocument()
+    expect(screen.getByText('storageDetails.releasedRetainWarning')).toBeInTheDocument()
+    expect(screen.getByText('CSI')).toBeInTheDocument()
+    expect(screen.getByText('ebs.csi.aws.com')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'default/data-web-0' })).toHaveAttribute(
+      'href',
+      '/persistentvolumeclaims/default/data-web-0'
+    )
+  })
+
+  it('shows storage class policy and linked pvcs and pvs', () => {
+    const storageClass = {
+      metadata: {
+        name: 'fast-ssd',
+        annotations: {
+          'storageclass.kubernetes.io/is-default-class': 'true',
+        },
+        creationTimestamp: '2026-05-09T13:52:32.000Z',
+      },
+      provisioner: 'ebs.csi.aws.com',
+      reclaimPolicy: 'Delete',
+      volumeBindingMode: 'WaitForFirstConsumer',
+      allowVolumeExpansion: true,
+      parameters: {
+        type: 'gp3',
+      },
+      mountOptions: ['discard'],
+    } as StorageClass
+    const pvc = {
+      metadata: {
+        name: 'data-web-0',
+        namespace: 'default',
+      },
+      spec: {
+        storageClassName: 'fast-ssd',
+      },
+      status: {
+        phase: 'Bound',
+      },
+    } as PersistentVolumeClaim
+    const pv = {
+      metadata: {
+        name: 'pv-data-web-0',
+      },
+      spec: {
+        storageClassName: 'fast-ssd',
+      },
+      status: {
+        phase: 'Bound',
+      },
+    } as PersistentVolume
+
+    mockUseResource.mockReturnValue({
+      data: storageClass,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseResources.mockImplementation((resource: string) => ({
+      data:
+        resource === 'persistentvolumeclaims'
+          ? [pvc]
+          : resource === 'persistentvolumes'
+            ? [pv]
+            : [],
+      isLoading: false,
+    }))
+
+    renderStorageClassDetail()
+
+    expect(screen.getByText('storageDetails.storageClassInformation')).toBeInTheDocument()
+    expect(screen.getByText('ebs.csi.aws.com')).toBeInTheDocument()
+    expect(screen.getByText('WaitForFirstConsumer')).toBeInTheDocument()
+    expect(screen.getAllByText('common.yes')).toHaveLength(2)
+    expect(screen.getByText('type=gp3')).toBeInTheDocument()
+    expect(screen.getByText('discard')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'default/data-web-0' })).toHaveAttribute(
+      'href',
+      '/persistentvolumeclaims/default/data-web-0'
+    )
+    expect(screen.getByRole('link', { name: 'pv-data-web-0' })).toHaveAttribute(
+      'href',
+      '/persistentvolumes/pv-data-web-0'
+    )
+  })
+})

--- a/ui/src/pages/storageclass-detail.tsx
+++ b/ui/src/pages/storageclass-detail.tsx
@@ -1,0 +1,219 @@
+import type { PersistentVolume, PersistentVolumeClaim } from 'kubernetes-types/core/v1'
+import { StorageClass } from 'kubernetes-types/storage/v1'
+import { Star } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { toast } from 'sonner'
+
+import { useResources } from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import {
+  isDefaultStorageClass,
+  setStorageClassDefault,
+} from '@/components/editors/storage-edit-dialogs'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import {
+  DetailField,
+  EmptyTableRow,
+  KeyValueList,
+  StatusBadge,
+  StorageResourceDetailShell,
+} from './storage-detail-shared'
+
+function StorageClassAssociations({
+  storageClass,
+}: {
+  storageClass: StorageClass
+}) {
+  const { t } = useTranslation()
+  const name = storageClass.metadata?.name || ''
+  const { data: pvcs = [] } = useResources('persistentvolumeclaims')
+  const { data: pvs = [] } = useResources('persistentvolumes')
+  const relatedPVCs = pvcs.filter((pvc) => pvc.spec?.storageClassName === name)
+  const relatedPVs = pvs.filter((pv) => pv.spec?.storageClassName === name)
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold">{t('storageDetails.claims')}</h3>
+        <Table containerClassName="border-b">
+          <TableHeader className="bg-muted">
+            <TableRow>
+              <TableHead>{t('common.name')}</TableHead>
+              <TableHead>{t('common.status')}</TableHead>
+              <TableHead>{t('pvcs.capacity')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {relatedPVCs.length === 0 ? (
+              <EmptyTableRow colSpan={3} />
+            ) : (
+              relatedPVCs.map((pvc: PersistentVolumeClaim) => (
+                <TableRow key={pvc.metadata?.uid || `${pvc.metadata?.namespace}/${pvc.metadata?.name}`}>
+                  <TableCell>
+                    <Link
+                      to={`/persistentvolumeclaims/${pvc.metadata?.namespace}/${pvc.metadata?.name}`}
+                      className="app-link"
+                    >
+                      {pvc.metadata?.namespace}/{pvc.metadata?.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge phase={pvc.status?.phase} />
+                  </TableCell>
+                  <TableCell className="font-mono">
+                    {pvc.status?.capacity?.storage ||
+                      pvc.spec?.resources?.requests?.storage ||
+                      '-'}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold">{t('storageDetails.volumes')}</h3>
+        <Table containerClassName="border-b">
+          <TableHeader className="bg-muted">
+            <TableRow>
+              <TableHead>{t('common.name')}</TableHead>
+              <TableHead>{t('common.status')}</TableHead>
+              <TableHead>{t('pvs.capacity')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {relatedPVs.length === 0 ? (
+              <EmptyTableRow colSpan={3} />
+            ) : (
+              relatedPVs.map((pv: PersistentVolume) => (
+                <TableRow key={pv.metadata?.uid || pv.metadata?.name}>
+                  <TableCell>
+                    <Link to={`/persistentvolumes/${pv.metadata?.name}`} className="app-link">
+                      {pv.metadata?.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge phase={pv.status?.phase} />
+                  </TableCell>
+                  <TableCell className="font-mono">
+                    {pv.spec?.capacity?.storage || '-'}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </section>
+    </div>
+  )
+}
+
+export function StorageClassDetail(props: { name: string }) {
+  const { name } = props
+  const { t } = useTranslation()
+
+  const handleToggleDefault = async (
+    storageClass: StorageClass,
+    refresh: () => Promise<void>
+  ) => {
+    const nextDefault = !isDefaultStorageClass(storageClass)
+    try {
+      await setStorageClassDefault(storageClass, nextDefault)
+      await refresh()
+      toast.success(
+        t(
+          nextDefault
+            ? 'storageEdit.setDefaultSuccess'
+            : 'storageEdit.unsetDefaultSuccess',
+          { name: storageClass.metadata?.name || '' }
+        )
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('common.error'))
+    }
+  }
+
+  return (
+    <StorageResourceDetailShell
+      resourceType="storageclasses"
+      name={name}
+      title="StorageClass"
+      overviewTitle={t('storageDetails.storageClassInformation')}
+      renderHeaderActions={(storageClass, refresh) => (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => handleToggleDefault(storageClass, refresh)}
+        >
+          <Star className="h-4 w-4" />
+          {isDefaultStorageClass(storageClass)
+            ? t('storageEdit.unsetDefaultAction')
+            : t('storageEdit.setDefaultAction')}
+        </Button>
+      )}
+      renderOverview={(storageClass) => (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <DetailField label={t('storageClasses.provisioner')} mono>
+              {storageClass.provisioner || '-'}
+            </DetailField>
+            <DetailField label={t('storageClasses.defaultClass')}>
+              <Badge variant={isDefaultStorageClass(storageClass) ? 'default' : 'outline'}>
+                {isDefaultStorageClass(storageClass) ? t('common.yes') : t('common.no')}
+              </Badge>
+            </DetailField>
+            <DetailField label={t('pvs.reclaimPolicy')}>
+              {storageClass.reclaimPolicy || 'Delete'}
+            </DetailField>
+            <DetailField label={t('storageClasses.volumeBindingMode')}>
+              {storageClass.volumeBindingMode || 'Immediate'}
+            </DetailField>
+            <DetailField label={t('storageClasses.allowExpansion')}>
+              {storageClass.allowVolumeExpansion ? t('common.yes') : t('common.no')}
+            </DetailField>
+            <DetailField label={t('detail.fields.created')}>
+              {formatDate(storageClass.metadata?.creationTimestamp || '')}
+            </DetailField>
+            <DetailField label={t('detail.fields.uid')} mono>
+              {storageClass.metadata?.uid || '-'}
+            </DetailField>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <DetailField label={t('storageClasses.parameters')}>
+              <KeyValueList values={storageClass.parameters} />
+            </DetailField>
+            <DetailField label={t('storageClasses.mountOptions')}>
+              {(storageClass.mountOptions || []).length > 0 ? (
+                <div className="space-y-1">
+                  {storageClass.mountOptions?.map((option) => (
+                    <div key={option} className="font-mono text-sm">
+                      {option}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                '-'
+              )}
+            </DetailField>
+          </div>
+        </div>
+      )}
+      renderAssociations={(storageClass) => (
+        <StorageClassAssociations storageClass={storageClass} />
+      )}
+    />
+  )
+}

--- a/ui/src/pages/storageclass-list-page.test.tsx
+++ b/ui/src/pages/storageclass-list-page.test.tsx
@@ -1,0 +1,287 @@
+import { type ReactNode } from 'react'
+import { createColumnHelper, flexRender } from '@tanstack/react-table'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { StorageClass } from 'kubernetes-types/storage/v1'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StorageClassListPage } from './storageclass-list-page'
+
+const mockNavigate = vi.fn()
+const mockCopyTextToClipboard = vi.fn()
+const mockInvalidateQueries = vi.fn()
+const mockSetStorageClassDefault = vi.fn()
+const mockResourceTable = vi.fn(
+  ({
+    onCreateClick,
+    resourceName,
+    showCreateButton,
+  }: {
+    onCreateClick?: () => void
+    resourceName: string
+    showCreateButton?: boolean
+  }) => (
+    <div>
+      <span>{resourceName}</span>
+      <span>{showCreateButton ? 'create-enabled' : 'create-disabled'}</span>
+      <button onClick={onCreateClick}>open-create</button>
+    </div>
+  )
+)
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: ReactNode; to: string }) => (
+      <a href={to}>{children}</a>
+    ),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query'
+  )
+
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  }
+})
+
+vi.mock('@/lib/desktop', () => ({
+  copyTextToClipboard: (value: string) => mockCopyTextToClipboard(value),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/resource-table', () => ({
+  ResourceTable: (props: { resourceName: string }) => mockResourceTable(props),
+}))
+
+vi.mock('@/components/editors/resource-metadata-dialog', () => ({
+  ResourceMetadataDialog: () => null,
+}))
+
+vi.mock('@/components/editors/storage-create-dialogs', () => ({
+  StorageClassCreateDialog: ({
+    open,
+    onSuccess,
+  }: {
+    open: boolean
+    onSuccess: (storageClass: StorageClass) => void
+  }) =>
+    open ? (
+      <div>
+        <span>storageclass-create-dialog</span>
+        <button
+          onClick={() =>
+            onSuccess({
+              metadata: {
+                name: 'fast-ssd',
+              },
+            } as StorageClass)
+          }
+        >
+          finish-create
+        </button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/editors/storage-edit-dialogs', () => ({
+  isDefaultStorageClass: (storageClass: StorageClass) =>
+    storageClass.metadata?.annotations?.[
+      'storageclass.kubernetes.io/is-default-class'
+    ] === 'true',
+  setStorageClassDefault: (...args: unknown[]) =>
+    mockSetStorageClassDefault(...args),
+}))
+
+describe('StorageClassListPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset()
+    mockCopyTextToClipboard.mockReset()
+    mockInvalidateQueries.mockReset()
+    mockSetStorageClassDefault.mockReset()
+    mockResourceTable.mockClear()
+  })
+
+  it('opens storage class create dialog and navigates to the created resource', async () => {
+    render(<StorageClassListPage />)
+
+    expect(screen.getByText('create-enabled')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'open-create' }))
+    expect(screen.getByText('storageclass-create-dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'finish-create' }))
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['storageclasses'],
+    })
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/storageclasses/fast-ssd')
+    })
+  })
+
+  it('renders storage class operational columns', () => {
+    render(<StorageClassListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      columns: ReturnType<typeof createColumnHelper<StorageClass>>[]
+      clusterScope: boolean
+    }
+
+    expect(resourceTableProps.clusterScope).toBe(true)
+    expect(resourceTableProps.columns.map((column) => column.id)).toEqual([
+      'name',
+      'provisioner',
+      'default-class',
+      'reclaim-policy',
+      'binding-mode',
+      'allow-expansion',
+      'parameters',
+      'mount-options',
+      'created',
+    ])
+
+    const storageClass = {
+      metadata: {
+        name: 'fast-ssd',
+        annotations: {
+          'storageclass.kubernetes.io/is-default-class': 'true',
+        },
+        creationTimestamp: '2026-05-10T13:53:27.000Z',
+      },
+      provisioner: 'ebs.csi.aws.com',
+      reclaimPolicy: 'Delete',
+      volumeBindingMode: 'WaitForFirstConsumer',
+      allowVolumeExpansion: true,
+      parameters: {
+        type: 'gp3',
+        encrypted: 'true',
+      },
+      mountOptions: ['discard'],
+    } as StorageClass
+
+    const row = {
+      original: storageClass,
+    }
+
+    const renderedRow = render(
+      <div>
+        {flexRender(resourceTableProps.columns[1].cell!, {
+          getValue: () => storageClass.provisioner,
+        })}
+        {flexRender(resourceTableProps.columns[2].cell!, { row })}
+        {flexRender(resourceTableProps.columns[4].cell!, {
+          getValue: () => storageClass.volumeBindingMode,
+        })}
+        {flexRender(resourceTableProps.columns[5].cell!, {
+          getValue: () => storageClass.allowVolumeExpansion,
+        })}
+        {flexRender(resourceTableProps.columns[6].cell!, { row })}
+        {flexRender(resourceTableProps.columns[7].cell!, { row })}
+      </div>
+    )
+
+    expect(renderedRow.container).toHaveTextContent('ebs.csi.aws.com')
+    expect(renderedRow.container).toHaveTextContent('common.yes')
+    expect(renderedRow.container).toHaveTextContent('WaitForFirstConsumer')
+    expect(screen.getByRole('button', { name: 'storageClasses.viewParameters' })).toHaveTextContent('2')
+    expect(screen.getByRole('button', { name: 'storageClasses.viewMountOptions' })).toHaveTextContent('1')
+  })
+
+  it('searches storage classes by provisioner, policy, mode, and parameters', () => {
+    render(<StorageClassListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      searchQueryFilter: (storageClass: StorageClass, query: string) => boolean
+    }
+
+    const storageClass = {
+      metadata: {
+        name: 'fast-ssd',
+      },
+      provisioner: 'ebs.csi.aws.com',
+      reclaimPolicy: 'Delete',
+      volumeBindingMode: 'WaitForFirstConsumer',
+      parameters: {
+        type: 'gp3',
+      },
+    } as StorageClass
+
+    expect(resourceTableProps.searchQueryFilter(storageClass, 'ebs')).toBe(true)
+    expect(resourceTableProps.searchQueryFilter(storageClass, 'delete')).toBe(true)
+    expect(resourceTableProps.searchQueryFilter(storageClass, 'consumer')).toBe(true)
+    expect(resourceTableProps.searchQueryFilter(storageClass, 'gp3')).toBe(true)
+    expect(resourceTableProps.searchQueryFilter(storageClass, 'missing')).toBe(false)
+  })
+
+  it('provides unified row actions for storage classes', async () => {
+    render(<StorageClassListPage />)
+
+    const resourceTableProps = mockResourceTable.mock.calls[0]?.[0] as {
+      getRowContextMenuItems: (storageClass: StorageClass) => {
+        key: string
+        onSelect?: () => void | Promise<void>
+      }[]
+    }
+
+    const storageClass = {
+      metadata: {
+        name: 'fast-ssd',
+      },
+      provisioner: 'ebs.csi.aws.com',
+    } as StorageClass
+
+    const items = resourceTableProps.getRowContextMenuItems(storageClass)
+
+    expect(items.map((item) => item.key)).toEqual([
+      'view-yaml',
+      'set-default-storage-class',
+      'primary-actions-separator',
+      'copy-name',
+      'copy-provisioner',
+      'metadata-actions-separator',
+      'manage-labels',
+      'manage-annotations',
+    ])
+
+    await items[0].onSelect?.()
+    expect(mockNavigate).toHaveBeenCalledWith('/storageclasses/fast-ssd?tab=yaml')
+
+    await items[1].onSelect?.()
+    expect(mockSetStorageClassDefault).toHaveBeenCalledWith(storageClass, true)
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['storageclasses'],
+    })
+
+    await items[3].onSelect?.()
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('fast-ssd')
+
+    await items[4].onSelect?.()
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('ebs.csi.aws.com')
+  })
+})

--- a/ui/src/pages/storageclass-list-page.tsx
+++ b/ui/src/pages/storageclass-list-page.tsx
@@ -1,0 +1,314 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { createColumnHelper } from '@tanstack/react-table'
+import { StorageClass } from 'kubernetes-types/storage/v1'
+import {
+  Copy,
+  Database,
+  FileCode2,
+  FileText,
+  ListChecks,
+  Star,
+  Tags,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link, useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+
+import { copyTextToClipboard } from '@/lib/desktop'
+import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
+import { ResourceMetadataDialog } from '@/components/editors/resource-metadata-dialog'
+import { StorageClassCreateDialog } from '@/components/editors/storage-create-dialogs'
+import {
+  isDefaultStorageClass,
+  setStorageClassDefault,
+} from '@/components/editors/storage-edit-dialogs'
+import {
+  MetadataSummaryButton,
+  renderMetadataTooltipContent,
+} from '@/components/metadata-action-button'
+import { Badge } from '@/components/ui/badge'
+import { ResourceTable } from '@/components/resource-table'
+import { RowContextMenuItem } from '@/components/row-context-menu'
+
+const storageClassColumnHelper = createColumnHelper<StorageClass>()
+
+function formatTimestampWithRelative(timestamp?: string) {
+  if (!timestamp) {
+    return '-'
+  }
+
+  return `${formatDate(timestamp)} (${formatRelativeTimeStrict(timestamp)})`
+}
+
+function includesRecordText(
+  values: Record<string, string> | undefined,
+  query: string
+) {
+  return Object.entries(values || {}).some(
+    ([key, value]) =>
+      key.toLowerCase().includes(query) ||
+      value.toLowerCase().includes(query)
+  )
+}
+
+export function StorageClassListPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [labelsStorageClass, setLabelsStorageClass] =
+    useState<StorageClass | null>(null)
+  const [annotationsStorageClass, setAnnotationsStorageClass] =
+    useState<StorageClass | null>(null)
+
+  const columns = useMemo(
+    () => [
+      storageClassColumnHelper.accessor((row) => row.metadata?.name, {
+        id: 'name',
+        header: t('common.name'),
+        cell: ({ row }) => (
+          <div className="font-medium app-link">
+            <Link to={`/storageclasses/${row.original.metadata!.name}`}>
+              {row.original.metadata!.name}
+            </Link>
+          </div>
+        ),
+      }),
+      storageClassColumnHelper.accessor('provisioner', {
+        id: 'provisioner',
+        header: t('storageClasses.provisioner'),
+        cell: ({ getValue }) => (
+          <span className="font-mono text-sm text-muted-foreground">
+            {getValue() || '-'}
+          </span>
+        ),
+      }),
+      storageClassColumnHelper.display({
+        id: 'default-class',
+        header: t('storageClasses.defaultClass'),
+        cell: ({ row }) => (
+          <Badge variant={isDefaultStorageClass(row.original) ? 'default' : 'outline'}>
+            {isDefaultStorageClass(row.original) ? t('common.yes') : t('common.no')}
+          </Badge>
+        ),
+      }),
+      storageClassColumnHelper.accessor('reclaimPolicy', {
+        id: 'reclaim-policy',
+        header: t('pvs.reclaimPolicy'),
+        enableColumnFilter: true,
+        cell: ({ getValue }) => getValue() || 'Delete',
+      }),
+      storageClassColumnHelper.accessor('volumeBindingMode', {
+        id: 'binding-mode',
+        header: t('storageClasses.volumeBindingMode'),
+        enableColumnFilter: true,
+        cell: ({ getValue }) => getValue() || 'Immediate',
+      }),
+      storageClassColumnHelper.accessor('allowVolumeExpansion', {
+        id: 'allow-expansion',
+        header: t('storageClasses.allowExpansion'),
+        cell: ({ getValue }) => (
+          <Badge variant={getValue() ? 'default' : 'outline'}>
+            {getValue() ? t('common.yes') : t('common.no')}
+          </Badge>
+        ),
+      }),
+      storageClassColumnHelper.display({
+        id: 'parameters',
+        header: t('storageClasses.parameters'),
+        meta: { align: 'left' },
+        cell: ({ row }) => (
+          <MetadataSummaryButton
+            ariaLabel={t('storageClasses.viewParameters')}
+            count={Object.keys(row.original.parameters || {}).length}
+            tooltipContent={renderMetadataTooltipContent(row.original.parameters)}
+          >
+            <ListChecks className="h-4 w-4" />
+          </MetadataSummaryButton>
+        ),
+      }),
+      storageClassColumnHelper.display({
+        id: 'mount-options',
+        header: t('storageClasses.mountOptions'),
+        meta: { align: 'left' },
+        cell: ({ row }) => {
+          const options = row.original.mountOptions || []
+          return (
+            <MetadataSummaryButton
+              ariaLabel={t('storageClasses.viewMountOptions')}
+              count={options.length}
+              tooltipContent={options.length ? options.join(', ') : '-'}
+            >
+              <Database className="h-4 w-4" />
+            </MetadataSummaryButton>
+          )
+        },
+      }),
+      storageClassColumnHelper.accessor('metadata.creationTimestamp', {
+        id: 'created',
+        header: t('common.created'),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground text-sm">
+            {formatTimestampWithRelative(getValue())}
+          </span>
+        ),
+      }),
+    ],
+    [t]
+  )
+
+  const storageClassSearchFilter = useCallback(
+    (storageClass: StorageClass, query: string) => {
+      const normalizedQuery = query.toLowerCase()
+      return (
+        storageClass.metadata!.name!.toLowerCase().includes(normalizedQuery) ||
+        storageClass.provisioner.toLowerCase().includes(normalizedQuery) ||
+        (storageClass.reclaimPolicy || 'Delete')
+          .toLowerCase()
+          .includes(normalizedQuery) ||
+        (storageClass.volumeBindingMode || 'Immediate')
+          .toLowerCase()
+          .includes(normalizedQuery) ||
+        includesRecordText(storageClass.parameters, normalizedQuery)
+      )
+    },
+    []
+  )
+
+  const handleCopy = useCallback(
+    async (value: string) => {
+      await copyTextToClipboard(value)
+      toast.success(t('keyValueDataViewer.copiedToClipboard'))
+    },
+    [t]
+  )
+
+  const handleToggleDefault = useCallback(
+    async (storageClass: StorageClass) => {
+      const nextDefault = !isDefaultStorageClass(storageClass)
+      try {
+        await setStorageClassDefault(storageClass, nextDefault)
+        await queryClient.invalidateQueries({ queryKey: ['storageclasses'] })
+        toast.success(
+          t(
+            nextDefault
+              ? 'storageEdit.setDefaultSuccess'
+              : 'storageEdit.unsetDefaultSuccess',
+            { name: storageClass.metadata?.name || '' }
+          )
+        )
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : t('common.error', 'Error')
+        )
+      }
+    },
+    [queryClient, t]
+  )
+
+  const getRowContextMenuItems = useCallback(
+    (storageClass: StorageClass): RowContextMenuItem<StorageClass>[] => [
+      {
+        key: 'view-yaml',
+        label: t('common.viewYaml', 'View YAML'),
+        icon: <FileCode2 className="h-4 w-4" />,
+        onSelect: () =>
+          navigate(`/storageclasses/${storageClass.metadata?.name}?tab=yaml`),
+      },
+      {
+        key: isDefaultStorageClass(storageClass)
+          ? 'unset-default-storage-class'
+          : 'set-default-storage-class',
+        label: isDefaultStorageClass(storageClass)
+          ? t('storageEdit.unsetDefaultAction')
+          : t('storageEdit.setDefaultAction'),
+        icon: <Star className="h-4 w-4" />,
+        onSelect: () => handleToggleDefault(storageClass),
+      },
+      { type: 'separator', key: 'primary-actions-separator' },
+      {
+        key: 'copy-name',
+        label: t('common.copyName', 'Copy name'),
+        icon: <Copy className="h-4 w-4" />,
+        onSelect: () => handleCopy(storageClass.metadata?.name || ''),
+      },
+      {
+        key: 'copy-provisioner',
+        label: t('storageClasses.copyProvisioner'),
+        icon: <Copy className="h-4 w-4" />,
+        onSelect: () => handleCopy(storageClass.provisioner || ''),
+      },
+      { type: 'separator', key: 'metadata-actions-separator' },
+      {
+        key: 'manage-labels',
+        label: t('common.manageLabels', 'Manage labels'),
+        icon: <Tags className="h-4 w-4" />,
+        onSelect: () => setLabelsStorageClass(storageClass),
+      },
+      {
+        key: 'manage-annotations',
+        label: t('common.manageAnnotations', 'Manage annotations'),
+        icon: <FileText className="h-4 w-4" />,
+        onSelect: () => setAnnotationsStorageClass(storageClass),
+      },
+    ],
+    [handleCopy, handleToggleDefault, navigate, t]
+  )
+
+  const handleCreateSuccess = useCallback(
+    async (storageClass: StorageClass) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['storageclasses'],
+      })
+      navigate(`/storageclasses/${storageClass.metadata?.name || ''}`)
+    },
+    [navigate, queryClient]
+  )
+
+  return (
+    <>
+      <ResourceTable
+        resourceName="storageclasses"
+        columns={columns}
+        clusterScope={true}
+        searchQueryFilter={storageClassSearchFilter}
+        showCreateButton={true}
+        onCreateClick={() => setIsCreateDialogOpen(true)}
+        getRowContextMenuItems={getRowContextMenuItems}
+      />
+
+      <StorageClassCreateDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        onSuccess={handleCreateSuccess}
+      />
+
+      <ResourceMetadataDialog
+        open={Boolean(labelsStorageClass)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setLabelsStorageClass(null)
+          }
+        }}
+        resourceType="storageclasses"
+        resource={labelsStorageClass}
+        type="labels"
+      />
+
+      <ResourceMetadataDialog
+        open={Boolean(annotationsStorageClass)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAnnotationsStorageClass(null)
+          }
+        }}
+        resourceType="storageclasses"
+        resource={annotationsStorageClass}
+        type="annotations"
+      />
+    </>
+  )
+}


### PR DESCRIPTION
- 新增 StorageClassDetail 组件，用于展示存储类的详细信息，包括 PVC 和 PV 的关联。
- 新增 StorageClassListPage 组件，提供存储类列表及创建功能。
- 添加相关的测试用例，确保组件功能正常。

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added storage resource creation dialogs for PersistentVolumes, PersistentVolumeClaims, and StorageClasses with predefined templates.
  * Added dedicated detail pages and list views for storage resources with management actions.
  * Added ability to resize PVCs, modify PV reclaim policies, and set default StorageClasses.

* **Internationalization**
  * Added storage management translations for English and Chinese locales.

* **Tests**
  * Added comprehensive test coverage for storage creation, editing, and detail components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->