### PR TITLE
feat(log): 使用 StreamingClientSet 处理长时间运行的日志流并添加重试机制

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -40,10 +40,11 @@ func init() {
 // K8sClient holds the Kubernetes client instances
 type K8sClient struct {
 	client.Client
-	ClientSet     kubernetes.Interface
-	Configuration *rest.Config
-	MetricsClient *metricsclient.Clientset
-	CacheEnabled  bool // true when using controller-runtime informer cache
+	ClientSet          kubernetes.Interface
+	StreamingClientSet kubernetes.Interface // For long-running streaming requests (e.g., log follow) without HTTP timeout
+	Configuration      *rest.Config
+	MetricsClient      *metricsclient.Clientset
+	CacheEnabled       bool // true when using controller-runtime informer cache
 
 	cancel context.CancelFunc
 }
@@ -55,6 +56,14 @@ func NewClient(config *rest.Config) (*K8sClient, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
+	}
+
+	// Create a streaming clientset without HTTP timeout for long-running requests like log streaming
+	streamingConfig := rest.CopyConfig(config)
+	streamingConfig.Timeout = 0
+	streamingClientset, err := kubernetes.NewForConfig(streamingConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create streaming clientset: %w", err)
 	}
 
 	metricsClient, err := metricsclient.NewForConfig(config)
@@ -121,12 +130,13 @@ func NewClient(config *rest.Config) (*K8sClient, error) {
 	}
 
 	return &K8sClient{
-		Client:        c,
-		ClientSet:     clientset,
-		Configuration: config,
-		MetricsClient: metricsClient,
-		CacheEnabled:  cacheEnabled,
-		cancel:        cancel,
+		Client:             c,
+		ClientSet:          clientset,
+		StreamingClientSet: streamingClientset,
+		Configuration:      config,
+		MetricsClient:      metricsClient,
+		CacheEnabled:       cacheEnabled,
+		cancel:             cancel,
 	}, nil
 }
 

--- a/pkg/kube/log.go
+++ b/pkg/kube/log.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"golang.org/x/net/websocket"
 	corev1 "k8s.io/api/core/v1"
@@ -64,16 +65,6 @@ func (l *BatchLogHandler) startPodLogStream(podStream *PodLogStream) {
 		close(podStream.Done)
 	}()
 
-	req := l.k8sClient.ClientSet.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, l.opts)
-	podLogs, err := req.Stream(podCtx)
-	if err != nil {
-		_ = sendErrorMessage(l.conn, fmt.Sprintf("Failed to get pod logs for %s: %v", pod.Name, err))
-		return
-	}
-	defer func() {
-		_ = podLogs.Close()
-	}()
-
 	lw := writerFunc(func(p []byte) (int, error) {
 		logString := string(p)
 		logLines := strings.SplitSeq(logString, "\n")
@@ -93,12 +84,57 @@ func (l *BatchLogHandler) startPodLogStream(podStream *PodLogStream) {
 		return len(p), nil
 	})
 
-	_, err = io.Copy(lw, podLogs)
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
-		_ = sendErrorMessage(l.conn, fmt.Sprintf("Failed to stream pod logs for %s: %v", pod.Name, err))
-	}
+	// Use StreamingClientSet (no HTTP timeout) to avoid killing long-running log streams.
+	// Retry on transient errors (e.g., network hiccups) with a brief delay.
+	isFirstAttempt := true
+	for {
+		select {
+		case <-podCtx.Done():
+			return
+		default:
+		}
 
-	_ = sendMessage(l.conn, "close", fmt.Sprintf("{\"status\":\"closed\",\"pod\":\"%s\"}", pod.Name))
+		// On retry, use TailLines=0 to avoid re-sending old log lines
+		opts := l.opts
+		if !isFirstAttempt {
+			retryOpts := *l.opts
+			var zero int64
+			retryOpts.TailLines = &zero
+			opts = &retryOpts
+		}
+
+		req := l.k8sClient.StreamingClientSet.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts)
+		podLogs, err := req.Stream(podCtx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			_ = sendErrorMessage(l.conn, fmt.Sprintf("Failed to get pod logs for %s: %v", pod.Name, err))
+			select {
+			case <-podCtx.Done():
+				return
+			case <-time.After(3 * time.Second):
+			}
+			isFirstAttempt = false
+			continue
+		}
+
+		_, err = io.Copy(lw, podLogs)
+		_ = podLogs.Close()
+
+		if err == nil || errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+			return
+		}
+
+		klog.Warningf("Log stream for %s interrupted: %v, will retry", pod.Name, err)
+		isFirstAttempt = false
+
+		select {
+		case <-podCtx.Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 func (l *BatchLogHandler) heartbeat(ctx context.Context) {


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #100

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pod log streaming now automatically retries on transient failures, improving reliability and reducing interruptions from temporary network issues.
  * Enhanced error handling for long-running streaming operations provides more stable log viewing experiences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->