### PR TITLE
feat: enhance terminal functionality and UI integration

### DIFF
--- a/docs/plans/2026-05-22-terminal-workspace-design.md
+++ b/docs/plans/2026-05-22-terminal-workspace-design.md
@@ -1,0 +1,53 @@
+# Terminal Workspace Design
+
+## Background
+
+Resource terminals used to live inside detail-page tabs. When users switched
+tabs or navigated away, React unmounted the terminal component, closing xterm
+and its WebSocket. Because the Go terminal stream is directly bound to that
+WebSocket, the Kubernetes exec or attach session ended as well.
+
+This behavior made terminals fragile during normal debugging workflows.
+
+## Decision
+
+Kite Desktop now treats terminals as a global workspace instead of detail-page
+content. Pod, workload, node, and kubectl entry points open sessions in a
+bottom panel that is mounted above the main app content.
+
+The workspace supports:
+
+- multiple concurrent terminal sessions
+- active-session switching
+- bottom panel resize
+- minimize without destroying sessions
+- fullscreen mode
+- explicit per-session close
+- explicit close-all behavior
+
+## Current Scope
+
+This implementation keeps session lifetime on the frontend. A session remains
+alive while its `Terminal` pane remains mounted inside the global workspace.
+Inactive panes are hidden with CSS instead of unmounted.
+
+The backend WebSocket contract is unchanged:
+
+- Pod terminal: `/api/v1/terminal/:namespace/:podName/ws`
+- Node terminal: `/api/v1/node-terminal/:nodeName/ws`
+- kubectl terminal: `/api/v1/kubectl-terminal/ws`
+
+Refreshing the app or losing the WebSocket still ends the underlying shell.
+Recoverable backend sessions are intentionally left for a future backend
+session broker.
+
+## Main Files
+
+- `ui/src/contexts/terminal-context.tsx`
+- `ui/src/components/floating-terminal.tsx`
+- `ui/src/components/terminal-launcher.tsx`
+- `ui/src/components/terminal-content.tsx`
+
+Resource pages should open terminals through `useTerminal().openSession(...)`
+or `TerminalLauncher` rather than embedding `<Terminal />` directly in page
+tabs.

--- a/pkg/handlers/resources/pod_handler.go
+++ b/pkg/handlers/resources/pod_handler.go
@@ -279,6 +279,8 @@ func (h *PodHandler) registerCustomRoutes(group *gin.RouterGroup) {
 	filesGroup.GET("/preview", h.PreviewFile)
 	filesGroup.GET("/download", h.DownloadFile)
 	filesGroup.PUT("/upload", h.UploadFile)
+	filesGroup.PUT("/content", h.UpdateFileContent)
+	filesGroup.DELETE("", h.DeleteFile)
 }
 
 type FileInfo struct {
@@ -496,6 +498,76 @@ func (h *PodHandler) UploadFile(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "file uploaded successfully"})
+}
+
+func (h *PodHandler) UpdateFileContent(c *gin.Context) {
+	namespace := c.Param("namespace")
+	podName := c.Param("name")
+	container := c.Query("container")
+	path := c.Query("path")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	if path == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "path is required"})
+		return
+	}
+	if strings.Contains(path, "->") {
+		path = strings.TrimSpace(strings.SplitN(path, "->", 2)[0])
+	}
+
+	var req struct {
+		Content string `json:"content"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	err := cs.K8sClient.ExecCommand(c.Request.Context(), kube.ExecOptions{
+		Namespace:     namespace,
+		PodName:       podName,
+		ContainerName: container,
+		Command:       []string{"tee", path},
+		Stdin:         strings.NewReader(req.Content),
+		Stdout:        nil,
+		Stderr:        nil,
+		TTY:           false,
+	})
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update file: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "file updated successfully"})
+}
+
+func (h *PodHandler) DeleteFile(c *gin.Context) {
+	namespace := c.Param("namespace")
+	podName := c.Param("name")
+	container := c.Query("container")
+	path := c.Query("path")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	if path == "" || path == "/" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "path is required"})
+		return
+	}
+	if strings.Contains(path, "->") {
+		path = strings.TrimSpace(strings.SplitN(path, "->", 2)[0])
+	}
+
+	_, _, err := cs.K8sClient.ExecCommandBuffered(
+		c.Request.Context(),
+		namespace,
+		podName,
+		container,
+		[]string{"rm", "-rf", "--", path},
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to delete path: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "path deleted successfully"})
 }
 
 func writeSSE(c *gin.Context, event string, payload any) error {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -129,13 +129,13 @@ function AppContent() {
             </div>
           </div>
         </SidebarInset>
+        {isTerminalOpen ? (
+          <Suspense fallback={null}>
+            <FloatingTerminal />
+          </Suspense>
+        ) : null}
       </SidebarProvider>
       <GlobalSearch open={isOpen} mode={mode} onOpenChange={closeSearch} />
-      {isTerminalOpen ? (
-        <Suspense fallback={null}>
-          <FloatingTerminal />
-        </Suspense>
-      ) : null}
       <UpdateDownloadToast />
       <AIChatbox />
       <Toaster />

--- a/ui/src/components/floating-terminal.tsx
+++ b/ui/src/components/floating-terminal.tsx
@@ -1,10 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRuntime } from '@/contexts/runtime-context'
 import { useTerminal } from '@/contexts/terminal-context'
-import { ChevronDown, ChevronUp, Maximize2, Minimize2, X } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronUp,
+  Maximize2,
+  Minimize2,
+  Monitor,
+  Server,
+  SquareTerminal,
+  X,
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { useGeneralSetting } from '@/lib/api'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
@@ -20,8 +30,17 @@ const DEFAULT_HEIGHT_VH = 40
 export function FloatingTerminal() {
   const { t } = useTranslation()
   const { isDesktop } = useRuntime()
-  const { isOpen, isMinimized, closeTerminal, minimizeTerminal, openTerminal } =
-    useTerminal()
+  const {
+    isOpen,
+    isMinimized,
+    sessions,
+    activeSessionId,
+    activateSession,
+    closeSession,
+    closeTerminal,
+    minimizeTerminal,
+    restoreTerminal,
+  } = useTerminal()
   const { data: generalSetting } = useGeneralSetting({
     enabled: isDesktop && isOpen,
   })
@@ -33,6 +52,27 @@ export function FloatingTerminal() {
   const dragging = useRef(false)
   const startY = useRef(0)
   const startH = useRef(0)
+  const [toolbarHostElement, setToolbarHostElement] =
+    useState<HTMLDivElement | null>(null)
+  const activeSession = useMemo(
+    () => sessions.find((session) => session.id === activeSessionId),
+    [activeSessionId, sessions]
+  )
+  const activeSessionDescription = useMemo(() => {
+    if (!activeSession) return ''
+
+    return [
+      activeSession.clusterName,
+      activeSession.namespace,
+      activeSession.containerName,
+    ]
+      .filter(Boolean)
+      .join(' · ')
+  }, [activeSession])
+
+  const setToolbarHostRef = useCallback((node: HTMLDivElement | null) => {
+    setToolbarHostElement(node)
+  }, [])
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -72,27 +112,35 @@ export function FloatingTerminal() {
   const handleMinimize = useCallback(() => {
     setIsFullscreen(false)
     if (isMinimized) {
-      openTerminal()
+      restoreTerminal()
       return
     }
     minimizeTerminal()
-  }, [isMinimized, minimizeTerminal, openTerminal])
+  }, [isMinimized, minimizeTerminal, restoreTerminal])
 
   const handleClose = useCallback(() => {
     setIsFullscreen(false)
     closeTerminal()
   }, [closeTerminal])
+  const activeToolbarPortalElement = isMinimized ? null : toolbarHostElement
 
-  if (!kubectlEnabled) return null
+  if (!kubectlEnabled && sessions.every((session) => session.type === 'kubectl'))
+    return null
   if (!isOpen) return null
+
+  const panelClassName = isFullscreen
+    ? 'fixed inset-0 z-50 flex flex-col bg-background shadow-2xl'
+    : isMinimized
+      ? [
+          'fixed bottom-0 right-0 z-50 flex flex-col border-t bg-background shadow-2xl',
+          'left-0 md:left-[var(--sidebar-width)]',
+          'group-has-[[data-slot=sidebar][data-state=collapsed]]/sidebar-wrapper:md:left-[var(--sidebar-width-icon)]',
+        ].join(' ')
+      : 'fixed bottom-0 left-0 right-0 z-50 flex flex-col border-t bg-background shadow-2xl'
 
   return (
     <div
-      className={
-        isFullscreen
-          ? 'fixed inset-0 z-50 flex flex-col bg-background shadow-2xl'
-          : 'fixed bottom-0 left-0 right-0 z-50 flex flex-col border-t bg-background shadow-2xl'
-      }
+      className={panelClassName}
       style={{
         height: isMinimized ? 40 : isFullscreen ? '100dvh' : height,
       }}
@@ -107,17 +155,36 @@ export function FloatingTerminal() {
         />
       )}
 
-      {/* Header */}
-      <div className="flex h-10 shrink-0 items-center justify-between border-b bg-muted/50 px-3">
+      <div className="flex min-h-10 shrink-0 items-center justify-between gap-3 border-b bg-muted/50 px-3 py-1">
         <button
-          className="flex items-center gap-2 text-sm font-semibold tracking-wide text-foreground hover:opacity-70 transition-opacity"
+          className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-sm font-semibold text-foreground transition-opacity hover:opacity-70"
           onClick={handleMinimize}
         >
-          <span className="h-2.5 w-2.5 rounded-full bg-green-500 shadow-sm" />
-          {t('siteHeader.kubectlTerminal')}
+          <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-green-500 shadow-sm" />
+          <span className="shrink-0 truncate">
+            {t('floatingTerminal.workspace', 'Terminal Workspace')}
+          </span>
+          {activeSession ? (
+            <span className="hidden min-w-0 truncate text-xs font-normal text-muted-foreground md:inline">
+              {activeSession.title}
+              {activeSessionDescription
+                ? ` · ${activeSessionDescription}`
+                : activeSession.subtitle
+                  ? ` · ${activeSession.subtitle}`
+                  : ''}
+            </span>
+          ) : null}
         </button>
 
-        <div className="flex items-center">
+        <div
+          ref={setToolbarHostRef}
+          className={cn(
+            'ml-auto hidden min-w-0 items-center justify-end gap-2 lg:flex',
+            isMinimized && 'lg:hidden'
+          )}
+        />
+
+        <div className="flex shrink-0 items-center">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -179,17 +246,102 @@ export function FloatingTerminal() {
               </Button>
             </TooltipTrigger>
             <TooltipContent side="top">
-              {t('floatingTerminal.closeSession')}
+              {t('floatingTerminal.closeAllSessions', 'Close all sessions')}
             </TooltipContent>
           </Tooltip>
         </div>
       </div>
 
       <div
-        className="flex-1 min-h-0 w-full"
+        className="min-h-0 flex-1 flex-col"
         style={{ display: isMinimized ? 'none' : 'flex' }}
       >
-        <Terminal type="kubectl" embedded />
+        <div className="flex h-9 shrink-0 items-center gap-1 overflow-x-auto border-b bg-background px-2">
+          {sessions.map((session) => {
+            const active = session.id === activeSessionId
+            return (
+              <button
+                key={session.id}
+                type="button"
+                className={cn(
+                  'group flex h-7 min-w-[140px] max-w-[260px] items-center gap-2 rounded-md border px-2 text-left text-xs transition-colors',
+                  active
+                    ? 'border-primary/40 bg-primary/10 text-foreground'
+                    : 'border-transparent bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+                onClick={() => activateSession(session.id)}
+              >
+                {session.type === 'kubectl' ? (
+                  <SquareTerminal className="h-3.5 w-3.5 shrink-0" />
+                ) : session.type === 'node' ? (
+                  <Server className="h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <Monitor className="h-3.5 w-3.5 shrink-0" />
+                )}
+                <span className="min-w-0 flex-1 truncate">
+                  {session.title}
+                </span>
+                <span className="hidden shrink-0 text-[11px] text-muted-foreground xl:inline">
+                  {session.clusterName}
+                </span>
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full bg-green-500"
+                  aria-hidden="true"
+                />
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="rounded p-0.5 opacity-60 hover:bg-background hover:opacity-100"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    closeSession(session.id)
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      closeSession(session.id)
+                    }
+                  }}
+                  aria-label={t('floatingTerminal.closeSession')}
+                >
+                  <X className="h-3 w-3" />
+                </span>
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="relative min-h-0 flex-1">
+          {sessions.map((session) => (
+            <div
+              key={session.id}
+              className={cn(
+                'absolute inset-0 min-h-0',
+                session.id === activeSessionId ? 'block' : 'hidden'
+              )}
+            >
+              <Terminal
+                type={session.type}
+                namespace={session.namespace}
+                podName={session.podName}
+                nodeName={session.nodeName}
+                pods={session.pods}
+                containers={session.containers}
+                initContainers={session.initContainers}
+                initialContainerName={session.containerName}
+                clusterName={session.clusterName}
+                embedded
+                embeddedToolbar
+                toolbarPortalElement={
+                  session.id === activeSessionId
+                    ? activeToolbarPortalElement
+                    : null
+                }
+              />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/ui/src/components/open-node-terminal-button.tsx
+++ b/ui/src/components/open-node-terminal-button.tsx
@@ -1,0 +1,48 @@
+import { TerminalSquare } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useTerminal } from '@/contexts/terminal-context'
+import { Button } from '@/components/ui/button'
+
+interface OpenNodeTerminalButtonProps {
+  nodeName?: string
+  variant?: React.ComponentProps<typeof Button>['variant']
+  size?: React.ComponentProps<typeof Button>['size']
+  label?: string
+  iconOnly?: boolean
+}
+
+export function OpenNodeTerminalButton({
+  nodeName,
+  variant = 'outline',
+  size = 'sm',
+  label,
+  iconOnly = false,
+}: OpenNodeTerminalButtonProps) {
+  const { t } = useTranslation()
+  const { openSession } = useTerminal()
+  const buttonLabel = label ?? t('terminalLauncher.open', 'Open terminal')
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      disabled={!nodeName}
+      title={buttonLabel}
+      aria-label={buttonLabel}
+      onClick={() => {
+        if (!nodeName) return
+        openSession({
+          type: 'node',
+          nodeName,
+          title: nodeName,
+          source: `node/${nodeName}`,
+          entry: 'resource-action',
+        })
+      }}
+    >
+      <TerminalSquare className="h-4 w-4" />
+      {iconOnly ? <span className="sr-only">{buttonLabel}</span> : buttonLabel}
+    </Button>
+  )
+}

--- a/ui/src/components/open-pod-terminal-button.tsx
+++ b/ui/src/components/open-pod-terminal-button.tsx
@@ -1,0 +1,66 @@
+import { TerminalSquare } from 'lucide-react'
+import type { Container, Pod } from 'kubernetes-types/core/v1'
+import { useTranslation } from 'react-i18next'
+
+import { useTerminal } from '@/contexts/terminal-context'
+import { Button } from '@/components/ui/button'
+
+interface OpenPodTerminalButtonProps {
+  namespace?: string
+  pod?: Pod
+  pods?: Pod[]
+  containers?: Container[]
+  initContainers?: Container[]
+  source?: string
+  variant?: React.ComponentProps<typeof Button>['variant']
+  size?: React.ComponentProps<typeof Button>['size']
+  label?: string
+  iconOnly?: boolean
+}
+
+export function OpenPodTerminalButton({
+  namespace,
+  pod,
+  pods,
+  containers,
+  initContainers,
+  source,
+  variant = 'outline',
+  size = 'sm',
+  label,
+  iconOnly = false,
+}: OpenPodTerminalButtonProps) {
+  const { t } = useTranslation()
+  const { openSession } = useTerminal()
+  const targetPod = pod ?? pods?.find((item) => Boolean(item.metadata?.name))
+  const podName = targetPod?.metadata?.name
+  const podNamespace = targetPod?.metadata?.namespace ?? namespace
+  const buttonLabel = label ?? t('terminalLauncher.open', 'Open terminal')
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      disabled={!podName || !podNamespace}
+      title={buttonLabel}
+      aria-label={buttonLabel}
+      onClick={() => {
+        if (!podName || !podNamespace) return
+        openSession({
+          type: 'pod',
+          namespace: podNamespace,
+          podName,
+          containers: containers ?? targetPod?.spec?.containers,
+          initContainers: initContainers ?? targetPod?.spec?.initContainers,
+          source,
+          title: source ? `${source} · ${podName}` : podName,
+          subtitle: podNamespace,
+          entry: 'resource-action',
+        })
+      }}
+    >
+      <TerminalSquare className="h-4 w-4" />
+      {iconOnly ? <span className="sr-only">{buttonLabel}</span> : buttonLabel}
+    </Button>
+  )
+}

--- a/ui/src/components/pod-file-browser.tsx
+++ b/ui/src/components/pod-file-browser.tsx
@@ -92,7 +92,10 @@ export function PodFileBrowser({
   const handleDownload = (fileName: string) => {
     const filePath =
       currentPath === '/' ? `/${fileName}` : `${currentPath}/${fileName}`
-    podDownloadFile(namespace, podName, selectedContainer, filePath)
+    const file = files?.find((item) => item.name === fileName)
+    podDownloadFile(namespace, podName, selectedContainer, filePath, {
+      isDirectory: file?.isDir,
+    })
   }
 
   const handlePreview = (fileName: string) => {

--- a/ui/src/components/pod-table.tsx
+++ b/ui/src/components/pod-table.tsx
@@ -31,6 +31,7 @@ import {
 import { DeleteConfirmationDialog } from './delete-confirmation-dialog'
 import { DescribeDialog } from './describe-dialog'
 import { MetricCell } from './metrics-cell'
+import { OpenPodTerminalButton } from './open-pod-terminal-button'
 import { PodStatusIcon } from './pod-status-icon'
 import { ResourceTableView } from './resource-table-view'
 import { Badge } from './ui/badge'
@@ -215,6 +216,11 @@ export function PodTable(props: {
                 resourceType="pods"
                 namespace={namespace}
                 name={podName}
+              />
+              <OpenPodTerminalButton
+                pod={pod}
+                source={`pod/${podName}`}
+                iconOnly
               />
               <Button
                 variant="destructive"

--- a/ui/src/components/pod-terminal-file-tree.test.tsx
+++ b/ui/src/components/pod-terminal-file-tree.test.tsx
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 import { PodTerminalFileTree } from './pod-terminal-file-tree'
 
 const mockUsePodFiles = vi.fn()
+const mockCopyTextToClipboard = vi.fn()
+const mockPodDownloadFile = vi.fn()
+const mockPodReadFileContent = vi.fn()
+const mockPodUpdateFileContent = vi.fn()
+const mockPodUploadFile = vi.fn()
+const mockPodDeleteFile = vi.fn()
+const mockPodListFiles = vi.fn()
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>()
@@ -19,10 +26,28 @@ vi.mock('react-i18next', async (importOriginal) => {
 
 vi.mock('@/lib/api', () => ({
   usePodFiles: (...args: unknown[]) => mockUsePodFiles(...args),
+  podListFiles: (...args: unknown[]) => mockPodListFiles(...args),
+  podDownloadFile: (...args: unknown[]) => mockPodDownloadFile(...args),
+  podReadFileContent: (...args: unknown[]) => mockPodReadFileContent(...args),
+  podUpdateFileContent: (...args: unknown[]) =>
+    mockPodUpdateFileContent(...args),
+  podUploadFile: (...args: unknown[]) => mockPodUploadFile(...args),
+  podDeleteFile: (...args: unknown[]) => mockPodDeleteFile(...args),
+}))
+
+vi.mock('@/lib/desktop', () => ({
+  copyTextToClipboard: (...args: unknown[]) => mockCopyTextToClipboard(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }))
 
 describe('PodTerminalFileTree', () => {
-  it('lists pod directories and navigates into a directory', () => {
+  it('lists pod directories and lazily expands a directory', () => {
     mockUsePodFiles.mockReturnValue({
       data: [
         { name: 'app', isDir: true, size: '-', modTime: '', mode: '', uid: '', gid: '' },
@@ -32,6 +57,17 @@ describe('PodTerminalFileTree', () => {
       error: null,
       refetch: vi.fn(),
     })
+    mockPodListFiles.mockResolvedValue([
+      {
+        name: 'config.yaml',
+        isDir: false,
+        size: '42',
+        modTime: '',
+        mode: '',
+        uid: '',
+        gid: '',
+      },
+    ])
 
     render(
       <PodTerminalFileTree
@@ -53,14 +89,14 @@ describe('PodTerminalFileTree', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'podFiles.enterDirectory:app' }))
 
-    expect(mockUsePodFiles).toHaveBeenLastCalledWith(
+    expect(mockPodListFiles).toHaveBeenLastCalledWith(
       'default',
       'web-abc',
       'nginx',
       '/app',
-      { enabled: true }
+      undefined
     )
-    expect(screen.getByDisplayValue('/app')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('/')).toBeInTheDocument()
   })
 
   it('does not query files until pod and container are available', () => {
@@ -85,6 +121,32 @@ describe('PodTerminalFileTree', () => {
       '',
       '/',
       { enabled: false }
+    )
+  })
+
+  it('passes the frozen cluster name when provided', () => {
+    mockUsePodFiles.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(
+      <PodTerminalFileTree
+        clusterName="cluster-a"
+        namespace="default"
+        podName="web-abc"
+        containerName="nginx"
+      />
+    )
+
+    expect(mockUsePodFiles).toHaveBeenLastCalledWith(
+      'default',
+      'web-abc',
+      'nginx',
+      '/',
+      { enabled: true, clusterName: 'cluster-a' }
     )
   })
 })

--- a/ui/src/components/pod-terminal-file-tree.tsx
+++ b/ui/src/components/pod-terminal-file-tree.tsx
@@ -1,24 +1,67 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   IconArrowUp,
+  IconChevronDown,
+  IconChevronRight,
+  IconCopy,
+  IconDownload,
+  IconEdit,
   IconFile,
   IconFolder,
   IconFolderOpen,
   IconLoader,
+  IconTrash,
+  IconUpload,
 } from '@tabler/icons-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 
-import { usePodFiles } from '@/lib/api'
+import {
+  podDeleteFile,
+  podDownloadFile,
+  podListFiles,
+  podReadFileContent,
+  podUpdateFileContent,
+  podUploadFile,
+  usePodFiles,
+} from '@/lib/api'
+import { copyTextToClipboard } from '@/lib/desktop'
+import { translateError } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 
 import { ErrorMessage } from './error-message'
 import { RefreshButton } from './refresh-button'
 
 interface PodTerminalFileTreeProps {
+  clusterName?: string
   namespace?: string
   podName: string
   containerName: string
+}
+
+type FileTreeNode = NonNullable<ReturnType<typeof usePodFiles>['data']>[number]
+
+interface DirectoryState {
+  files?: FileTreeNode[]
+  isLoading: boolean
+  error?: unknown
 }
 
 function joinPath(currentPath: string, name: string) {
@@ -36,16 +79,35 @@ function getParentPath(currentPath: string) {
 }
 
 export function PodTerminalFileTree({
+  clusterName,
   namespace = '',
   podName,
   containerName,
 }: PodTerminalFileTreeProps) {
   const { t } = useTranslation()
   const [currentPath, setCurrentPath] = useState('/')
+  const [uploadDirectory, setUploadDirectory] = useState<string | null>(null)
+  const [editingPath, setEditingPath] = useState<string | null>(null)
+  const [editingContent, setEditingContent] = useState('')
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isEditorLoading, setIsEditorLoading] = useState(false)
+  const [isEditorSaving, setIsEditorSaving] = useState(false)
+  const [deletePath, setDeletePath] = useState<string | null>(null)
+  const [deleteIsDir, setDeleteIsDir] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
+    () => new Set(['/'])
+  )
+  const [directoryStates, setDirectoryStates] = useState<
+    Record<string, DirectoryState>
+  >({})
+  const uploadInputRef = useRef<HTMLInputElement>(null)
   const enabled = Boolean(namespace && podName && containerName)
 
   useEffect(() => {
     setCurrentPath('/')
+    setExpandedPaths(new Set(['/']))
+    setDirectoryStates({})
   }, [containerName, podName])
 
   const {
@@ -53,10 +115,305 @@ export function PodTerminalFileTree({
     isLoading,
     error,
     refetch,
-  } = usePodFiles(namespace, podName, containerName, currentPath, { enabled })
+  } = usePodFiles(
+    namespace,
+    podName,
+    containerName,
+    currentPath,
+    clusterName ? { enabled, clusterName } : { enabled }
+  )
 
   const handleNavigate = (path: string) => {
     setCurrentPath(path.startsWith('/') ? path : `/${path}`)
+  }
+
+  const buildRequestOptions = () =>
+    clusterName ? { headers: { 'x-cluster-name': clusterName } } : undefined
+
+  const refreshDirectory = async (path: string) => {
+    setDirectoryStates((current) => ({
+      ...current,
+      [path]: {
+        ...current[path],
+        isLoading: true,
+        error: undefined,
+      },
+    }))
+    try {
+      const nextFiles = await podListFiles(
+        namespace,
+        podName,
+        containerName,
+        path,
+        buildRequestOptions()
+      )
+      setDirectoryStates((current) => ({
+        ...current,
+        [path]: {
+          files: nextFiles,
+          isLoading: false,
+        },
+      }))
+    } catch (error) {
+      setDirectoryStates((current) => ({
+        ...current,
+        [path]: {
+          ...current[path],
+          isLoading: false,
+          error,
+        },
+      }))
+    }
+  }
+
+  const refreshVisibleFiles = () => {
+    void refetch()
+    for (const path of expandedPaths) {
+      if (path !== '/') {
+        void refreshDirectory(path)
+      }
+    }
+  }
+
+  const handleRefreshTree = () => {
+    setExpandedPaths(new Set(['/']))
+    setDirectoryStates({})
+    void refetch()
+  }
+
+  const handleToggleDirectory = (path: string) => {
+    const isExpanded = expandedPaths.has(path)
+    setExpandedPaths((current) => {
+      const next = new Set(current)
+      if (isExpanded) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+
+    if (!isExpanded && path !== '/' && !directoryStates[path]?.files) {
+      void refreshDirectory(path)
+    }
+  }
+
+  const handleCopyPath = async (path: string) => {
+    await copyTextToClipboard(path)
+    toast.success(t('podFiles.pathCopied'))
+  }
+
+  const handleDownload = (path: string, isDirectory: boolean) => {
+    podDownloadFile(namespace, podName, containerName, path, {
+      clusterName,
+      isDirectory,
+    })
+  }
+
+  const handleOpenEditor = async (path: string) => {
+    setEditingPath(path)
+    setEditingContent('')
+    setIsEditDialogOpen(true)
+    setIsEditorLoading(true)
+    try {
+      const content = await podReadFileContent(
+        namespace,
+        podName,
+        containerName,
+        path,
+        { clusterName }
+      )
+      setEditingContent(content)
+    } catch (error) {
+      toast.error(translateError(error, t))
+      setIsEditDialogOpen(false)
+    } finally {
+      setIsEditorLoading(false)
+    }
+  }
+
+  const handleSaveEditor = async () => {
+    if (!editingPath) return
+    setIsEditorSaving(true)
+    try {
+      await podUpdateFileContent(
+        namespace,
+        podName,
+        containerName,
+        editingPath,
+        editingContent,
+        { clusterName }
+      )
+      toast.success(t('podFiles.fileSaved'))
+      setIsEditDialogOpen(false)
+      refreshVisibleFiles()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsEditorSaving(false)
+    }
+  }
+
+  const handlePickUpload = (path: string) => {
+    setUploadDirectory(path)
+    uploadInputRef.current?.click()
+  }
+
+  const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file || !uploadDirectory) return
+    try {
+      await podUploadFile(
+        namespace,
+        podName,
+        containerName,
+        uploadDirectory,
+        file,
+        { clusterName }
+      )
+      toast.success(t('podFiles.uploadedSuccess', { name: file.name }))
+      refreshVisibleFiles()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      event.target.value = ''
+      setUploadDirectory(null)
+    }
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deletePath) return
+    setIsDeleting(true)
+    try {
+      await podDeleteFile(namespace, podName, containerName, deletePath, {
+        clusterName,
+      })
+      toast.success(
+        deleteIsDir
+          ? t('podFiles.directoryDeleted')
+          : t('podFiles.fileDeleted')
+      )
+      setDeletePath(null)
+      refreshVisibleFiles()
+    } catch (error) {
+      toast.error(translateError(error, t))
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  const renderFileEntry = (
+    file: FileTreeNode,
+    parentPath: string,
+    depth = 0
+  ) => {
+    const filePath = joinPath(parentPath, file.name)
+    const isExpanded = expandedPaths.has(filePath)
+    const directoryState = directoryStates[filePath]
+    const icon = file.isDir ? (
+      <IconFolder className="h-4 w-4 shrink-0 text-blue-500" />
+    ) : (
+      <IconFile className="h-4 w-4 shrink-0 text-muted-foreground" />
+    )
+    const content = file.isDir ? (
+      <Button
+        variant="ghost"
+        className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
+        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        aria-label={t('podFiles.enterDirectory', {
+          name: file.name,
+        })}
+        onClick={() => handleToggleDirectory(filePath)}
+      >
+        {isExpanded ? (
+          <IconChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <IconChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        {icon}
+        <span className="truncate font-mono text-sm">{file.name}</span>
+      </Button>
+    ) : (
+      <div
+        className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground hover:bg-muted/60"
+        style={{ paddingLeft: `${depth * 14 + 28}px` }}
+      >
+        {icon}
+        <span className="truncate font-mono">{file.name}</span>
+      </div>
+    )
+
+    return (
+      <ContextMenu key={file.name}>
+        <ContextMenuTrigger asChild>{content}</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={() => void handleCopyPath(filePath)}>
+            <IconCopy className="h-4 w-4" />
+            {t('podFiles.copyPath')}
+          </ContextMenuItem>
+          {!file.isDir ? (
+            <ContextMenuItem onSelect={() => void handleOpenEditor(filePath)}>
+              <IconEdit className="h-4 w-4" />
+              {t('podFiles.edit')}
+            </ContextMenuItem>
+          ) : null}
+          <ContextMenuItem onSelect={() => handleDownload(filePath, file.isDir)}>
+            <IconDownload className="h-4 w-4" />
+            {file.isDir
+              ? t('podFiles.downloadDirectoryArchive')
+              : t('podFiles.downloadFile')}
+          </ContextMenuItem>
+          {file.isDir ? (
+            <ContextMenuItem onSelect={() => handlePickUpload(filePath)}>
+              <IconUpload className="h-4 w-4" />
+              {t('podFiles.upload')}
+            </ContextMenuItem>
+          ) : null}
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() => {
+              setDeletePath(filePath)
+              setDeleteIsDir(file.isDir)
+            }}
+          >
+            <IconTrash className="h-4 w-4" />
+            {t('podFiles.delete')}
+          </ContextMenuItem>
+        </ContextMenuContent>
+        {file.isDir && isExpanded ? (
+          <div className="space-y-1">
+            {directoryState?.isLoading ? (
+              <div
+                className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground"
+                style={{ paddingLeft: `${(depth + 1) * 14 + 28}px` }}
+              >
+                <IconLoader className="h-4 w-4 animate-spin" />
+                {t('podFiles.loadingFiles')}
+              </div>
+            ) : directoryState?.error ? (
+              <div
+                className="px-2 py-1.5 text-sm text-destructive"
+                style={{ paddingLeft: `${(depth + 1) * 14 + 28}px` }}
+              >
+                {translateError(directoryState.error, t)}
+              </div>
+            ) : directoryState?.files && directoryState.files.length > 0 ? (
+              directoryState.files.map((child) =>
+                renderFileEntry(child, filePath, depth + 1)
+              )
+            ) : (
+              <div
+                className="px-2 py-1.5 text-sm text-muted-foreground"
+                style={{ paddingLeft: `${(depth + 1) * 14 + 28}px` }}
+              >
+                {t('podFiles.noFilesFound')}
+              </div>
+            )}
+          </div>
+        ) : null}
+      </ContextMenu>
+    )
   }
 
   return (
@@ -87,12 +444,18 @@ export function PodTerminalFileTree({
           variant="ghost"
           size="icon"
           aria-label={t('podFiles.refreshFileList')}
-          onClick={() => refetch()}
+          onClick={handleRefreshTree}
           disabled={!enabled}
         />
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        <input
+          ref={uploadInputRef}
+          type="file"
+          className="hidden"
+          onChange={(event) => void handleUpload(event)}
+        />
         {!enabled ? (
           <div className="px-2 py-6 text-sm text-muted-foreground">
             {t('terminalContent.fileTreeUnavailable')}
@@ -110,34 +473,7 @@ export function PodTerminalFileTree({
           </div>
         ) : files && files.length > 0 ? (
           <div className="space-y-1">
-            {files.map((file) =>
-              file.isDir ? (
-                <Button
-                  key={file.name}
-                  variant="ghost"
-                  className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-left font-normal"
-                  aria-label={t('podFiles.enterDirectory', {
-                    name: file.name,
-                  })}
-                  onClick={() =>
-                    handleNavigate(joinPath(currentPath, file.name))
-                  }
-                >
-                  <IconFolder className="h-4 w-4 shrink-0 text-blue-500" />
-                  <span className="truncate font-mono text-sm">
-                    {file.name}
-                  </span>
-                </Button>
-              ) : (
-                <div
-                  key={file.name}
-                  className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground"
-                >
-                  <IconFile className="h-4 w-4 shrink-0" />
-                  <span className="truncate font-mono">{file.name}</span>
-                </div>
-              )
-            )}
+            {files.map((file) => renderFileEntry(file, currentPath))}
           </div>
         ) : (
           <div className="px-2 py-6 text-sm text-muted-foreground">
@@ -145,6 +481,83 @@ export function PodTerminalFileTree({
           </div>
         )}
       </div>
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="flex h-[80vh] max-h-[80vh] flex-col overflow-hidden sm:max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>{t('podFiles.editFile')}</DialogTitle>
+            <DialogDescription className="truncate font-mono">
+              {editingPath}
+            </DialogDescription>
+          </DialogHeader>
+          {isEditorLoading ? (
+            <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+              <IconLoader className="h-4 w-4 animate-spin" />
+              {t('podFiles.loadingFileContent')}
+            </div>
+          ) : (
+            <Textarea
+              value={editingContent}
+              onChange={(event) => setEditingContent(event.target.value)}
+              className="min-h-0 flex-1 resize-none font-mono text-sm"
+            />
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isEditorSaving}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              onClick={() => void handleSaveEditor()}
+              disabled={isEditorLoading || isEditorSaving}
+            >
+              {isEditorSaving ? (
+                <IconLoader className="h-4 w-4 animate-spin" />
+              ) : null}
+              {t('common.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(deletePath)}
+        onOpenChange={(open) => {
+          if (!open) setDeletePath(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('podFiles.deleteConfirmTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('podFiles.deleteConfirmDescription', {
+                path: deletePath ?? '',
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeletePath(null)}
+              disabled={isDeleting}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void handleConfirmDelete()}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <IconLoader className="h-4 w-4 animate-spin" />
+              ) : null}
+              {t('podFiles.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </aside>
   )
 }

--- a/ui/src/components/site-header.tsx
+++ b/ui/src/components/site-header.tsx
@@ -33,7 +33,7 @@ export function SiteHeader() {
   const isMobile = useIsMobile()
   const navigate = useNavigate()
   const { isDesktop } = useRuntime()
-  const { toggleTerminal, isOpen } = useTerminal()
+  const { openTerminal, sessions } = useTerminal()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const { t } = useTranslation()
   const { data: generalSetting } = useGeneralSetting({
@@ -41,6 +41,9 @@ export function SiteHeader() {
   })
   const kubectlEnabled = generalSetting?.kubectlEnabled ?? true
   const canManageSettings = isDesktop
+  const hasKubectlSession = sessions.some(
+    (session) => session.type === 'kubectl'
+  )
 
   return (
     <>
@@ -61,11 +64,11 @@ export function SiteHeader() {
             />
             {canManageSettings && kubectlEnabled && (
               <button
-                onClick={() => toggleTerminal('button')}
+                onClick={() => openTerminal('button')}
                 title={t('siteHeader.kubectlTerminal')}
                 aria-label={t('siteHeader.toggleKubectlTerminal')}
                 className={`flex items-center justify-center rounded-sm p-1 transition-colors ${
-                  isOpen
+                  hasKubectlSession
                     ? 'text-green-500 hover:text-green-600'
                     : 'text-muted-foreground hover:text-foreground'
                 }`}

--- a/ui/src/components/terminal-content.test.tsx
+++ b/ui/src/components/terminal-content.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { Pod } from 'kubernetes-types/core/v1'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Terminal } from './terminal-content'
+
+const websocketUrls: string[] = []
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: class {
@@ -19,7 +21,7 @@ vi.mock('@xterm/xterm', () => ({
     }
     rows = 24
     cols = 80
-    options = {}
+    options: Record<string, unknown> = {}
   },
 }))
 
@@ -82,7 +84,8 @@ class WebSocketMock {
   onerror: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
 
-  constructor() {
+  constructor(url: string) {
+    websocketUrls.push(url)
     setTimeout(() => this.onopen?.(), 0)
   }
 
@@ -106,6 +109,11 @@ const pods = [
 ] as Pod[]
 
 describe('Terminal', () => {
+  beforeEach(() => {
+    websocketUrls.length = 0
+    localStorage.clear()
+  })
+
   it('shows a pod file tree toggle for pod terminals', () => {
     render(
       <Terminal
@@ -133,5 +141,24 @@ describe('Terminal', () => {
         name: 'terminalContent.toggleFileTree',
       })
     ).not.toBeInTheDocument()
+  })
+
+  it('uses the frozen session cluster for websocket connections', async () => {
+    localStorage.setItem('current-cluster', 'cluster-b')
+
+    render(
+      <Terminal
+        type="pod"
+        clusterName="cluster-a"
+        namespace="default"
+        podName="web-abc"
+        containers={[{ name: 'nginx', image: 'nginx:latest' }]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(websocketUrls[0]).toContain('x-cluster-name=cluster-a')
+    })
+    expect(websocketUrls[0]).not.toContain('cluster-b')
   })
 })

--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -1,10 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
 import {
   IconClearAll,
   IconFolder,
   IconMaximize,
   IconMinimize,
-  IconPalette,
   IconSettings,
   IconTerminal,
 } from '@tabler/icons-react'
@@ -51,25 +57,35 @@ import { PodSelector } from './selector/pod-selector'
 
 export interface TerminalProps {
   type?: 'node' | 'pod' | 'kubectl'
+  clusterName?: string
   namespace?: string
   podName?: string
   nodeName?: string
   pods?: Pod[]
   containers?: Container[]
   initContainers?: Container[]
+  initialContainerName?: string
   /** When true, hides the internal toolbar and fills parent container */
   embedded?: boolean
+  /** When true with embedded mode, shows session-scoped terminal controls */
+  embeddedToolbar?: boolean
+  /** Optional host for rendering embedded controls into the workspace header */
+  toolbarPortalElement?: HTMLElement | null
 }
 
 export function Terminal({
+  clusterName,
   namespace,
   podName,
   pods,
   nodeName,
   containers: _containers = [],
   initContainers = [],
+  initialContainerName,
   type = 'pod',
   embedded = false,
+  embeddedToolbar = false,
+  toolbarPortalElement,
 }: TerminalProps) {
   const containers = useMemo(() => {
     return toSimpleContainer(initContainers, _containers)
@@ -83,20 +99,29 @@ export function Terminal({
     const saved = localStorage.getItem('terminal-theme')
     return (saved as TerminalTheme) || 'classic'
   })
+  const [previewTerminalTheme, setPreviewTerminalTheme] =
+    useState<TerminalTheme | null>(null)
   const [fontSize, setFontSize] = useState(() => {
     const saved = localStorage.getItem('log-viewer-font-size')
     return saved ? parseInt(saved, 10) : 14
   })
+  const [previewFontSize, setPreviewFontSize] = useState<number | null>(null)
   const [cursorStyle, setCursorStyle] = useState<'block' | 'underline' | 'bar'>(
     () => {
       const saved = localStorage.getItem('terminal-cursor-style')
       return (saved as 'block' | 'underline' | 'bar') || 'bar'
     }
   )
+  const [previewCursorStyle, setPreviewCursorStyle] = useState<
+    'block' | 'underline' | 'bar' | null
+  >(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [showFileTree, setShowFileTree] = useState(false)
   const viewerPreferenceReadyRef = useRef(false)
   const lastPersistedViewerPreferenceRef = useRef<string | null>(null)
+  const selectedTerminalThemeRef = useRef<TerminalTheme>(terminalTheme)
+  const selectedFontSizeRef = useRef(fontSize)
+  const selectedCursorStyleRef = useRef(cursorStyle)
 
   const terminalRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
@@ -111,6 +136,21 @@ export function Terminal({
   const speedUpdateTimerRef = useRef<NodeJS.Timeout | null>(null)
   const pingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { t } = useTranslation()
+  const visibleTerminalTheme = previewTerminalTheme ?? terminalTheme
+  const visibleFontSize = previewFontSize ?? fontSize
+  const visibleCursorStyle = previewCursorStyle ?? cursorStyle
+
+  useEffect(() => {
+    selectedTerminalThemeRef.current = terminalTheme
+  }, [terminalTheme])
+
+  useEffect(() => {
+    selectedFontSizeRef.current = fontSize
+  }, [fontSize])
+
+  useEffect(() => {
+    selectedCursorStyleRef.current = cursorStyle
+  }, [cursorStyle])
 
   useEffect(() => {
     let cancelled = false
@@ -166,17 +206,16 @@ export function Terminal({
 
     setSelectedContainer((current) => {
       if (!current || !containers.find((c) => c.name === current)) {
-        return containers[0].name
+        return initialContainerName &&
+          containers.find((c) => c.name === initialContainerName)
+          ? initialContainerName
+          : containers[0].name
       }
       return current
     })
-  }, [containers])
+  }, [containers, initialContainerName])
 
-  // Handle theme change and persist to localStorage
-  const handleThemeChange = useCallback((theme: TerminalTheme) => {
-    setTerminalTheme(theme)
-    localStorage.setItem('terminal-theme', theme)
-    // Update terminal theme without recreating the instance
+  const applyTerminalTheme = useCallback((theme: TerminalTheme) => {
     if (xtermRef.current) {
       const currentTheme = TERMINAL_THEMES[theme]
       xtermRef.current.options.theme = {
@@ -206,14 +245,34 @@ export function Terminal({
     }
   }, [])
 
-  // Handle font size change and persist to localStorage
-  const handleFontSizeChange = useCallback((size: number) => {
-    setFontSize(size)
-    localStorage.setItem('log-viewer-font-size', size.toString()) // 与 log viewer 共用同一个 key
-    // Update terminal font size without recreating the instance
+  // Handle theme change and persist to localStorage
+  const handleThemeChange = useCallback(
+    (theme: TerminalTheme) => {
+      selectedTerminalThemeRef.current = theme
+      setPreviewTerminalTheme(null)
+      setTerminalTheme(theme)
+      localStorage.setItem('terminal-theme', theme)
+      applyTerminalTheme(theme)
+    },
+    [applyTerminalTheme]
+  )
+
+  const handleThemePreview = useCallback(
+    (theme: TerminalTheme) => {
+      setPreviewTerminalTheme(theme)
+      applyTerminalTheme(theme)
+    },
+    [applyTerminalTheme]
+  )
+
+  const restoreThemePreview = useCallback(() => {
+    setPreviewTerminalTheme(null)
+    applyTerminalTheme(selectedTerminalThemeRef.current)
+  }, [applyTerminalTheme])
+
+  const applyFontSize = useCallback((size: number) => {
     if (xtermRef.current && fitAddonRef.current) {
       xtermRef.current.options.fontSize = size
-      // Delay fit to ensure font size has been applied
       setTimeout(() => {
         if (fitAddonRef.current) {
           fitAddonRef.current.fit()
@@ -222,16 +281,75 @@ export function Terminal({
     }
   }, [])
 
-  const handleCursorStyleChange = useCallback(
+  // Handle font size change and persist to localStorage
+  const handleFontSizeChange = useCallback(
+    (size: number) => {
+      selectedFontSizeRef.current = size
+      setPreviewFontSize(null)
+      setFontSize(size)
+      localStorage.setItem('log-viewer-font-size', size.toString()) // 与 log viewer 共用同一个 key
+      applyFontSize(size)
+    },
+    [applyFontSize]
+  )
+
+  const handleFontSizePreview = useCallback(
+    (size: number) => {
+      setPreviewFontSize(size)
+      applyFontSize(size)
+    },
+    [applyFontSize]
+  )
+
+  const restoreFontSizePreview = useCallback(() => {
+    setPreviewFontSize(null)
+    applyFontSize(selectedFontSizeRef.current)
+  }, [applyFontSize])
+
+  const applyCursorStyle = useCallback(
     (style: 'block' | 'underline' | 'bar') => {
-      setCursorStyle(style)
-      localStorage.setItem('terminal-cursor-style', style)
       if (xtermRef.current) {
         xtermRef.current.options.cursorStyle = style
       }
     },
     []
   )
+
+  const handleCursorStyleChange = useCallback(
+    (style: 'block' | 'underline' | 'bar') => {
+      selectedCursorStyleRef.current = style
+      setPreviewCursorStyle(null)
+      setCursorStyle(style)
+      localStorage.setItem('terminal-cursor-style', style)
+      applyCursorStyle(style)
+    },
+    [applyCursorStyle]
+  )
+
+  const handleCursorStylePreview = useCallback(
+    (style: 'block' | 'underline' | 'bar') => {
+      setPreviewCursorStyle(style)
+      applyCursorStyle(style)
+    },
+    [applyCursorStyle]
+  )
+
+  const restoreCursorStylePreview = useCallback(() => {
+    setPreviewCursorStyle(null)
+    applyCursorStyle(selectedCursorStyleRef.current)
+  }, [applyCursorStyle])
+
+  useEffect(() => {
+    if (previewFontSize === null) {
+      applyFontSize(fontSize)
+    }
+  }, [applyFontSize, fontSize, previewFontSize])
+
+  useEffect(() => {
+    if (previewCursorStyle === null) {
+      applyCursorStyle(cursorStyle)
+    }
+  }, [applyCursorStyle, cursorStyle, previewCursorStyle])
 
   useEffect(() => {
     if (!viewerPreferenceReadyRef.current) {
@@ -259,14 +377,6 @@ export function Terminal({
       console.error('Failed to save viewer preference to storage:', error)
     })
   }, [cursorStyle, fontSize, terminalTheme])
-
-  // Quick theme cycling function
-  const cycleTheme = useCallback(() => {
-    const themes = Object.keys(TERMINAL_THEMES) as TerminalTheme[]
-    const currentIndex = themes.indexOf(terminalTheme)
-    const nextIndex = (currentIndex + 1) % themes.length
-    handleThemeChange(themes[nextIndex])
-  }, [terminalTheme, handleThemeChange])
 
   const toggleFullscreen = useCallback(() => {
     setIsFullscreen((v) => !v)
@@ -377,7 +487,7 @@ export function Terminal({
 
     // WebSocket connection
     setIsConnected(false)
-    const currentCluster = localStorage.getItem('current-cluster')
+    const currentCluster = clusterName ?? localStorage.getItem('current-cluster')
     const wsPath =
       type === 'pod'
         ? appendClusterNameParam(
@@ -566,6 +676,7 @@ export function Terminal({
   }, [
     selectedPod,
     selectedContainer,
+    clusterName,
     namespace,
     type,
     updateNetworkStats,
@@ -595,8 +706,254 @@ export function Terminal({
     />
   )
 
+  const toolbarControls = (
+    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+      {embeddedToolbar && (
+        <NetworkSpeedIndicator
+          uploadSpeed={networkSpeed.upload}
+          downloadSpeed={networkSpeed.download}
+        />
+      )}
+
+      {containers.length > 1 && (
+        <ContainerSelector
+          containers={containers}
+          showAllOption={false}
+          selectedContainer={selectedContainer}
+          onContainerChange={handleContainerChange}
+        />
+      )}
+
+      {pods && pods.length > 0 && (
+        <PodSelector
+          pods={pods}
+          selectedPod={selectedPod}
+          onPodChange={handlePodChange}
+        />
+      )}
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label={t('terminalContent.settings', 'Terminal settings')}
+            title={t('terminalContent.settings', 'Terminal settings')}
+          >
+            <IconSettings className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80" align="end">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="terminal-theme">
+                  {t('terminalContent.terminalTheme')}
+                </Label>
+                <Select value={terminalTheme} onValueChange={handleThemeChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent onPointerLeave={restoreThemePreview}>
+                    {Object.entries(TERMINAL_THEMES).map(([key, theme]) => (
+                      <SelectItem
+                        key={key}
+                        value={key}
+                        onPointerEnter={() =>
+                          handleThemePreview(key as TerminalTheme)
+                        }
+                        onFocus={() => handleThemePreview(key as TerminalTheme)}
+                      >
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="w-3 h-3 rounded-full border border-gray-400"
+                            style={{
+                              backgroundColor: theme.background,
+                            }}
+                          />
+                          <span className="text-sm">{theme.name}</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div
+                className="p-3 rounded space-y-1"
+                style={{
+                  backgroundColor:
+                    TERMINAL_THEMES[visibleTerminalTheme].background,
+                  color: TERMINAL_THEMES[visibleTerminalTheme].foreground,
+                  fontSize: `${visibleFontSize}px`,
+                }}
+              >
+                <div>
+                  <span
+                    style={{
+                      color: TERMINAL_THEMES[visibleTerminalTheme].green,
+                    }}
+                  >
+                    user@pod:~$
+                  </span>{' '}
+                  ls -la
+                </div>
+                <div style={{ color: TERMINAL_THEMES[visibleTerminalTheme].blue }}>
+                  drwxr-xr-x 3 user user 4096 Dec 9 10:30 .
+                </div>
+                <div
+                  style={{ color: TERMINAL_THEMES[visibleTerminalTheme].yellow }}
+                >
+                  -rw-r--r-- 1 user user 220 Dec 9 10:30 README.md
+                </div>
+                <div style={{ color: TERMINAL_THEMES[visibleTerminalTheme].red }}>
+                  -rwx------ 1 user user 1024 Dec 9 10:30 script.sh
+                </div>
+                <div className="flex items-center gap-1 opacity-80">
+                  <span>{t('terminalContent.cursorStyle')}</span>
+                  <span>
+                    {visibleCursorStyle === 'block'
+                      ? t('terminalContent.block')
+                      : visibleCursorStyle === 'underline'
+                        ? t('terminalContent.underline')
+                        : t('terminalContent.bar')}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="font-size">{t('logViewer.fontSize')}</Label>
+                <Select
+                  value={fontSize.toString()}
+                  onValueChange={(value) => handleFontSizeChange(Number(value))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent onPointerLeave={restoreFontSizePreview}>
+                    {[10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24].map(
+                      (size) => (
+                        <SelectItem
+                          key={size}
+                          value={size.toString()}
+                          onPointerEnter={() => handleFontSizePreview(size)}
+                          onFocus={() => handleFontSizePreview(size)}
+                        >
+                          {size}px
+                        </SelectItem>
+                      )
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="cursor-style">
+                  {t('terminalContent.cursorStyle')}
+                </Label>
+                <Select
+                  value={cursorStyle}
+                  onValueChange={handleCursorStyleChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent onPointerLeave={restoreCursorStylePreview}>
+                    <SelectItem
+                      value="block"
+                      onPointerEnter={() => handleCursorStylePreview('block')}
+                      onFocus={() => handleCursorStylePreview('block')}
+                    >
+                      {t('terminalContent.block')}
+                    </SelectItem>
+                    <SelectItem
+                      value="underline"
+                      onPointerEnter={() =>
+                        handleCursorStylePreview('underline')
+                      }
+                      onFocus={() => handleCursorStylePreview('underline')}
+                    >
+                      {t('terminalContent.underline')}
+                    </SelectItem>
+                    <SelectItem
+                      value="bar"
+                      onPointerEnter={() => handleCursorStylePreview('bar')}
+                      onFocus={() => handleCursorStylePreview('bar')}
+                    >
+                      {t('terminalContent.bar')}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {canShowFileTree && (
+        <Button
+          variant={showFileTree ? 'secondary' : 'outline'}
+          size="sm"
+          aria-label={t('terminalContent.toggleFileTree')}
+          title={t('terminalContent.toggleFileTree')}
+          onClick={() => setShowFileTree((value) => !value)}
+        >
+          <IconFolder className="h-4 w-4" />
+        </Button>
+      )}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={clearTerminal}
+        aria-label={t('terminalContent.clear', 'Clear terminal')}
+        title={t('terminalContent.clear', 'Clear terminal')}
+      >
+        <IconClearAll className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+  const shouldRenderEmbeddedToolbarInline =
+    embeddedToolbar && !toolbarPortalElement
+
+  const terminalBody = (
+    <div className="flex h-full min-h-0">
+      {canShowFileTree && showFileTree ? (
+        <div className="h-full min-h-0 w-[360px] shrink-0 max-w-[45%]">
+          <PodTerminalFileTree
+            clusterName={clusterName}
+            namespace={namespace}
+            podName={selectedPod}
+            containerName={selectedContainer}
+          />
+        </div>
+      ) : null}
+      {terminalDiv}
+    </div>
+  )
+
   // Embedded mode: no header, fills parent completely
   if (embedded) {
+    if (embeddedToolbar) {
+      return (
+        <div className="flex h-full min-h-0 w-full flex-col">
+          {toolbarPortalElement
+            ? createPortal(toolbarControls, toolbarPortalElement)
+            : null}
+          {shouldRenderEmbeddedToolbarInline ? (
+            <div className="flex min-h-10 shrink-0 items-center justify-end gap-3 border-b bg-muted/30 px-3 py-1">
+              {toolbarControls}
+            </div>
+          ) : null}
+          <div className="min-h-0 flex-1">{terminalBody}</div>
+        </div>
+      )
+    }
+
     return (
       <div className="flex flex-col h-full w-full min-h-0">{terminalDiv}</div>
     )
@@ -626,201 +983,7 @@ export function Terminal({
           </div>
 
           <div className="flex items-center gap-2">
-            {/* Container Selector */}
-            {containers.length > 1 && (
-              <ContainerSelector
-                containers={containers}
-                showAllOption={false}
-                selectedContainer={selectedContainer}
-                onContainerChange={handleContainerChange}
-              />
-            )}
-
-            {/* Pod Selector */}
-            {pods && pods.length > 0 && (
-              <PodSelector
-                pods={pods}
-                selectedPod={selectedPod}
-                onPodChange={handlePodChange}
-              />
-            )}
-
-            {/* Quick Theme Toggle */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={cycleTheme}
-              title={t('terminalContent.currentThemeShortcut', {
-                name: TERMINAL_THEMES[terminalTheme].name,
-              })}
-              className="relative"
-            >
-              <IconPalette className="h-4 w-4" />
-              <div
-                className="absolute -top-1 -right-1 w-3 h-3 rounded-full border border-gray-400"
-                style={{
-                  backgroundColor: TERMINAL_THEMES[terminalTheme].background,
-                }}
-              ></div>
-            </Button>
-
-            {/* Settings */}
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button variant="outline" size="sm">
-                  <IconSettings className="h-4 w-4" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-80" align="end">
-                <div className="space-y-4">
-                  {/* Terminal Theme Selector */}
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="terminal-theme">
-                        {t('terminalContent.terminalTheme')}
-                      </Label>
-                      <Select
-                        value={terminalTheme}
-                        onValueChange={handleThemeChange}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {Object.entries(TERMINAL_THEMES).map(
-                            ([key, theme]) => (
-                              <SelectItem key={key} value={key}>
-                                <div className="flex items-center gap-2">
-                                  <div
-                                    className="w-3 h-3 rounded-full border border-gray-400"
-                                    style={{
-                                      backgroundColor: theme.background,
-                                    }}
-                                  ></div>
-                                  <span className="text-sm">{theme.name}</span>
-                                </div>
-                              </SelectItem>
-                            )
-                          )}
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    {/* Theme Preview */}
-                    <div
-                      className="p-3 rounded space-y-1"
-                      style={{
-                        backgroundColor:
-                          TERMINAL_THEMES[terminalTheme].background,
-                        color: TERMINAL_THEMES[terminalTheme].foreground,
-                        fontSize: `${fontSize}px`,
-                      }}
-                    >
-                      <div>
-                        <span
-                          style={{
-                            color: TERMINAL_THEMES[terminalTheme].green,
-                          }}
-                        >
-                          user@pod:~$
-                        </span>{' '}
-                        ls -la
-                      </div>
-                      <div
-                        style={{ color: TERMINAL_THEMES[terminalTheme].blue }}
-                      >
-                        drwxr-xr-x 3 user user 4096 Dec 9 10:30 .
-                      </div>
-                      <div
-                        style={{ color: TERMINAL_THEMES[terminalTheme].yellow }}
-                      >
-                        -rw-r--r-- 1 user user 220 Dec 9 10:30 README.md
-                      </div>
-                      <div
-                        style={{ color: TERMINAL_THEMES[terminalTheme].red }}
-                      >
-                        -rwx------ 1 user user 1024 Dec 9 10:30 script.sh
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Font Size Selector */}
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="font-size">{t('logViewer.fontSize')}</Label>
-                      <Select
-                        value={fontSize.toString()}
-                        onValueChange={(value) =>
-                          handleFontSizeChange(Number(value))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="10">10px</SelectItem>
-                          <SelectItem value="11">11px</SelectItem>
-                          <SelectItem value="12">12px</SelectItem>
-                          <SelectItem value="13">13px</SelectItem>
-                          <SelectItem value="14">14px</SelectItem>
-                          <SelectItem value="15">15px</SelectItem>
-                          <SelectItem value="16">16px</SelectItem>
-                          <SelectItem value="18">18px</SelectItem>
-                          <SelectItem value="20">20px</SelectItem>
-                          <SelectItem value="22">22px</SelectItem>
-                          <SelectItem value="24">24px</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-
-                  {/* Cursor Style Selector */}
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="cursor-style">
-                        {t('terminalContent.cursorStyle')}
-                      </Label>
-                      <Select
-                        value={cursorStyle}
-                        onValueChange={handleCursorStyleChange}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="block">
-                            {t('terminalContent.block')}
-                          </SelectItem>
-                          <SelectItem value="underline">
-                            {t('terminalContent.underline')}
-                          </SelectItem>
-                          <SelectItem value="bar">
-                            {t('terminalContent.bar')}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                </div>
-              </PopoverContent>
-            </Popover>
-
-            {canShowFileTree && (
-              <Button
-                variant={showFileTree ? 'secondary' : 'outline'}
-                size="sm"
-                aria-label={t('terminalContent.toggleFileTree')}
-                title={t('terminalContent.toggleFileTree')}
-                onClick={() => setShowFileTree((value) => !value)}
-              >
-                <IconFolder className="h-4 w-4" />
-              </Button>
-            )}
-
-            {/* Clear Terminal */}
-            <Button variant="outline" size="sm" onClick={clearTerminal}>
-              <IconClearAll className="h-4 w-4" />
-            </Button>
+            {toolbarControls}
 
             <Button variant="outline" size="sm" onClick={toggleFullscreen}>
               {isFullscreen ? (
@@ -833,18 +996,7 @@ export function Terminal({
         </div>
       </CardHeader>
 
-      <CardContent className="flex h-full min-h-0 p-0">
-        {canShowFileTree && showFileTree ? (
-          <div className="h-full min-h-0 w-[360px] shrink-0 max-w-[45%]">
-            <PodTerminalFileTree
-              namespace={namespace}
-              podName={selectedPod}
-              containerName={selectedContainer}
-            />
-          </div>
-        ) : null}
-        {terminalDiv}
-      </CardContent>
+      <CardContent className="h-full min-h-0 p-0">{terminalBody}</CardContent>
     </Card>
   )
 }

--- a/ui/src/components/terminal-launcher.tsx
+++ b/ui/src/components/terminal-launcher.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from 'react'
+import { TerminalSquare } from 'lucide-react'
+import type { Container, Pod } from 'kubernetes-types/core/v1'
+import { useTranslation } from 'react-i18next'
+
+import { useTerminal } from '@/contexts/terminal-context'
+import { toSimpleContainer } from '@/lib/k8s'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+interface TerminalLauncherProps {
+  namespace?: string
+  podName?: string
+  pods?: Pod[]
+  containers?: Container[]
+  initContainers?: Container[]
+  source?: string
+  title?: string
+  description?: string
+}
+
+export function TerminalLauncher({
+  namespace,
+  podName,
+  pods,
+  containers: workloadContainers = [],
+  initContainers = [],
+  source,
+  title,
+  description,
+}: TerminalLauncherProps) {
+  const { t } = useTranslation()
+  const { openSession } = useTerminal()
+  const availablePods = useMemo(() => {
+    if (podName) return []
+    return pods?.filter((pod) => Boolean(pod.metadata?.name)) ?? []
+  }, [podName, pods])
+  const simpleContainers = useMemo(
+    () => toSimpleContainer(initContainers, workloadContainers),
+    [initContainers, workloadContainers]
+  )
+  const [selectedPod, setSelectedPod] = useState(
+    podName || availablePods[0]?.metadata?.name || ''
+  )
+  const [selectedContainer, setSelectedContainer] = useState(
+    simpleContainers[0]?.name || ''
+  )
+
+  useEffect(() => {
+    setSelectedPod((current) => {
+      if (podName) return podName
+      if (current && availablePods.some((pod) => pod.metadata?.name === current))
+        return current
+      return availablePods[0]?.metadata?.name || ''
+    })
+  }, [availablePods, podName])
+
+  useEffect(() => {
+    setSelectedContainer((current) => {
+      if (
+        current &&
+        simpleContainers.some((container) => container.name === current)
+      )
+        return current
+      return simpleContainers[0]?.name || ''
+    })
+  }, [simpleContainers])
+
+  const effectivePodName = podName || selectedPod
+  const effectiveNamespace =
+    namespace ||
+    availablePods.find((pod) => pod.metadata?.name === effectivePodName)
+      ?.metadata?.namespace
+  const canOpen = Boolean(effectiveNamespace && effectivePodName)
+
+  return (
+    <div className="flex min-h-[320px] flex-col items-center justify-center gap-5 rounded-md border border-dashed bg-muted/20 p-8 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-md border bg-background shadow-sm">
+        <TerminalSquare className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <div className="max-w-xl space-y-2">
+        <h3 className="text-base font-semibold">
+          {title ?? t('terminalLauncher.title', 'Open terminal workspace')}
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          {description ??
+            t(
+              'terminalLauncher.description',
+              'Start the shell in the bottom terminal workspace. The session stays alive while you inspect other pages.'
+            )}
+        </p>
+      </div>
+
+      <div className="flex w-full max-w-xl flex-col gap-3 sm:flex-row">
+        {availablePods.length > 1 ? (
+          <Select value={selectedPod} onValueChange={setSelectedPod}>
+            <SelectTrigger className="sm:flex-1">
+              <SelectValue
+                placeholder={t('terminalLauncher.selectPod', 'Select pod')}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availablePods.map((pod) => (
+                <SelectItem
+                  key={pod.metadata!.name}
+                  value={pod.metadata!.name!}
+                >
+                  {pod.metadata!.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+
+        {simpleContainers.length > 1 ? (
+          <Select value={selectedContainer} onValueChange={setSelectedContainer}>
+            <SelectTrigger className="sm:flex-1">
+              <SelectValue
+                placeholder={t(
+                  'terminalLauncher.selectContainer',
+                  'Select container'
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {simpleContainers.map((container) => (
+                <SelectItem key={container.name} value={container.name}>
+                  {container.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+
+        <Button
+          className="sm:w-auto"
+          disabled={!canOpen}
+          onClick={() => {
+            if (!effectiveNamespace || !effectivePodName) return
+            openSession({
+              type: 'pod',
+              namespace: effectiveNamespace,
+              podName: effectivePodName,
+              containerName: selectedContainer || undefined,
+              pods: podName ? undefined : pods,
+              containers: workloadContainers,
+              initContainers,
+              source,
+              title: source
+                ? `${source} · ${effectivePodName}`
+                : effectivePodName,
+              subtitle: selectedContainer || effectiveNamespace,
+              entry: 'resource',
+            })
+          }}
+        >
+          <TerminalSquare className="h-4 w-4" />
+          {t('terminalLauncher.open', 'Open terminal')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/contexts/terminal-context.test.tsx
+++ b/ui/src/contexts/terminal-context.test.tsx
@@ -39,7 +39,9 @@ function TerminalConsumer() {
   const {
     isOpen,
     isMinimized,
+    sessions,
     openTerminal,
+    openSession,
     closeTerminal,
     minimizeTerminal,
     toggleTerminal,
@@ -50,8 +52,26 @@ function TerminalConsumer() {
       <span data-testid="state">
         {isOpen ? 'open' : 'closed'}/{isMinimized ? 'minimized' : 'expanded'}
       </span>
+      <span data-testid="sessions">
+        {sessions
+          .map((session) => `${session.id}|${session.clusterName}`)
+          .join(',')}
+      </span>
       <button type="button" onClick={() => openTerminal()}>
         open
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          openSession({
+            type: 'pod',
+            namespace: 'default',
+            podName: 'web-abc',
+            containerName: 'nginx',
+          })
+        }
+      >
+        open pod
       </button>
       <button type="button" onClick={closeTerminal}>
         close
@@ -69,6 +89,7 @@ function TerminalConsumer() {
 describe('TerminalProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
   })
 
   it('drives the terminal state through its public actions', async () => {
@@ -88,6 +109,8 @@ describe('TerminalProvider', () => {
       runtime: 'desktop',
       entry: 'button',
       page: 'overview',
+      type: 'kubectl',
+      source: 'global',
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'toggle' }))
@@ -105,6 +128,31 @@ describe('TerminalProvider', () => {
     fireEvent.click(screen.getByRole('button', { name: 'close' }))
     await waitFor(() => {
       expect(screen.getByTestId('state')).toHaveTextContent('closed/expanded')
+    })
+  })
+
+  it('freezes the current cluster on new sessions', async () => {
+    localStorage.setItem('current-cluster', 'cluster-a')
+
+    render(
+      <TerminalProvider>
+        <TerminalConsumer />
+      </TerminalProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'open pod' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('sessions')).toHaveTextContent(
+        'cluster-a:pod:default:web-abc::nginx|cluster-a'
+      )
+    })
+
+    localStorage.setItem('current-cluster', 'cluster-b')
+    fireEvent.click(screen.getByRole('button', { name: 'open pod' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('sessions')).toHaveTextContent(
+        'cluster-b:pod:default:web-abc::nginx|cluster-b'
+      )
     })
   })
 })

--- a/ui/src/contexts/terminal-context.tsx
+++ b/ui/src/contexts/terminal-context.tsx
@@ -1,12 +1,44 @@
-import { createContext, ReactNode, useContext, useState } from 'react'
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react'
+import type { Container, Pod } from 'kubernetes-types/core/v1'
 
 import { trackEvent } from '@/lib/analytics'
 import { getCurrentAnalyticsPageKey } from '@/lib/analytics-route'
 
+export type TerminalSessionType = 'node' | 'pod' | 'kubectl'
+
+export interface TerminalSessionSpec {
+  type: TerminalSessionType
+  title?: string
+  subtitle?: string
+  clusterName?: string
+  namespace?: string
+  podName?: string
+  nodeName?: string
+  containerName?: string
+  pods?: Pod[]
+  containers?: Container[]
+  initContainers?: Container[]
+  source?: string
+  entry?: string
+}
+
+export interface TerminalSession extends TerminalSessionSpec {
+  id: string
+  title: string
+  clusterName: string
+  createdAt: number
+}
+
 interface TerminalContextType {
   isOpen: boolean
   isMinimized: boolean
+  sessions: TerminalSession[]
+  activeSessionId: string | null
   openTerminal: (entry?: string) => void
+  restoreTerminal: () => void
+  openSession: (spec: TerminalSessionSpec) => string
+  activateSession: (sessionId: string) => void
+  closeSession: (sessionId: string) => void
   closeTerminal: () => void
   minimizeTerminal: () => void
   toggleTerminal: (entry?: string) => void
@@ -17,25 +49,88 @@ const TerminalContext = createContext<TerminalContextType | undefined>(
 )
 
 export function TerminalProvider({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [sessions, setSessions] = useState<TerminalSession[]>([])
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [isMinimized, setIsMinimized] = useState(false)
+  const isOpen = sessions.length > 0
 
-  // Open (or un-minimize) the terminal
-  const openTerminal = (entry: string = 'button') => {
-    if (!isOpen) {
-      trackEvent('kubectl_terminal_open', {
+  const activeSession = useMemo(
+    () => sessions.find((session) => session.id === activeSessionId) ?? null,
+    [activeSessionId, sessions]
+  )
+
+  const openSession = (spec: TerminalSessionSpec) => {
+    const session = createTerminalSession(spec)
+    const alreadyExists = sessions.some((item) => item.id === session.id)
+
+    setSessions((current) => {
+      const existing = current.find((item) => item.id === session.id)
+      if (existing) {
+        return current
+      }
+      return [...current, session]
+    })
+    setActiveSessionId(session.id)
+    setIsMinimized(false)
+
+    if (!alreadyExists) {
+      const eventProperties = {
         runtime: 'desktop',
-        entry,
+        entry: spec.entry ?? 'resource',
         page: getCurrentAnalyticsPageKey(),
-      })
+        type: session.type,
+        ...(spec.source ? { source: spec.source } : {}),
+      }
+
+      trackEvent(
+        session.type === 'kubectl'
+          ? 'kubectl_terminal_open'
+          : 'resource_terminal_open',
+        eventProperties
+      )
     }
-    setIsOpen(true)
+
+    return session.id
+  }
+
+  // Open (or un-minimize) the default kubectl terminal.
+  const openTerminal = (entry: string = 'button') => {
+    openSession({
+      type: 'kubectl',
+      title: 'kubectl',
+      entry,
+      source: 'global',
+    })
+  }
+
+  const activateSession = (sessionId: string) => {
+    setActiveSessionId(sessionId)
     setIsMinimized(false)
   }
 
-  // Fully close and destroy the session
+  const restoreTerminal = () => {
+    if (isOpen) {
+      setIsMinimized(false)
+    }
+  }
+
+  const closeSession = (sessionId: string) => {
+    setSessions((current) => {
+      const next = current.filter((session) => session.id !== sessionId)
+      if (activeSessionId === sessionId) {
+        setActiveSessionId(next[next.length - 1]?.id ?? null)
+      }
+      if (next.length === 0) {
+        setIsMinimized(false)
+      }
+      return next
+    })
+  }
+
+  // Fully close and destroy all terminal sessions.
   const closeTerminal = () => {
-    setIsOpen(false)
+    setSessions([])
+    setActiveSessionId(null)
     setIsMinimized(false)
   }
 
@@ -60,7 +155,13 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
       value={{
         isOpen,
         isMinimized,
+        sessions,
+        activeSessionId: activeSession?.id ?? null,
         openTerminal,
+        restoreTerminal,
+        openSession,
+        activateSession,
+        closeSession,
         closeTerminal,
         minimizeTerminal,
         toggleTerminal,
@@ -78,4 +179,44 @@ export function useTerminal() {
     throw new Error('useTerminal must be used within a TerminalProvider')
   }
   return context
+}
+
+function createTerminalSession(spec: TerminalSessionSpec): TerminalSession {
+  const clusterName =
+    spec.clusterName ?? localStorage.getItem('current-cluster') ?? 'default'
+  const id = createTerminalSessionId(spec, clusterName)
+  return {
+    ...spec,
+    id,
+    title: spec.title ?? createTerminalTitle(spec),
+    clusterName,
+    createdAt: Date.now(),
+  }
+}
+
+function createTerminalSessionId(
+  spec: TerminalSessionSpec,
+  clusterName: string
+) {
+  return [
+    clusterName,
+    spec.type,
+    spec.namespace ?? '',
+    spec.podName ?? '',
+    spec.nodeName ?? '',
+    spec.containerName ?? '',
+  ].join(':')
+}
+
+function createTerminalTitle(spec: TerminalSessionSpec) {
+  if (spec.type === 'kubectl') {
+    return 'kubectl'
+  }
+
+  if (spec.type === 'node') {
+    return spec.nodeName ?? 'Node terminal'
+  }
+
+  const containerSuffix = spec.containerName ? ` · ${spec.containerName}` : ''
+  return `${spec.podName ?? 'Pod'}${containerSuffix}`
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1460,7 +1460,18 @@
     "enterDirectory": "Enter directory {{name}}",
     "previewFile": "Preview file",
     "downloadDirectoryArchive": "Download directory as .tar archive",
-    "downloadFile": "Download file"
+    "downloadFile": "Download file",
+    "copyPath": "Copy path",
+    "pathCopied": "Path copied",
+    "edit": "Edit",
+    "editFile": "Edit file",
+    "loadingFileContent": "Loading file content...",
+    "fileSaved": "File saved",
+    "delete": "Delete",
+    "fileDeleted": "File deleted",
+    "directoryDeleted": "Directory deleted",
+    "deleteConfirmTitle": "Delete path",
+    "deleteConfirmDescription": "Delete {{path}}? This operation cannot be undone."
   },
   "siteHeader": {
     "createNewResource": "Create new resource",
@@ -2004,21 +2015,33 @@
     "seconds": "{{count}} seconds"
   },
   "terminalContent": {
-    "currentThemeShortcut": "Current theme: {{name}} (Ctrl+T to cycle)",
     "terminalTheme": "Terminal Theme",
     "cursorStyle": "Cursor Style",
     "block": "Block",
     "underline": "Underline",
     "bar": "Bar",
     "toggleFileTree": "Toggle pod file tree",
-    "fileTreeUnavailable": "Select a pod and container to browse files."
+    "fileTreeUnavailable": "Select a pod and container to browse files.",
+    "settings": "Terminal settings",
+    "clear": "Clear terminal"
   },
   "floatingTerminal": {
+    "workspace": "Terminal Workspace",
     "fullscreen": "Fullscreen",
     "exitFullscreen": "Exit fullscreen",
     "restore": "Restore",
     "minimize": "Minimize",
-    "closeSession": "Close (ends session)"
+    "closeSession": "Close session",
+    "closeAllSessions": "Close all sessions"
+  },
+  "terminalLauncher": {
+    "title": "Open terminal workspace",
+    "description": "Start the shell in the bottom terminal workspace. The session stays alive while you inspect other pages.",
+    "nodeTitle": "Open node terminal",
+    "nodeDescription": "Start the shell in the bottom terminal workspace. The session stays alive while you inspect other pages.",
+    "selectPod": "Select pod",
+    "selectContainer": "Select container",
+    "open": "Open terminal"
   },
   "containerInfo": {
     "running": "Running",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1942,7 +1942,18 @@
     "enterDirectory": "进入目录 {{name}}",
     "previewFile": "预览文件",
     "downloadDirectoryArchive": "将目录下载为 .tar 压缩包",
-    "downloadFile": "下载文件"
+    "downloadFile": "下载文件",
+    "copyPath": "复制路径",
+    "pathCopied": "路径已复制",
+    "edit": "编辑",
+    "editFile": "编辑文件",
+    "loadingFileContent": "正在加载文件内容...",
+    "fileSaved": "文件已保存",
+    "delete": "删除",
+    "fileDeleted": "文件已删除",
+    "directoryDeleted": "目录已删除",
+    "deleteConfirmTitle": "删除路径",
+    "deleteConfirmDescription": "确认删除 {{path}} 吗？此操作不可撤销。"
   },
   "siteHeader": {
     "createNewResource": "创建新资源",
@@ -2295,21 +2306,33 @@
     "seconds": "{{count}} 秒"
   },
   "terminalContent": {
-    "currentThemeShortcut": "当前主题：{{name}}（Ctrl+T 可循环切换）",
     "terminalTheme": "终端主题",
     "cursorStyle": "光标样式",
     "block": "块状",
     "underline": "下划线",
     "bar": "竖线",
     "toggleFileTree": "切换 Pod 文件树",
-    "fileTreeUnavailable": "请选择 Pod 和容器后浏览文件。"
+    "fileTreeUnavailable": "请选择 Pod 和容器后浏览文件。",
+    "settings": "终端设置",
+    "clear": "清空终端"
   },
   "floatingTerminal": {
+    "workspace": "终端工作台",
     "fullscreen": "全屏",
     "exitFullscreen": "退出全屏",
     "restore": "恢复",
     "minimize": "最小化",
-    "closeSession": "关闭（结束会话）"
+    "closeSession": "关闭会话",
+    "closeAllSessions": "关闭全部会话"
+  },
+  "terminalLauncher": {
+    "title": "打开终端工作台",
+    "description": "在底部终端工作台中启动 Shell，会话会在你查看其他页面时继续保持。",
+    "nodeTitle": "打开节点终端",
+    "nodeDescription": "在底部终端工作台中启动 Shell，会话会在你查看其他页面时继续保持。",
+    "selectPod": "选择 Pod",
+    "selectContainer": "选择容器",
+    "open": "打开终端"
   },
   "containerInfo": {
     "running": "运行中",

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -13,6 +13,7 @@ import {
 } from '@/types/api'
 
 import { API_BASE_URL, apiClient } from '../api-client'
+import { appendClusterNameParam } from '../cluster-transport'
 import { downloadNativeFile, openURL } from '../desktop'
 import { withSubPath } from '../subpath'
 import { fetchAPI } from './shared'
@@ -592,16 +593,23 @@ export const podDownloadFile = (
   namespace: string,
   podName: string,
   container: string,
-  path: string
+  path: string,
+  options?: { clusterName?: string; isDirectory?: boolean }
 ) => {
   const params = new URLSearchParams({
     container,
     path,
   })
-  const url = withSubPath(
-    `${API_BASE_URL}/pods/${namespace}/${podName}/files/download?${params.toString()}`
+  const url = appendClusterNameParam(
+    withSubPath(
+      `${API_BASE_URL}/pods/${namespace}/${podName}/files/download?${params.toString()}`
+    ),
+    options?.clusterName
   )
-  const suggestedName = path.split('/').filter(Boolean).pop() || 'download'
+  const baseName = path.split('/').filter(Boolean).pop() || 'download'
+  const suggestedName = options?.isDirectory
+    ? `${baseName}.tar`
+    : baseName
 
   void downloadNativeFile({
     title: 'Save File',
@@ -620,14 +628,18 @@ export const podPreviewFile = (
   namespace: string,
   podName: string,
   container: string,
-  path: string
+  path: string,
+  options?: { clusterName?: string }
 ) => {
   const params = new URLSearchParams({
     container,
     path,
   })
-  const url = withSubPath(
-    `${API_BASE_URL}/pods/${namespace}/${podName}/files/preview?${params.toString()}`
+  const url = appendClusterNameParam(
+    withSubPath(
+      `${API_BASE_URL}/pods/${namespace}/${podName}/files/preview?${params.toString()}`
+    ),
+    options?.clusterName
   )
   void openURL(url)
 }
@@ -637,7 +649,8 @@ export const podUploadFile = async (
   podName: string,
   container: string,
   path: string,
-  file: File
+  file: File,
+  options?: { clusterName?: string }
 ): Promise<void> => {
   const formData = new FormData()
   formData.append('file', file)
@@ -648,7 +661,70 @@ export const podUploadFile = async (
 
   await apiClient.put(
     `/pods/${namespace}/${podName}/files/upload?${params.toString()}`,
-    formData
+    formData,
+    options?.clusterName
+      ? { headers: { 'x-cluster-name': options.clusterName } }
+      : undefined
+  )
+}
+
+export const podReadFileContent = async (
+  namespace: string,
+  podName: string,
+  container: string,
+  path: string,
+  options?: { clusterName?: string }
+): Promise<string> => {
+  const params = new URLSearchParams({
+    container,
+    path,
+  })
+  const headers = options?.clusterName
+    ? { 'x-cluster-name': options.clusterName }
+    : undefined
+  return apiClient.get<string>(
+    `/pods/${namespace}/${podName}/files/preview?${params.toString()}`,
+    { headers }
+  )
+}
+
+export const podUpdateFileContent = async (
+  namespace: string,
+  podName: string,
+  container: string,
+  path: string,
+  content: string,
+  options?: { clusterName?: string }
+): Promise<void> => {
+  const params = new URLSearchParams({
+    container,
+    path,
+  })
+  await apiClient.put(
+    `/pods/${namespace}/${podName}/files/content?${params.toString()}`,
+    { content },
+    options?.clusterName
+      ? { headers: { 'x-cluster-name': options.clusterName } }
+      : undefined
+  )
+}
+
+export const podDeleteFile = async (
+  namespace: string,
+  podName: string,
+  container: string,
+  path: string,
+  options?: { clusterName?: string }
+): Promise<void> => {
+  const params = new URLSearchParams({
+    container,
+    path,
+  })
+  await apiClient.delete(
+    `/pods/${namespace}/${podName}/files?${params.toString()}`,
+    options?.clusterName
+      ? { headers: { 'x-cluster-name': options.clusterName } }
+      : undefined
   )
 }
 
@@ -761,11 +837,23 @@ export const usePodFiles = (
   podName: string,
   container: string,
   path: string,
-  options?: { enabled?: boolean }
+  options?: { enabled?: boolean; clusterName?: string }
 ) => {
   return useQuery({
-    queryKey: ['pod-files', namespace, podName, container, path],
-    queryFn: () => podListFiles(namespace, podName, container, path),
+    queryKey: [
+      'pod-files',
+      options?.clusterName ?? '',
+      namespace,
+      podName,
+      container,
+      path,
+    ],
+    queryFn: () =>
+      podListFiles(namespace, podName, container, path, {
+        headers: options?.clusterName
+          ? { 'x-cluster-name': options.clusterName }
+          : undefined,
+      }),
     enabled: options?.enabled !== false,
     staleTime: 10000, // 10 seconds cache
   })

--- a/ui/src/pages/daemonset-detail.tsx
+++ b/ui/src/pages/daemonset-detail.tsx
@@ -29,13 +29,13 @@ import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
+import { OpenPodTerminalButton } from '@/components/open-pod-terminal-button'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
-import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
@@ -275,6 +275,13 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
             namespace={namespace}
             name={name}
           />
+          <OpenPodTerminalButton
+            namespace={namespace}
+            pods={relatedPods}
+            containers={spec?.template.spec?.containers}
+            initContainers={spec?.template.spec?.initContainers}
+            source={`daemonset/${name}`}
+          />
           <Popover
             open={isRestartPopoverOpen}
             onOpenChange={setIsRestartPopoverOpen}
@@ -464,22 +471,6 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
                         initContainers={spec?.template.spec?.initContainers}
                         labelSelector={labelSelector}
                       />
-                    </div>
-                  ),
-                },
-                {
-                  value: 'terminal',
-                  label: t('detail.tabs.terminal'),
-                  content: (
-                    <div className="space-y-6">
-                      {relatedPods && relatedPods.length > 0 && (
-                        <Terminal
-                          namespace={namespace}
-                          pods={relatedPods}
-                          containers={spec?.template.spec?.containers}
-                          initContainers={spec?.template.spec?.initContainers}
-                        />
-                      )}
                     </div>
                   ),
                 },

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -45,13 +45,13 @@ import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
+import { OpenPodTerminalButton } from '@/components/open-pod-terminal-button'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
-import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
@@ -375,6 +375,13 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
             namespace={namespace}
             name={name}
           />
+          <OpenPodTerminalButton
+            namespace={namespace}
+            pods={relatedPods}
+            containers={deployment.spec?.template.spec?.containers}
+            initContainers={deployment.spec?.template.spec?.initContainers}
+            source={`deployment/${name}`}
+          />
           <Popover
             open={isScalePopoverOpen}
             onOpenChange={setIsScalePopoverOpen}
@@ -650,26 +657,6 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
                         }
                         labelSelector={labelSelector}
                       />
-                    </div>
-                  ),
-                },
-                {
-                  value: 'terminal',
-                  label: t('detail.tabs.terminal'),
-                  content: (
-                    <div className="space-y-6">
-                      {relatedPods && relatedPods.length > 0 && (
-                        <Terminal
-                          namespace={namespace}
-                          pods={relatedPods}
-                          containers={
-                            deployment.spec?.template.spec?.containers
-                          }
-                          initContainers={
-                            deployment.spec?.template.spec?.initContainers
-                          }
-                        />
-                      )}
                     </div>
                   ),
                 },

--- a/ui/src/pages/job-detail.tsx
+++ b/ui/src/pages/job-detail.tsx
@@ -27,13 +27,13 @@ import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LabelsAnno } from '@/components/lables-anno'
 import { LogViewer } from '@/components/log-viewer'
+import { OpenPodTerminalButton } from '@/components/open-pod-terminal-button'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
-import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
@@ -244,6 +244,13 @@ export function JobDetail(props: { namespace: string; name: string }) {
             resourceType={'jobs'}
             namespace={namespace}
             name={name}
+          />
+          <OpenPodTerminalButton
+            namespace={namespace}
+            pods={pods}
+            containers={job.spec?.template.spec?.containers}
+            initContainers={job.spec?.template.spec?.initContainers}
+            source={`job/${name}`}
           />
           <Button
             variant="destructive"
@@ -513,20 +520,6 @@ export function JobDetail(props: { namespace: string; name: string }) {
                         containers={job.spec?.template.spec?.containers}
                         initContainers={job.spec?.template.spec?.initContainers}
                         labelSelector={`job-name=${name}`}
-                      />
-                    </div>
-                  ),
-                },
-                {
-                  value: 'terminal',
-                  label: t('detail.tabs.terminal'),
-                  content: (
-                    <div className="space-y-6">
-                      <Terminal
-                        namespace={namespace}
-                        pods={pods}
-                        containers={job.spec?.template.spec?.containers}
-                        initContainers={job.spec?.template.spec?.initContainers}
                       />
                     </div>
                   ),

--- a/ui/src/pages/node-detail.tsx
+++ b/ui/src/pages/node-detail.tsx
@@ -63,9 +63,9 @@ import { MetricCell } from '@/components/metrics-cell'
 import { NodeDrainOptionRow } from '@/components/node-drain-option-row'
 import { NodeImageTable } from '@/components/node-image-table'
 import { NodeMonitoring } from '@/components/node-monitoring'
+import { OpenNodeTerminalButton } from '@/components/open-node-terminal-button'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
-import { Terminal } from '@/components/terminal'
 import { YamlEditor } from '@/components/yaml-editor'
 
 function NodePodsUsageSummary({
@@ -389,6 +389,7 @@ export function NodeDetail(props: { name: string }) {
             {t('detail.buttons.refresh')}
           </RefreshButton>
           <DescribeDialog resourceType="nodes" name={name} />
+          <OpenNodeTerminalButton nodeName={name} />
           {/* Drain Node Popover */}
           <Popover
             open={isDrainPopoverOpen}
@@ -1151,15 +1152,6 @@ export function NodeDetail(props: { name: string }) {
             value: 'monitor',
             label: t('detail.tabs.monitor'),
             content: <NodeMonitoring name={name} />,
-          },
-          {
-            value: 'Terminal',
-            label: t('detail.tabs.terminal'),
-            content: (
-              <div className="space-y-6">
-                <Terminal type="node" nodeName={name} />
-              </div>
-            ),
           },
           {
             value: 'events',

--- a/ui/src/pages/node-list-page.test.tsx
+++ b/ui/src/pages/node-list-page.test.tsx
@@ -16,6 +16,7 @@ const mockDrainNode = vi.fn()
 const mockTrackResourceAction = vi.fn()
 const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
+const mockOpenSession = vi.fn()
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>()
@@ -82,6 +83,12 @@ vi.mock('@/lib/analytics', () => ({
   trackResourceAction: (...args: unknown[]) => mockTrackResourceAction(...args),
 }))
 
+vi.mock('@/contexts/terminal-context', () => ({
+  useTerminal: () => ({
+    openSession: mockOpenSession,
+  }),
+}))
+
 vi.mock('sonner', () => ({
   toast: {
     success: (value: string) => mockToastSuccess(value),
@@ -99,6 +106,7 @@ describe('NodeListPage', () => {
     mockTrackResourceAction.mockClear()
     mockToastSuccess.mockClear()
     mockToastError.mockClear()
+    mockOpenSession.mockClear()
     mockDrainNode.mockResolvedValue(undefined)
   })
 
@@ -261,7 +269,13 @@ describe('NodeListPage', () => {
     await act(async () => {
       await items[5].onSelect?.()
     })
-    expect(screen.getByText('nodes.terminalDialogTitle')).toBeInTheDocument()
+    expect(mockOpenSession).toHaveBeenCalledWith({
+      type: 'node',
+      nodeName: 'orbstack',
+      title: 'orbstack',
+      source: 'node/orbstack',
+      entry: 'node-list',
+    })
   })
 
   it('explains drain options and submits the selected values', async () => {

--- a/ui/src/pages/node-list-page.tsx
+++ b/ui/src/pages/node-list-page.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { useTerminal } from '@/contexts/terminal-context'
 import { NodeWithMetrics } from '@/types/api'
 import { trackResourceAction } from '@/lib/analytics'
 import { cordonNode, drainNode, uncordonNode } from '@/lib/api'
@@ -36,7 +37,6 @@ import { NodeDrainOptionRow } from '@/components/node-drain-option-row'
 import { NodeStatusIcon } from '@/components/node-status-icon'
 import { ResourceTable } from '@/components/resource-table'
 import { RowContextMenuItem } from '@/components/row-context-menu'
-import { Terminal } from '@/components/terminal'
 
 function NodePodsUsageCell({ node }: { node: NodeWithMetrics }) {
   const podsUsed = node.metrics?.pods || 0
@@ -202,7 +202,7 @@ export function NodeListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [terminalNode, setTerminalNode] = useState<NodeWithMetrics | null>(null)
+  const { openSession } = useTerminal()
   const [cordonNodeTarget, setCordonNodeTarget] =
     useState<NodeWithMetrics | null>(null)
   const [drainNodeTarget, setDrainNodeTarget] =
@@ -415,8 +415,16 @@ export function NodeListPage() {
   }, [queryClient])
 
   const handleOpenNodeTerminal = useCallback((node: NodeWithMetrics) => {
-    setTerminalNode(node)
-  }, [])
+    const nodeName = node.metadata?.name
+    if (!nodeName) return
+    openSession({
+      type: 'node',
+      nodeName,
+      title: nodeName,
+      source: `node/${nodeName}`,
+      entry: 'node-list',
+    })
+  }, [openSession])
 
   const handleCordon = useCallback(async () => {
     if (!cordonNodeTarget?.metadata?.name) {
@@ -585,45 +593,6 @@ export function NodeListPage() {
         ]}
         getRowContextMenuItems={getRowContextMenuItems}
       />
-
-      <Dialog
-        open={Boolean(terminalNode)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setTerminalNode(null)
-          }
-        }}
-      >
-        <DialogContent className="flex h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] min-h-0 flex-col p-0 md:h-[80dvh] md:max-w-[80vw]">
-          <DialogHeader className="px-6 pt-6 pb-0">
-            <DialogTitle>
-              {terminalNode
-                ? t('nodes.terminalDialogTitle', {
-                    name: terminalNode.metadata?.name,
-                    defaultValue: '{{name}} · Terminal',
-                  })
-                : t('detail.tabs.terminal')}
-            </DialogTitle>
-            <DialogDescription>
-              {t(
-                'nodes.terminalDialogDescription',
-                'Open a shell session on the selected node.'
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="min-h-0 flex-1 px-6 pb-6">
-            {terminalNode ? (
-              <div className="h-full min-h-[480px]">
-                <Terminal
-                  type="node"
-                  nodeName={terminalNode.metadata?.name}
-                  embedded
-                />
-              </div>
-            ) : null}
-          </div>
-        </DialogContent>
-      </Dialog>
 
       <Dialog
         open={Boolean(cordonNodeTarget)}

--- a/ui/src/pages/pod-detail.tsx
+++ b/ui/src/pages/pod-detail.tsx
@@ -52,6 +52,7 @@ import { ResourceEditor } from '@/components/editors/resource-editor'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
+import { OpenPodTerminalButton } from '@/components/open-pod-terminal-button'
 import { PodFileBrowser } from '@/components/pod-file-browser'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodStatusIcon } from '@/components/pod-status-icon'
@@ -59,7 +60,6 @@ import { RefreshButton } from '@/components/refresh-button'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ContainerSelector } from '@/components/selector/container-selector'
-import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
@@ -312,6 +312,11 @@ export function PodDetail(props: { namespace: string; name: string }) {
             resourceType="pods"
             namespace={namespace}
             name={name}
+          />
+          <OpenPodTerminalButton
+            namespace={namespace}
+            pod={pod}
+            source={`pod/${name}`}
           />
           {resizeAvailable && (
             <Button
@@ -707,20 +712,6 @@ export function PodDetail(props: { namespace: string; name: string }) {
                 containers={pod.spec?.containers}
                 initContainers={pod.spec?.initContainers}
               />
-            ),
-          },
-          {
-            value: 'terminal',
-            label: t('detail.tabs.terminal'),
-            content: (
-              <div className="space-y-6">
-                <Terminal
-                  namespace={namespace}
-                  podName={name}
-                  containers={pod.spec?.containers}
-                  initContainers={pod.spec?.initContainers}
-                />
-              </div>
             ),
           },
           {

--- a/ui/src/pages/pod-list-page.test.tsx
+++ b/ui/src/pages/pod-list-page.test.tsx
@@ -10,6 +10,7 @@ const mockNavigate = vi.fn()
 const mockResourceTable = vi.fn(({ resourceName }: { resourceName: string }) => (
   <div>{resourceName}</div>
 ))
+const mockOpenSession = vi.fn()
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>()
@@ -40,6 +41,12 @@ vi.mock('sonner', () => ({
     success: vi.fn(),
     error: vi.fn(),
   },
+}))
+
+vi.mock('@/contexts/terminal-context', () => ({
+  useTerminal: () => ({
+    openSession: mockOpenSession,
+  }),
 }))
 
 vi.mock('@/components/resource-table', () => ({
@@ -88,6 +95,7 @@ describe('PodListPage', () => {
   beforeEach(() => {
     mockNavigate.mockReset()
     mockResourceTable.mockClear()
+    mockOpenSession.mockClear()
   })
 
   it('provides unified row actions for pods', async () => {
@@ -127,9 +135,15 @@ describe('PodListPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/pods/default/api-0?tab=yaml')
 
     await items[1].onSelect?.()
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/pods/default/api-0?tab=terminal'
-    )
+    expect(mockOpenSession).toHaveBeenCalledWith({
+      type: 'pod',
+      namespace: 'default',
+      podName: 'api-0',
+      containers: undefined,
+      initContainers: undefined,
+      source: 'pod/api-0',
+      entry: 'pod-list',
+    })
 
     await items[2].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith('/pods/default/api-0?tab=logs')

--- a/ui/src/pages/pod-list-page.tsx
+++ b/ui/src/pages/pod-list-page.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { useTerminal } from '@/contexts/terminal-context'
 import { PodWithMetrics } from '@/types/api'
 import { getPodStatus } from '@/lib/k8s'
 import { formatDate, formatRelativeTimeStrict } from '@/lib/utils'
@@ -40,6 +41,7 @@ function formatTimestampWithRelative(timestamp?: string) {
 export function PodListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const { openSession } = useTerminal()
   const [labelsPod, setLabelsPod] = useState<Pod | null>(null)
   const [annotationsPod, setAnnotationsPod] = useState<Pod | null>(null)
   const [deletePodTarget, setDeletePodTarget] = useState<Pod | null>(null)
@@ -242,7 +244,17 @@ export function PodListPage() {
           key: 'open-terminal',
           label: t('detail.tabs.terminal'),
           icon: <TerminalSquare className="h-4 w-4" />,
-          onSelect: () => navigate(`${detailPath}?tab=terminal`),
+          onSelect: () => {
+            openSession({
+              type: 'pod',
+              namespace: pod.metadata?.namespace,
+              podName: pod.metadata?.name,
+              containers: pod.spec?.containers,
+              initContainers: pod.spec?.initContainers,
+              source: `pod/${pod.metadata?.name}`,
+              entry: 'pod-list',
+            })
+          },
         },
         {
           key: 'view-logs',
@@ -272,7 +284,7 @@ export function PodListPage() {
         },
       ]
     },
-    [getPodDetailPath, navigate, t]
+    [getPodDetailPath, navigate, openSession, t]
   )
 
   return (

--- a/ui/src/pages/statefulset-detail.tsx
+++ b/ui/src/pages/statefulset-detail.tsx
@@ -35,6 +35,7 @@ import { DescribeDialog } from '@/components/describe-dialog'
 import { ErrorMessage } from '@/components/error-message'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
+import { OpenPodTerminalButton } from '@/components/open-pod-terminal-button'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RefreshButton } from '@/components/refresh-button'
@@ -42,7 +43,6 @@ import { RelatedResourcesTable } from '@/components/related-resource-table'
 import { ResourceDeleteConfirmationDialog } from '@/components/resource-delete-confirmation-dialog'
 import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { StatefulSetOverviewInfoCard } from '@/components/statefulset-overview-info-card'
-import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
 import { YamlEditor } from '@/components/yaml-editor'
 
@@ -328,6 +328,13 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
             namespace={namespace}
             name={name}
           />
+          <OpenPodTerminalButton
+            namespace={namespace}
+            pods={relatedPods}
+            containers={spec?.template.spec?.containers}
+            initContainers={spec?.template.spec?.initContainers}
+            source={`statefulset/${name}`}
+          />
           <Popover
             open={isScalePopoverOpen}
             onOpenChange={setIsScalePopoverOpen}
@@ -564,22 +571,6 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
                         initContainers={spec?.template.spec?.initContainers}
                         labelSelector={labelSelector}
                       />
-                    </div>
-                  ),
-                },
-                {
-                  value: 'terminal',
-                  label: t('detail.tabs.terminal'),
-                  content: (
-                    <div className="space-y-6">
-                      {relatedPods && relatedPods.length > 0 && (
-                        <Terminal
-                          namespace={namespace}
-                          pods={relatedPods}
-                          containers={spec?.template.spec?.containers}
-                          initContainers={spec?.template.spec?.initContainers}
-                        />
-                      )}
                     </div>
                   ),
                 },


### PR DESCRIPTION
- Added support for managing terminal sessions in the TerminalContext, including session creation, activation, and closure.
- Updated TerminalConsumer component to display active sessions and allow opening new pod terminals.
- Integrated OpenPodTerminalButton across various resource detail pages (DaemonSet, Deployment, Job, Node, Pod, StatefulSet) for streamlined terminal access.
- Removed legacy terminal tab implementations in resource detail pages, replacing them with direct terminal buttons.
- Enhanced localization files to include new terminal-related strings for English and Chinese.
- Updated API functions to support cluster-specific file operations, including reading, updating, and deleting files in pods.
- Improved test coverage for terminal session management and UI interactions.

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global terminal workspace with multi-session support, appearing as a bottom panel
  * New action buttons to open terminals from resource detail pages (pods, nodes, deployments, etc.)
  * File browser edit and delete capabilities for pod files

* **Improvements**
  * Terminal sessions now independently manageable with switching, minimize, and fullscreen options
  * Pod file operations are cluster-aware

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eryajf/kite-desktop/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->