### PR TITLE
✨ feat(terminal): 支持从工作负载列表打开终端并应用主题背景

### DIFF
--- a/ui/src/components/deployment-overview-info-card.test.tsx
+++ b/ui/src/components/deployment-overview-info-card.test.tsx
@@ -120,7 +120,7 @@ describe('DeploymentOverviewInfoCard', () => {
 
     expect(screen.getByText('选择器')).toBeInTheDocument()
     expect(screen.getByText('资源请求总计')).toBeInTheDocument()
-    expect(screen.getByText('资源限制总计')).toBeInTheDocument()
+    expect(screen.getByText('资源限制')).toBeInTheDocument()
     expect(screen.getByText('app: ops-whoami')).toBeInTheDocument()
     expect(screen.getByText('CPU: 200m')).toBeInTheDocument()
     expect(screen.getByText('CPU: 500m')).toBeInTheDocument()

--- a/ui/src/components/floating-terminal.tsx
+++ b/ui/src/components/floating-terminal.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from 'react-i18next'
 
 import { useGeneralSetting } from '@/lib/api'
+import { TERMINAL_THEMES, TerminalTheme } from '@/types/themes'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -49,6 +50,12 @@ export function FloatingTerminal() {
   const [height, setHeight] = useState(
     () => (window.innerHeight * DEFAULT_HEIGHT_VH) / 100
   )
+  const terminalThemeName =
+    (localStorage.getItem('terminal-theme') as TerminalTheme | null) ??
+    'classic'
+  const terminalBackground =
+    TERMINAL_THEMES[terminalThemeName]?.background ??
+    TERMINAL_THEMES.classic.background
   const dragging = useRef(false)
   const startY = useRef(0)
   const startH = useRef(0)
@@ -312,7 +319,10 @@ export function FloatingTerminal() {
           })}
         </div>
 
-        <div className="relative min-h-0 flex-1">
+        <div
+          className="relative min-h-0 flex-1"
+          style={{ backgroundColor: terminalBackground }}
+        >
           {sessions.map((session) => (
             <div
               key={session.id}
@@ -320,6 +330,7 @@ export function FloatingTerminal() {
                 'absolute inset-0 min-h-0',
                 session.id === activeSessionId ? 'block' : 'hidden'
               )}
+              style={{ backgroundColor: terminalBackground }}
             >
               <Terminal
                 type={session.type}

--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -139,6 +139,8 @@ export function Terminal({
   const visibleTerminalTheme = previewTerminalTheme ?? terminalTheme
   const visibleFontSize = previewFontSize ?? fontSize
   const visibleCursorStyle = previewCursorStyle ?? cursorStyle
+  const visibleTerminalBackground =
+    TERMINAL_THEMES[visibleTerminalTheme].background
 
   useEffect(() => {
     selectedTerminalThemeRef.current = terminalTheme
@@ -470,6 +472,7 @@ export function Terminal({
 
     // Apply additional styles to prevent scroll bubbling
     if (terminal.element) {
+      terminal.element.style.backgroundColor = currentTheme.background
       terminal.element.style.overscrollBehavior = 'none'
       terminal.element.style.touchAction = 'none'
       terminal.element.addEventListener(
@@ -696,6 +699,7 @@ export function Terminal({
       ref={terminalRef}
       className="flex-1 h-full min-h-0 w-full"
       style={{
+        backgroundColor: visibleTerminalBackground,
         maxHeight: '100%',
         overflow: 'hidden',
         overscrollBehavior: 'none',
@@ -921,7 +925,10 @@ export function Terminal({
     embeddedToolbar && !toolbarPortalElement
 
   const terminalBody = (
-    <div className="flex h-full min-h-0">
+    <div
+      className="flex h-full min-h-0"
+      style={{ backgroundColor: visibleTerminalBackground }}
+    >
       {canShowFileTree && showFileTree ? (
         <div className="h-full min-h-0 w-[360px] shrink-0 max-w-[45%]">
           <PodTerminalFileTree
@@ -940,7 +947,10 @@ export function Terminal({
   if (embedded) {
     if (embeddedToolbar) {
       return (
-        <div className="flex h-full min-h-0 w-full flex-col">
+        <div
+          className="flex h-full min-h-0 w-full flex-col"
+          style={{ backgroundColor: visibleTerminalBackground }}
+        >
           {toolbarPortalElement
             ? createPortal(toolbarControls, toolbarPortalElement)
             : null}
@@ -949,13 +959,23 @@ export function Terminal({
               {toolbarControls}
             </div>
           ) : null}
-          <div className="min-h-0 flex-1">{terminalBody}</div>
+          <div
+            className="min-h-0 flex-1"
+            style={{ backgroundColor: visibleTerminalBackground }}
+          >
+            {terminalBody}
+          </div>
         </div>
       )
     }
 
     return (
-      <div className="flex flex-col h-full w-full min-h-0">{terminalDiv}</div>
+      <div
+        className="flex flex-col h-full w-full min-h-0"
+        style={{ backgroundColor: visibleTerminalBackground }}
+      >
+        {terminalDiv}
+      </div>
     )
   }
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -390,7 +390,7 @@
       "diskPressure": "Disk pressure",
       "pidPressure": "PID pressure"
     },
-    "openShellTerminal": "Open shell terminal",
+    "openShellTerminal": "Terminal",
     "terminalDialogTitle": "{{name}} · Terminal",
     "terminalDialogDescription": "Open a shell session on the selected node.",
     "cordonDialogTitle": "Set {{name}} as unschedulable",
@@ -2041,7 +2041,9 @@
     "nodeDescription": "Start the shell in the bottom terminal workspace. The session stays alive while you inspect other pages.",
     "selectPod": "Select pod",
     "selectContainer": "Select container",
-    "open": "Open terminal"
+    "open": "Open terminal",
+    "noAvailablePod": "No available pod found for {{source}}.",
+    "openFailed": "Failed to open terminal for {{source}}."
   },
   "containerInfo": {
     "running": "Running",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -415,7 +415,7 @@
       "diskPressure": "磁盘压力",
       "pidPressure": "PID 压力"
     },
-    "openShellTerminal": "进入 Shell 终端",
+    "openShellTerminal": "终端",
     "terminalDialogTitle": "{{name}} · 终端",
     "terminalDialogDescription": "打开所选节点的 Shell 会话。",
     "cordonDialogTitle": "将 {{name}} 设为不可调度",
@@ -1979,7 +1979,7 @@
     "rolloutPendingTitle": "部署尚未完全收敛",
     "rolloutPendingDescription": "控制器当前观察到的 generation 为 {{observed}}，期望 generation 为 {{generation}}。",
     "resourceRequests": "资源请求总计",
-    "resourceLimits": "资源限制总计",
+    "resourceLimits": "资源限制",
     "containers": "容器",
     "containersAndImages": "容器与镜像",
     "notSet": "未指定",
@@ -2332,7 +2332,9 @@
     "nodeDescription": "在底部终端工作台中启动 Shell，会话会在你查看其他页面时继续保持。",
     "selectPod": "选择 Pod",
     "selectContainer": "选择容器",
-    "open": "打开终端"
+    "open": "终端",
+    "noAvailablePod": "没有找到可用的 Pod：{{source}}",
+    "openFailed": "打开终端失败：{{source}}"
   },
   "containerInfo": {
     "running": "运行中",

--- a/ui/src/lib/workload-terminal.ts
+++ b/ui/src/lib/workload-terminal.ts
@@ -1,0 +1,131 @@
+import type { TFunction } from 'i18next'
+import type {
+  DaemonSet,
+  Deployment,
+  ReplicaSetList,
+  StatefulSet,
+} from 'kubernetes-types/apps/v1'
+import type { Pod, PodList } from 'kubernetes-types/core/v1'
+import { toast } from 'sonner'
+
+import type { TerminalSessionSpec } from '@/contexts/terminal-context'
+import { fetchResources } from '@/lib/api'
+import {
+  filterPodsOwnedByController,
+  filterPodsOwnedByDeployment,
+} from '@/lib/k8s'
+
+type Workload = Deployment | StatefulSet | DaemonSet
+type WorkloadKind = 'Deployment' | 'StatefulSet' | 'DaemonSet'
+
+interface OpenWorkloadTerminalOptions {
+  workload: Workload
+  kind: WorkloadKind
+  sourcePrefix: string
+  openSession: (spec: TerminalSessionSpec) => string
+  t: TFunction
+}
+
+function buildLabelSelector(matchLabels?: Record<string, string>) {
+  if (!matchLabels) {
+    return undefined
+  }
+
+  return Object.entries(matchLabels)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+}
+
+function getPreferredPod(pods: Pod[] | undefined) {
+  if (!pods?.length) {
+    return undefined
+  }
+
+  return (
+    pods.find((pod) => pod.status?.phase === 'Running') ??
+    pods.find((pod) => Boolean(pod.metadata?.name))
+  )
+}
+
+export async function openWorkloadTerminal({
+  workload,
+  kind,
+  sourcePrefix,
+  openSession,
+  t,
+}: OpenWorkloadTerminalOptions) {
+  const name = workload.metadata?.name
+  const namespace = workload.metadata?.namespace
+  const labelSelector = buildLabelSelector(workload.spec?.selector.matchLabels)
+  const source = name ? `${sourcePrefix}/${name}` : sourcePrefix
+
+  if (!name || !namespace || !labelSelector) {
+    toast.error(
+      t('terminalLauncher.noAvailablePod', {
+        source,
+        defaultValue: 'No available pod found for {{source}}.',
+      })
+    )
+    return
+  }
+
+  try {
+    const podList = await fetchResources<PodList>('pods', namespace, {
+      labelSelector,
+      reduce: false,
+    })
+    let relatedPods: Pod[] | undefined = podList.items
+
+    if (kind === 'Deployment') {
+      const replicaSetList = await fetchResources<ReplicaSetList>(
+        'replicasets',
+        namespace,
+        {
+          labelSelector,
+          reduce: false,
+        }
+      )
+      relatedPods = filterPodsOwnedByDeployment(
+        podList.items,
+        workload as Deployment,
+        replicaSetList.items
+      )
+    } else {
+      relatedPods = filterPodsOwnedByController(podList.items, kind, workload)
+    }
+
+    const pod = getPreferredPod(relatedPods)
+    const podName = pod?.metadata?.name
+
+    if (!podName) {
+      toast.error(
+        t('terminalLauncher.noAvailablePod', {
+          source,
+          defaultValue: 'No available pod found for {{source}}.',
+        })
+      )
+      return
+    }
+
+    openSession({
+      type: 'pod',
+      namespace,
+      podName,
+      pods: relatedPods,
+      containers: workload.spec?.template.spec?.containers,
+      initContainers: workload.spec?.template.spec?.initContainers,
+      source,
+      title: `${source} · ${podName}`,
+      subtitle: namespace,
+      entry: 'resource-action',
+    })
+  } catch (error) {
+    console.error(`Failed to open terminal for ${source}:`, error)
+    toast.error(
+      t('terminalLauncher.openFailed', {
+        source,
+        defaultValue: 'Failed to open terminal for {{source}}.',
+      })
+    )
+  }
+}

--- a/ui/src/pages/daemonset-list-page.tsx
+++ b/ui/src/pages/daemonset-list-page.tsx
@@ -10,18 +10,21 @@ import {
   Image,
   RefreshCcw,
   Tags,
+  TerminalSquare,
   Trash2,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { useTerminal } from '@/contexts/terminal-context'
 import { patchResource } from '@/lib/api'
 import {
   formatDate,
   formatRelativeTimeStrict,
   translateError,
 } from '@/lib/utils'
+import { openWorkloadTerminal } from '@/lib/workload-terminal'
 import { WorkloadWithPodTemplate } from '@/hooks/use-deployment-container-editor'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -57,6 +60,7 @@ export function DaemonSetListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { openSession } = useTerminal()
   const [labelsDaemonSet, setLabelsDaemonSet] = useState<DaemonSet | null>(null)
   const [annotationsDaemonSet, setAnnotationsDaemonSet] =
     useState<DaemonSet | null>(null)
@@ -302,6 +306,19 @@ export function DaemonSetListPage() {
           onSelect: () => navigate(`${detailPath}?tab=yaml`),
         },
         {
+          key: 'open-terminal',
+          label: t('terminalLauncher.open', 'Open terminal'),
+          icon: <TerminalSquare className="h-4 w-4" />,
+          onSelect: () =>
+            openWorkloadTerminal({
+              workload: daemonSet,
+              kind: 'DaemonSet',
+              sourcePrefix: 'daemonset',
+              openSession,
+              t,
+            }),
+        },
+        {
           key: 'edit-image',
           label: t('deploymentList.editImage'),
           icon: <Image className="h-4 w-4" />,
@@ -341,7 +358,7 @@ export function DaemonSetListPage() {
         },
       ]
     },
-    [getDaemonSetDetailPath, navigate, t]
+    [getDaemonSetDetailPath, navigate, openSession, t]
   )
 
   return (

--- a/ui/src/pages/deployment-list-page.test.tsx
+++ b/ui/src/pages/deployment-list-page.test.tsx
@@ -14,6 +14,8 @@ const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 const mockInvalidateQueries = vi.fn()
 const mockPatchResource = vi.fn()
+const mockOpenSession = vi.fn()
+const mockOpenWorkloadTerminal = vi.fn()
 const mockT = (key: string) => key
 const mockResourceTable = vi.fn(
   ({
@@ -73,6 +75,17 @@ vi.mock('@/lib/desktop', () => ({
 
 vi.mock('@/lib/api', () => ({
   patchResource: (...args: unknown[]) => mockPatchResource(...args),
+}))
+
+vi.mock('@/contexts/terminal-context', () => ({
+  useTerminal: () => ({
+    openSession: mockOpenSession,
+  }),
+}))
+
+vi.mock('@/lib/workload-terminal', () => ({
+  openWorkloadTerminal: (...args: unknown[]) =>
+    mockOpenWorkloadTerminal(...args),
 }))
 
 vi.mock('sonner', () => ({
@@ -201,6 +214,8 @@ describe('DeploymentListPage', () => {
     mockToastError.mockReset()
     mockInvalidateQueries.mockReset()
     mockPatchResource.mockReset()
+    mockOpenSession.mockReset()
+    mockOpenWorkloadTerminal.mockReset()
     mockResourceTable.mockClear()
   })
 
@@ -397,6 +412,7 @@ describe('DeploymentListPage', () => {
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
+      'open-terminal',
       'edit-image',
       'pause-orchestration',
       'rollout-restart',
@@ -415,36 +431,48 @@ describe('DeploymentListPage', () => {
     await act(async () => {
       await items[1].onSelect?.()
     })
+    expect(mockOpenWorkloadTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workload: deployment,
+        kind: 'Deployment',
+        sourcePrefix: 'deployment',
+        openSession: mockOpenSession,
+      })
+    )
+
+    await act(async () => {
+      await items[2].onSelect?.()
+    })
     expect(screen.getByText('container-edit-dialog')).toBeInTheDocument()
 
     await act(async () => {
-      await items[3].onSelect?.()
+      await items[4].onSelect?.()
     })
     expect(
       screen.getByText('detail.dialogs.restartDeployment.title')
     ).toBeInTheDocument()
 
-    await items[4].onSelect?.()
+    await items[5].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith(
       '/deployments/default/web?tab=history'
     )
 
     await act(async () => {
-      await items[6].onSelect?.()
+      await items[7].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-labels')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[7].onSelect?.()
+      await items[8].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-annotations')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[8].onSelect?.()
+      await items[9].onSelect?.()
     })
     expect(
       screen.getByText('resource-delete-confirmation-dialog')
@@ -477,7 +505,7 @@ describe('DeploymentListPage', () => {
     const items = resourceTableProps.getRowContextMenuItems(deployment)
 
     await act(async () => {
-      await items[3].onSelect?.()
+      await items[4].onSelect?.()
     })
     expect(
       screen.getByText('detail.dialogs.restartDeployment.title')
@@ -547,7 +575,7 @@ describe('DeploymentListPage', () => {
     const items = resourceTableProps.getRowContextMenuItems(deployment)
 
     await act(async () => {
-      await items[2].onSelect?.()
+      await items[3].onSelect?.()
     })
     await waitFor(() => {
       expect(mockPatchResource).toHaveBeenCalledWith(
@@ -563,7 +591,7 @@ describe('DeploymentListPage', () => {
     })
 
     await act(async () => {
-      await items[1].onSelect?.()
+      await items[2].onSelect?.()
     })
     await act(async () => {
       fireEvent.click(screen.getByText('save-container-edit'))
@@ -617,11 +645,11 @@ describe('DeploymentListPage', () => {
 
     const items = resourceTableProps.getRowContextMenuItems(deployment)
 
-    expect(items[2].key).toBe('resume-orchestration')
-    expect(items[2].label).toBe('deploymentList.resumeOrchestration')
+    expect(items[3].key).toBe('resume-orchestration')
+    expect(items[3].label).toBe('deploymentList.resumeOrchestration')
 
     await act(async () => {
-      await items[2].onSelect?.()
+      await items[3].onSelect?.()
     })
     await waitFor(() => {
       expect(mockPatchResource).toHaveBeenCalledWith(

--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -11,12 +11,14 @@ import {
   Play,
   RefreshCcw,
   Tags,
+  TerminalSquare,
   Trash2,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { useTerminal } from '@/contexts/terminal-context'
 import { patchResource } from '@/lib/api'
 import { getDeploymentStatus } from '@/lib/k8s'
 import {
@@ -24,6 +26,7 @@ import {
   formatRelativeTimeStrict,
   translateError,
 } from '@/lib/utils'
+import { openWorkloadTerminal } from '@/lib/workload-terminal'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -60,6 +63,7 @@ export function DeploymentListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { openSession } = useTerminal()
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [labelsDeployment, setLabelsDeployment] = useState<Deployment | null>(
     null
@@ -316,6 +320,19 @@ export function DeploymentListPage() {
           onSelect: () => navigate(`${detailPath}?tab=yaml`),
         },
         {
+          key: 'open-terminal',
+          label: t('terminalLauncher.open', 'Open terminal'),
+          icon: <TerminalSquare className="h-4 w-4" />,
+          onSelect: () =>
+            openWorkloadTerminal({
+              workload: deployment,
+              kind: 'Deployment',
+              sourcePrefix: 'deployment',
+              openSession,
+              t,
+            }),
+        },
+        {
           key: 'edit-image',
           label: t('deploymentList.editImage'),
           icon: <Image className="h-4 w-4" />,
@@ -368,7 +385,14 @@ export function DeploymentListPage() {
         },
       ]
     },
-    [getDeploymentDetailPath, handlePauseToggle, isPauseToggling, navigate, t]
+    [
+      getDeploymentDetailPath,
+      handlePauseToggle,
+      isPauseToggling,
+      navigate,
+      openSession,
+      t,
+    ]
   )
 
   return (

--- a/ui/src/pages/node-list-page.test.tsx
+++ b/ui/src/pages/node-list-page.test.tsx
@@ -248,11 +248,11 @@ describe('NodeListPage', () => {
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
+      'open-terminal',
       'primary-actions-separator',
       'copy-name',
       'copy-ip',
       'node-operations-separator',
-      'open-terminal',
       'cordon',
       'drain',
     ])
@@ -260,14 +260,8 @@ describe('NodeListPage', () => {
     await items[0].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith('/nodes/orbstack?tab=yaml')
 
-    await items[2].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('orbstack')
-
-    await items[3].onSelect?.()
-    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('192.168.64.3')
-
     await act(async () => {
-      await items[5].onSelect?.()
+      await items[1].onSelect?.()
     })
     expect(mockOpenSession).toHaveBeenCalledWith({
       type: 'node',
@@ -276,6 +270,12 @@ describe('NodeListPage', () => {
       source: 'node/orbstack',
       entry: 'node-list',
     })
+
+    await items[3].onSelect?.()
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('orbstack')
+
+    await items[4].onSelect?.()
+    expect(mockCopyTextToClipboard).toHaveBeenCalledWith('192.168.64.3')
   })
 
   it('explains drain options and submits the selected values', async () => {

--- a/ui/src/pages/node-list-page.tsx
+++ b/ui/src/pages/node-list-page.tsx
@@ -532,6 +532,12 @@ export function NodeListPage() {
           icon: <FileCode2 className="h-4 w-4" />,
           onSelect: () => navigate(`/nodes/${node.metadata!.name}?tab=yaml`),
         },
+        {
+          key: 'open-terminal',
+          label: t('terminalLauncher.open', 'Open terminal'),
+          icon: <TerminalSquare className="h-4 w-4" />,
+          onSelect: () => handleOpenNodeTerminal(node),
+        },
         { type: 'separator', key: 'primary-actions-separator' },
         {
           key: 'copy-name',
@@ -547,12 +553,6 @@ export function NodeListPage() {
           onSelect: () => handleCopy(nodeIP),
         },
         { type: 'separator', key: 'node-operations-separator' },
-        {
-          key: 'open-terminal',
-          label: t('nodes.openShellTerminal', 'Open shell terminal'),
-          icon: <TerminalSquare className="h-4 w-4" />,
-          onSelect: () => handleOpenNodeTerminal(node),
-        },
         isUnschedulable
           ? {
               key: 'uncordon',

--- a/ui/src/pages/pod-list-page.tsx
+++ b/ui/src/pages/pod-list-page.tsx
@@ -242,7 +242,7 @@ export function PodListPage() {
         },
         {
           key: 'open-terminal',
-          label: t('detail.tabs.terminal'),
+          label: t('terminalLauncher.open', 'Open terminal'),
           icon: <TerminalSquare className="h-4 w-4" />,
           onSelect: () => {
             openSession({

--- a/ui/src/pages/statefulset-list-page.test.tsx
+++ b/ui/src/pages/statefulset-list-page.test.tsx
@@ -10,6 +10,8 @@ const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 const mockInvalidateQueries = vi.fn()
 const mockPatchResource = vi.fn()
+const mockOpenSession = vi.fn()
+const mockOpenWorkloadTerminal = vi.fn()
 const mockT = (key: string) => key
 const mockResourceTable = vi.fn(() => <div>statefulset-table</div>)
 
@@ -52,6 +54,17 @@ vi.mock('@tanstack/react-query', async () => {
 
 vi.mock('@/lib/api', () => ({
   patchResource: (...args: unknown[]) => mockPatchResource(...args),
+}))
+
+vi.mock('@/contexts/terminal-context', () => ({
+  useTerminal: () => ({
+    openSession: mockOpenSession,
+  }),
+}))
+
+vi.mock('@/lib/workload-terminal', () => ({
+  openWorkloadTerminal: (...args: unknown[]) =>
+    mockOpenWorkloadTerminal(...args),
 }))
 
 vi.mock('sonner', () => ({
@@ -147,6 +160,8 @@ describe('StatefulSetListPage', () => {
     mockToastError.mockReset()
     mockInvalidateQueries.mockReset()
     mockPatchResource.mockReset()
+    mockOpenSession.mockReset()
+    mockOpenWorkloadTerminal.mockReset()
     mockResourceTable.mockClear()
   })
 
@@ -185,6 +200,7 @@ describe('StatefulSetListPage', () => {
 
     expect(items.map((item) => item.key)).toEqual([
       'view-yaml',
+      'open-terminal',
       'edit-image',
       'rollout-restart',
       'rollback',
@@ -193,7 +209,7 @@ describe('StatefulSetListPage', () => {
       'manage-annotations',
       'delete-statefulset',
     ])
-    expect(items[3].label).toBe('deploymentList.rollback')
+    expect(items[4].label).toBe('deploymentList.rollback')
 
     await items[0].onSelect?.()
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -203,24 +219,36 @@ describe('StatefulSetListPage', () => {
     await act(async () => {
       await items[1].onSelect?.()
     })
+    expect(mockOpenWorkloadTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workload: statefulSet,
+        kind: 'StatefulSet',
+        sourcePrefix: 'statefulset',
+        openSession: mockOpenSession,
+      })
+    )
+
+    await act(async () => {
+      await items[2].onSelect?.()
+    })
     expect(screen.getByText('container-edit-dialog')).toBeInTheDocument()
 
     await act(async () => {
-      await items[5].onSelect?.()
+      await items[6].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-labels')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[6].onSelect?.()
+      await items[7].onSelect?.()
     })
     expect(
       screen.getByText('resource-metadata-dialog-annotations')
     ).toBeInTheDocument()
 
     await act(async () => {
-      await items[7].onSelect?.()
+      await items[8].onSelect?.()
     })
     expect(
       screen.getByText('resource-delete-confirmation-dialog')
@@ -263,7 +291,7 @@ describe('StatefulSetListPage', () => {
     const items = resourceTableProps.getRowContextMenuItems(statefulSet)
 
     await act(async () => {
-      await items[1].onSelect?.()
+      await items[2].onSelect?.()
     })
     await act(async () => {
       fireEvent.click(screen.getByText('save-container-edit'))

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -10,18 +10,21 @@ import {
   Image,
   RefreshCcw,
   Tags,
+  TerminalSquare,
   Trash2,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { useTerminal } from '@/contexts/terminal-context'
 import { patchResource } from '@/lib/api'
 import {
   formatDate,
   formatRelativeTimeStrict,
   translateError,
 } from '@/lib/utils'
+import { openWorkloadTerminal } from '@/lib/workload-terminal'
 import { WorkloadWithPodTemplate } from '@/hooks/use-deployment-container-editor'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -57,6 +60,7 @@ export function StatefulSetListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { openSession } = useTerminal()
   const [labelsStatefulSet, setLabelsStatefulSet] =
     useState<StatefulSet | null>(null)
   const [annotationsStatefulSet, setAnnotationsStatefulSet] =
@@ -312,6 +316,19 @@ export function StatefulSetListPage() {
           onSelect: () => navigate(`${detailPath}?tab=yaml`),
         },
         {
+          key: 'open-terminal',
+          label: t('terminalLauncher.open', 'Open terminal'),
+          icon: <TerminalSquare className="h-4 w-4" />,
+          onSelect: () =>
+            openWorkloadTerminal({
+              workload: statefulSet,
+              kind: 'StatefulSet',
+              sourcePrefix: 'statefulset',
+              openSession,
+              t,
+            }),
+        },
+        {
           key: 'edit-image',
           label: t('deploymentList.editImage'),
           icon: <Image className="h-4 w-4" />,
@@ -351,7 +368,7 @@ export function StatefulSetListPage() {
         },
       ]
     },
-    [getStatefulSetDetailPath, navigate, t]
+    [getStatefulSetDetailPath, navigate, openSession, t]
   )
 
   return (


### PR DESCRIPTION
- 新增 `workload-terminal` 工具库，支持从 Deployment、StatefulSet 和 DaemonSet 列表页直接打开终端会话。
- 在 `floating-terminal` 和 `terminal-content` 组件中根据主题配置动态应用背景颜色。

🌐 i18n(locales): 更新终端和资源相关的翻译文案

- 新增终端启动失败及无可用 Pod 的错误提示翻译。
- 优化“资源限制”及“打开终端”等标签文本，使其更加简洁。

🌈 style(pages): 统一列表页菜单项顺序与操作标签

- 调整节点列表页上下文菜单顺序，将常用操作前置。
- 统一 Pod 和节点列表页中终端操作按钮的文案显示。

✅ test(pages): 更新单元测试以适配功能变更

- 更新 Deployment、StatefulSet、DaemonSet 和 Node 列表页的测试用例。
- 修正菜单项索引断言并补充终端功能的 Mock。

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] I have the right to submit these contributions under `AGPL-3.0-only`.
- [ ] Each non-merge commit includes a DCO `Signed-off-by` line.
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal launching now available from Deployment, StatefulSet, and DaemonSet workload lists
  * Terminal theme preference is now saved and persists across sessions

* **Improvements**
  * Terminal background styling applies consistently throughout the application
  * Updated terminal and resource limit UI labels
  * Improved Chinese and English localization for terminal functionality and error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->