### PR TITLE
feat(environment-editor): 添加受控编辑器以支持环境变量的动态更新和测试用例

### DIFF
--- a/ui/src/components/editors/environment-editor.test.tsx
+++ b/ui/src/components/editors/environment-editor.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { Container } from 'kubernetes-types/core/v1'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { EnvironmentEditor } from './environment-editor'
@@ -52,6 +53,30 @@ vi.mock('../selector/secret-selector', () => ({
 }))
 
 describe('EnvironmentEditor', () => {
+  function ControlledEditor({
+    initialContainer,
+    onUpdate,
+  }: {
+    initialContainer: Container
+    onUpdate: (updates: Partial<Container>) => void
+  }) {
+    const [container, setContainer] = useState(initialContainer)
+
+    return (
+      <EnvironmentEditor
+        container={container}
+        namespace="default"
+        onUpdate={(updates) => {
+          onUpdate(updates)
+          setContainer((currentContainer) => ({
+            ...currentContainer,
+            ...updates,
+          }))
+        }}
+      />
+    )
+  }
+
   it('adds new environment variables at the top', () => {
     const onUpdate = vi.fn()
     const container = {
@@ -84,6 +109,39 @@ describe('EnvironmentEditor', () => {
     })
   })
 
+  it('keeps pending environment variable rows after editing one row', () => {
+    const onUpdate = vi.fn()
+
+    render(
+      <ControlledEditor
+        initialContainer={{ name: 'app' } as Container}
+        onUpdate={onUpdate}
+      />
+    )
+
+    const addButton = screen.getByRole('button', {
+      name: /environmentEditor.addVariable/,
+    })
+    fireEvent.click(addButton)
+    fireEvent.click(addButton)
+    fireEvent.click(addButton)
+
+    let nameInputs = screen.getAllByPlaceholderText(
+      'environmentEditor.variableNamePlaceholder'
+    )
+    expect(nameInputs).toHaveLength(3)
+
+    fireEvent.change(nameInputs[0], { target: { value: 'FIRST_ENV' } })
+
+    nameInputs = screen.getAllByPlaceholderText(
+      'environmentEditor.variableNamePlaceholder'
+    )
+    expect(nameInputs).toHaveLength(3)
+    expect(nameInputs[0]).toHaveValue('FIRST_ENV')
+    expect(nameInputs[1]).toHaveValue('')
+    expect(nameInputs[2]).toHaveValue('')
+  })
+
   it('adds new environment sources at the top', () => {
     const onUpdate = vi.fn()
     const container = {
@@ -108,7 +166,10 @@ describe('EnvironmentEditor', () => {
     )
     expect(sourceInputs[0]).toHaveValue('')
     expect(onUpdate).toHaveBeenLastCalledWith({
-      envFrom: [{ secretRef: { name: 'existing-secret' } }],
+      envFrom: [
+        { configMapRef: { name: '' } },
+        { secretRef: { name: 'existing-secret' } },
+      ],
     })
   })
 })

--- a/ui/src/components/editors/environment-editor.tsx
+++ b/ui/src/components/editors/environment-editor.tsx
@@ -28,12 +28,6 @@ interface EnvironmentEditorProps {
   onUpdate: (updates: Partial<Container>) => void
 }
 
-function hasEnvFromSourceValue(source: EnvFromSource) {
-  return Boolean(
-    source.configMapRef?.name?.trim() || source.secretRef?.name?.trim()
-  )
-}
-
 export function EnvironmentEditor({
   container,
   namespace,
@@ -53,19 +47,13 @@ export function EnvironmentEditor({
   const addEnvVar = () => {
     const newEnvVars = [{ name: '', value: '' }, ...envVars]
     setEnvVars(newEnvVars)
-    // Don't filter out empty names immediately, let user fill them in
     onUpdate({ env: newEnvVars })
   }
 
   const removeEnvVar = (index: number) => {
     const newEnvVars = envVars.filter((_, i) => i !== index)
     setEnvVars(newEnvVars)
-    onUpdate({
-      env: newEnvVars.filter(
-        (env) =>
-          env.name.trim() !== '' || env.value?.trim() !== '' || env.valueFrom
-      ),
-    })
+    onUpdate({ env: newEnvVars })
   }
 
   const updateEnvVar = (
@@ -77,13 +65,7 @@ export function EnvironmentEditor({
       i === index ? { ...env, [field]: value } : env
     )
     setEnvVars(newEnvVars)
-    // Only filter out completely empty entries (both name and value empty)
-    onUpdate({
-      env: newEnvVars.filter(
-        (env) =>
-          env.name.trim() !== '' || env.value?.trim() !== '' || env.valueFrom
-      ),
-    })
+    onUpdate({ env: newEnvVars })
   }
 
   const updateEnvVarType = (index: number, type: 'value' | 'valueFrom') => {
@@ -110,12 +92,7 @@ export function EnvironmentEditor({
       return env
     })
     setEnvVars(newEnvVars)
-    onUpdate({
-      env: newEnvVars.filter(
-        (env) =>
-          env.name.trim() !== '' || env.value?.trim() !== '' || env.valueFrom
-      ),
-    })
+    onUpdate({ env: newEnvVars })
   }
 
   const updateValueFrom = (
@@ -171,12 +148,7 @@ export function EnvironmentEditor({
       return env
     })
     setEnvVars(newEnvVars)
-    onUpdate({
-      env: newEnvVars.filter(
-        (env) =>
-          env.name.trim() !== '' || env.value?.trim() !== '' || env.valueFrom
-      ),
-    })
+    onUpdate({ env: newEnvVars })
   }
 
   const updateValueFromType = (
@@ -202,12 +174,7 @@ export function EnvironmentEditor({
       return env
     })
     setEnvVars(newEnvVars)
-    onUpdate({
-      env: newEnvVars.filter(
-        (env) =>
-          env.name.trim() !== '' || env.value?.trim() !== '' || env.valueFrom
-      ),
-    })
+    onUpdate({ env: newEnvVars })
   }
 
   // EnvFrom management functions
@@ -217,17 +184,13 @@ export function EnvironmentEditor({
       ...envFromSources,
     ]
     setEnvFromSources(newEnvFromSources)
-    onUpdate({
-      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
-    })
+    onUpdate({ envFrom: newEnvFromSources })
   }
 
   const removeEnvFromSource = (index: number) => {
     const newEnvFromSources = envFromSources.filter((_, i) => i !== index)
     setEnvFromSources(newEnvFromSources)
-    onUpdate({
-      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
-    })
+    onUpdate({ envFrom: newEnvFromSources })
   }
 
   const updateEnvFromSource = (
@@ -268,9 +231,7 @@ export function EnvironmentEditor({
       return source
     })
     setEnvFromSources(newEnvFromSources)
-    onUpdate({
-      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
-    })
+    onUpdate({ envFrom: newEnvFromSources })
   }
 
   const updateEnvFromSourceType = (
@@ -288,9 +249,7 @@ export function EnvironmentEditor({
       return source
     })
     setEnvFromSources(newEnvFromSources)
-    onUpdate({
-      envFrom: newEnvFromSources.filter(hasEnvFromSourceValue),
-    })
+    onUpdate({ envFrom: newEnvFromSources })
   }
 
   return (

--- a/ui/src/components/yaml-editor.test.tsx
+++ b/ui/src/components/yaml-editor.test.tsx
@@ -1,12 +1,15 @@
 import '@/i18n'
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { YamlEditor } from './yaml-editor'
 
 const originalYaml =
   'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n'
+const modifiedYaml =
+  'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n'
 
 vi.mock('@/lib/monaco-loader', () => ({
   MonacoEditor: ({
@@ -40,6 +43,31 @@ vi.mock('@/lib/monaco-loader', () => ({
 }))
 
 describe('YamlEditor', () => {
+  function ControlledYamlTab({
+    initialValue = originalYaml,
+    onSave,
+  }: {
+    initialValue?: string
+    onSave?: Parameters<typeof YamlEditor<'configmaps'>>[0]['onSave']
+  }) {
+    const [value, setValue] = useState(initialValue)
+    const [showYamlTab, setShowYamlTab] = useState(true)
+
+    return (
+      <div>
+        <button onClick={() => setShowYamlTab(false)}>overview</button>
+        <button onClick={() => setShowYamlTab(true)}>yaml</button>
+        {showYamlTab ? (
+          <YamlEditor<'configmaps'>
+            value={value}
+            onChange={setValue}
+            onSave={onSave}
+          />
+        ) : null}
+      </div>
+    )
+  }
+
   it('opens in view mode and switches to edit mode from the edit button', () => {
     render(<YamlEditor<'configmaps'> value={originalYaml} />)
 
@@ -78,8 +106,6 @@ describe('YamlEditor', () => {
 
   it('shows a diff before saving changed YAML and saves after confirmation', async () => {
     const handleSave = vi.fn().mockResolvedValue(undefined)
-    const modifiedYaml =
-      'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n'
 
     render(
       <YamlEditor<'configmaps'> value={originalYaml} onSave={handleSave} />
@@ -120,9 +146,7 @@ describe('YamlEditor', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /edit/i }))
     fireEvent.change(screen.getByLabelText('yaml-editor'), {
-      target: {
-        value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n',
-      },
+      target: { value: modifiedYaml },
     })
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
     fireEvent.click(screen.getByRole('button', { name: /continue editing/i }))
@@ -141,9 +165,7 @@ describe('YamlEditor', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /edit/i }))
     fireEvent.change(screen.getByLabelText('yaml-editor'), {
-      target: {
-        value: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: changed\n',
-      },
+      target: { value: modifiedYaml },
     })
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
     fireEvent.click(screen.getByRole('button', { name: /confirm save/i }))
@@ -153,6 +175,30 @@ describe('YamlEditor', () => {
     })
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByLabelText('yaml-editor')).not.toHaveAttribute('readonly')
+  })
+
+  it('does not restore a failed save draft after the YAML tab remounts', async () => {
+    const handleSave = vi.fn().mockResolvedValue(false)
+
+    render(<ControlledYamlTab onSave={handleSave} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('yaml-editor'), {
+      target: { value: modifiedYaml },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm save/i }))
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /continue editing/i }))
+    fireEvent.click(screen.getByRole('button', { name: /overview/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^yaml$/i }))
+
+    expect(screen.getByLabelText('yaml-editor')).toHaveValue(originalYaml)
+    expect(screen.getByLabelText('yaml-editor')).toHaveAttribute('readonly')
   })
 
   it('exits edit mode without opening diff when YAML is unchanged', () => {

--- a/ui/src/components/yaml-editor.tsx
+++ b/ui/src/components/yaml-editor.tsx
@@ -27,7 +27,7 @@ interface YamlEditorProps<T extends ResourceType> {
   title?: string
   /** Minimum height of the editor */
   minHeight?: number
-  /** Callback when YAML content changes */
+  /** Callback when committed YAML content changes or edits are canceled */
   onChange?: (value: string) => void
   /** Callback when save is confirmed. Return false to keep editing after a handled failure. */
   onSave?: (
@@ -115,7 +115,6 @@ export function YamlEditor<T extends ResourceType>({
   const handleEditorChange = (value: string | undefined) => {
     const newValue = value || ''
     setEditorValue(newValue)
-    onChange?.(newValue)
   }
 
   const handleEdit = () => {
@@ -143,6 +142,7 @@ export function YamlEditor<T extends ResourceType>({
         return
       }
       editStartValueRef.current = editorValue
+      onChange?.(editorValue)
       setIsDiffOpen(false)
       if (!readOnly) {
         setIsEditing(false)


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable editor now correctly retains previously added rows when editing individual entries
  * YAML editor improved draft handling when save operations fail
  * YAML editor change detection optimized to occur only after successful saves

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->